### PR TITLE
fix: refresh property fields live during canvas drag

### DIFF
--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -88,6 +88,9 @@ namespace CtrDxEditor.Rendering
         /// <summary>Callback used to toggle the locked object from canvas gestures.</summary>
         public Action<LevelObject?>? ToggleLock { get; set; }
 
+        /// <summary>Callback raised when a canvas drag moves the selected object, so bound views can refresh.</summary>
+        public Action? SelectedObjectMoved { get; set; }
+
         private bool _dragging;
         private Vec2 _dragOffset;
         private int _lastHitIndex = -1;
@@ -440,6 +443,7 @@ namespace CtrDxEditor.Rendering
             (int gx, int gy) = Snap(levelPt - _dragOffset);
             selected.X = gx;
             selected.Y = gy;
+            SelectedObjectMoved?.Invoke();
             InvalidateVisual();
         }
 

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -31,5 +31,11 @@ namespace CtrDxEditor.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        /// <summary>Re-reads <see cref="Value"/> from the target, for when the object is mutated elsewhere (e.g. a canvas drag).</summary>
+        public void Refresh()
+        {
+            OnPropertyChanged(nameof(Value));
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -138,6 +138,15 @@ namespace CtrDxEditor.ViewModels
             return Document?.Save();
         }
 
+        /// <summary>Re-reads every property field from the selected object, for canvas-driven mutations like dragging.</summary>
+        public void RefreshFieldValues()
+        {
+            foreach (AttributeFieldViewModel field in Fields)
+            {
+                field.Refresh();
+            }
+        }
+
         partial void OnSelectedObjectChanged(LevelObject? value)
         {
             Fields.Clear();

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -34,6 +34,7 @@ namespace CtrDxEditor.Views
             canvas.PlaceAt = (element, x, y) =>
                 DataContext is EditorViewModel vm ? vm.PlaceObject(element, x, y) : null;
             canvas.ToggleLock = obj => (DataContext as EditorViewModel)?.ToggleLock(obj);
+            canvas.SelectedObjectMoved = () => (DataContext as EditorViewModel)?.RefreshFieldValues();
 
             // Palette placement is an internal pointer-capture drag (no OS drag-drop, so no OS drag image):
             // a click drops at center, a drag drops where it lands on the canvas, a drag off-canvas cancels.

--- a/src/CtrDxEditor.Tests/EditorFieldRefreshTests.cs
+++ b/src/CtrDxEditor.Tests/EditorFieldRefreshTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests that property fields refresh live when the selected object is mutated outside the panel (e.g. a canvas drag).</summary>
+    public class EditorFieldRefreshTests
+    {
+        private sealed class EmptyStore : IContentStore
+        {
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                return Task.FromResult(Array.Empty<byte>());
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult("");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        private const string Level = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <map>
+            <layer name="settings">
+                <map gridSize="32" width="640" height="480" />
+            </layer>
+            <layer name="Objects">
+                <candy x="100" y="100" />
+            </layer>
+        </map>
+        """;
+
+        /// <summary>Verifies that mutating the object and calling RefreshFieldValues raises change notification so bound fields re-read.</summary>
+        [Fact]
+        public void RefreshFieldValuesReReadsMutatedPosition()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject candy = vm.Document!.Objects[0];
+            vm.SelectedObject = candy;
+
+            AttributeFieldViewModel xField = vm.Fields.Single(f => f.Name == "x");
+            List<string?> changes = [];
+            xField.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(AttributeFieldViewModel.Value))
+                {
+                    changes.Add(xField.Value);
+                }
+            };
+
+            // Simulate a canvas drag: the canvas mutates the object directly, then signals a refresh.
+            candy.X = 250;
+            vm.RefreshFieldValues();
+
+            Assert.Contains("250", changes);
+            Assert.Equal("250", xField.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Canvas drags mutated the selected object directly but never notified the Properties panel, so X/Y and other fields showed stale values.

This PR add a `SelectedObjectMoved` callback from the canvas that refreshes every bound field on each pointer-move, mirroring the existing panel-to-canvas path.