### PR TITLE
feat: render ropes with game-accurate visuals in the level canvas

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.0.5" />
     <PackageVersion Include="AvaloniaDialogs" Version="3.7.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="3.0.2" />

--- a/src/CtrDxEditor.Core.Tests/RopeCurveTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeCurveTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for the static rope sag-curve approximation.</summary>
+    public class RopeCurveTests
+    {
+        private static double PolylineLength(IReadOnlyList<Vec2> pts)
+        {
+            double sum = 0;
+            for (int i = 1; i < pts.Count; i++)
+            {
+                double dx = pts[i].X - pts[i - 1].X;
+                double dy = pts[i].Y - pts[i - 1].Y;
+                sum += Math.Sqrt((dx * dx) + (dy * dy));
+            }
+            return sum;
+        }
+
+        private static int LowestIndex(IReadOnlyList<Vec2> pts)
+        {
+            int idx = 0;
+            for (int i = 1; i < pts.Count; i++)
+            {
+                if (pts[i].Y > pts[idx].Y)
+                {
+                    idx = i;
+                }
+            }
+            return idx;
+        }
+
+        /// <summary>A rope no longer than the gap is drawn straight (endpoints only).</summary>
+        [Fact]
+        public void TautRopeIsStraight()
+        {
+            Vec2 a = new(0, 0);
+            Vec2 b = new(100, 0);
+
+            IReadOnlyList<Vec2> pts = RopeCurve.Sample(a, b, length: 80);
+
+            Assert.Equal(2, pts.Count);
+            Assert.Equal(a, pts[0]);
+            Assert.Equal(b, pts[^1]);
+        }
+
+        /// <summary>A slack rope sags: the midpoint sits below the chord midpoint (greater Y = down).</summary>
+        [Fact]
+        public void SlackRopeSagsBelowChord()
+        {
+            Vec2 a = new(0, 0);
+            Vec2 b = new(100, 0);
+
+            IReadOnlyList<Vec2> pts = RopeCurve.Sample(a, b, length: 160, segments: 20);
+
+            Assert.Equal(21, pts.Count);
+            Assert.Equal(a, pts[0]);
+            Assert.Equal(b, pts[^1]);
+            Assert.True(pts[10].Y > 0, "curve midpoint should droop downward");
+        }
+
+        /// <summary>More slack produces a deeper sag.</summary>
+        [Fact]
+        public void MoreSlackSagsDeeper()
+        {
+            Vec2 a = new(0, 0);
+            Vec2 b = new(100, 0);
+
+            double shallow = RopeCurve.Sample(a, b, length: 130, segments: 20)[10].Y;
+            double deep = RopeCurve.Sample(a, b, length: 200, segments: 20)[10].Y;
+
+            Assert.True(deep > shallow, "longer rope should sag deeper");
+        }
+
+        /// <summary>On a tilted chord the lowest point sits nearer the lower endpoint (catenary asymmetry).</summary>
+        [Fact]
+        public void TiltedChordLowPointNearerLowerEnd()
+        {
+            Vec2 a = new(0, 0);
+            Vec2 b = new(100, 40); // +Y is down, so b is the lower endpoint
+
+            IReadOnlyList<Vec2> pts = RopeCurve.Sample(a, b, length: 200, segments: 20);
+
+            double lowX = pts[LowestIndex(pts)].X;
+            Assert.True(lowX > 50, "catenary low point should shift toward the lower (right) endpoint");
+        }
+
+        /// <summary>The sampled polyline length approximates the requested rope length (validates the a-solve).</summary>
+        [Fact]
+        public void SampledLengthApproximatesRopeLength()
+        {
+            Vec2 a = new(0, 0);
+            Vec2 b = new(100, 0);
+
+            IReadOnlyList<Vec2> pts = RopeCurve.Sample(a, b, length: 160, segments: 64);
+
+            Assert.Equal(160, PolylineLength(pts), tolerance: 2.0);
+        }
+
+        /// <summary>Coincident/near-vertical endpoints do not throw, produce NaN, or drop the endpoints.</summary>
+        [Fact]
+        public void CoincidentEndpointsAreSafe()
+        {
+            Vec2 a = new(50, 50);
+
+            IReadOnlyList<Vec2> pts = RopeCurve.Sample(a, a, length: 100, segments: 20);
+
+            Assert.Equal(21, pts.Count);
+            Assert.Equal(a, pts[0]);
+            Assert.Equal(a, pts[^1]);
+            Assert.All(pts, p => Assert.False(double.IsNaN(p.X) || double.IsNaN(p.Y)));
+            Assert.True(pts[10].Y > a.Y, "a slack rope between coincident points should hang below them");
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
@@ -4,14 +4,14 @@ using Xunit;
 
 namespace CtrDxEditor.Core.Tests
 {
-    /// <summary>Tests for rope skin palettes, shading, and the stretch tint reduction.</summary>
+    /// <summary>Tests for rope skin palettes and shading.</summary>
     public class RopePaletteTests
     {
         /// <summary>Skin 0 base color is the game's default brown primary.</summary>
         [Fact]
         public void DefaultSkinBaseIsBrown()
         {
-            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+            RopeDrawColors c = RopePalette.GetDrawColors(0);
 
             Assert.Equal(0.475, c.Base1.R, precision: 3);
             Assert.Equal(0.305, c.Base1.G, precision: 3);
@@ -22,8 +22,8 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void OutOfRangeSkinFallsBackToDefault()
         {
-            RopeDrawColors fallback = RopePalette.GetDrawColors(99, distance: 50, length: 100);
-            RopeDrawColors zero = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+            RopeDrawColors fallback = RopePalette.GetDrawColors(99);
+            RopeDrawColors zero = RopePalette.GetDrawColors(0);
 
             Assert.Equal(zero, fallback);
         }
@@ -32,30 +32,20 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void DefaultSkinShadeIsDarkerThanBase()
         {
-            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+            RopeDrawColors c = RopePalette.GetDrawColors(0);
 
             Assert.True(c.Shade1.R < c.Base1.R, "shade should be darker than base");
         }
 
-        /// <summary>A non-stretched custom skin has shade equal to base (no ramp, pure alternation).</summary>
+        /// <summary>A custom skin has shade equal to base (no ramp, pure alternation).</summary>
         [Fact]
-        public void UnstretchedCustomSkinShadeEqualsBase()
+        public void CustomSkinShadeEqualsBase()
         {
-            // Skin 2 (teal) primary is (0.404, 0.612, 0.635); dark factor is 1.0 when unstretched.
-            RopeDrawColors c = RopePalette.GetDrawColors(2, distance: 50, length: 100);
+            // Skin 2 (teal) primary is (0.404, 0.612, 0.635); dark factor is 1.0.
+            RopeDrawColors c = RopePalette.GetDrawColors(2);
 
             Assert.Equal(0.404, c.Base1.R, precision: 3);
             Assert.Equal(c.Base1, c.Shade1);
-        }
-
-        /// <summary>An over-stretched rope raises the shade red channel above the un-stretched value.</summary>
-        [Fact]
-        public void StretchedRopeBoostsShadeRed()
-        {
-            RopeDrawColors relaxed = RopePalette.GetDrawColors(0, distance: 100, length: 100);
-            RopeDrawColors stretched = RopePalette.GetDrawColors(0, distance: 300, length: 100);
-
-            Assert.True(stretched.Shade1.R > relaxed.Shade1.R, "stretch should increase shade red");
         }
 
         /// <summary>Component-wise lerp hits both endpoints and the midpoint.</summary>

--- a/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
@@ -4,14 +4,14 @@ using Xunit;
 
 namespace CtrDxEditor.Core.Tests
 {
-    /// <summary>Tests for rope skin palettes and shading.</summary>
+    /// <summary>Tests for rope skin palettes, shading, and the stretch tint.</summary>
     public class RopePaletteTests
     {
         /// <summary>Skin 0 base color is the game's default brown primary.</summary>
         [Fact]
         public void DefaultSkinBaseIsBrown()
         {
-            RopeDrawColors c = RopePalette.GetDrawColors(0);
+            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
 
             Assert.Equal(0.475, c.Base1.R, precision: 3);
             Assert.Equal(0.305, c.Base1.G, precision: 3);
@@ -22,8 +22,8 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void OutOfRangeSkinFallsBackToDefault()
         {
-            RopeDrawColors fallback = RopePalette.GetDrawColors(99);
-            RopeDrawColors zero = RopePalette.GetDrawColors(0);
+            RopeDrawColors fallback = RopePalette.GetDrawColors(99, distance: 50, length: 100);
+            RopeDrawColors zero = RopePalette.GetDrawColors(0, distance: 50, length: 100);
 
             Assert.Equal(zero, fallback);
         }
@@ -32,20 +32,44 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void DefaultSkinShadeIsDarkerThanBase()
         {
-            RopeDrawColors c = RopePalette.GetDrawColors(0);
+            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
 
             Assert.True(c.Shade1.R < c.Base1.R, "shade should be darker than base");
         }
 
-        /// <summary>A custom skin has shade equal to base (no ramp, pure alternation).</summary>
+        /// <summary>An unstretched custom skin has shade equal to base (no ramp, pure alternation).</summary>
         [Fact]
-        public void CustomSkinShadeEqualsBase()
+        public void UnstretchedCustomSkinShadeEqualsBase()
         {
-            // Skin 2 (teal) primary is (0.404, 0.612, 0.635); dark factor is 1.0.
-            RopeDrawColors c = RopePalette.GetDrawColors(2);
+            // Skin 2 (teal) primary is (0.404, 0.612, 0.635); dark factor is 1.0 when unstretched.
+            RopeDrawColors c = RopePalette.GetDrawColors(2, distance: 50, length: 100);
 
             Assert.Equal(0.404, c.Base1.R, precision: 3);
             Assert.Equal(c.Base1, c.Shade1);
+        }
+
+        /// <summary>An over-stretched rope raises the shade red channel above the un-stretched value.</summary>
+        [Fact]
+        public void StretchedRopeBoostsShadeRed()
+        {
+            RopeDrawColors relaxed = RopePalette.GetDrawColors(0, distance: 100, length: 100);
+            RopeDrawColors stretched = RopePalette.GetDrawColors(0, distance: 300, length: 100);
+
+            Assert.True(stretched.Shade1.R > relaxed.Shade1.R, "stretch should increase shade red");
+        }
+
+        /// <summary>The stretch tint uses the game's desktop threshold: rest + 7/105, not before.</summary>
+        [Fact]
+        public void StretchTintFiresAtGameThreshold()
+        {
+            // 5% over rest: below the ~6.67% threshold -> unchanged colors.
+            RopeDrawColors below = RopePalette.GetDrawColors(0, distance: 105, length: 100);
+            RopeDrawColors atRest = RopePalette.GetDrawColors(0, distance: 100, length: 100);
+            Assert.Equal(atRest, below);
+
+            // 8% over rest: past the threshold -> shade red boosted.
+            RopeDrawColors above = RopePalette.GetDrawColors(0, distance: 108, length: 100);
+            Assert.True(above.Shade1.R > atRest.Shade1.R, "tint should fire just past rest + 7/105");
         }
 
         /// <summary>Component-wise lerp hits both endpoints and the midpoint.</summary>

--- a/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopePaletteTests.cs
@@ -1,0 +1,84 @@
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for rope skin palettes, shading, and the stretch tint reduction.</summary>
+    public class RopePaletteTests
+    {
+        /// <summary>Skin 0 base color is the game's default brown primary.</summary>
+        [Fact]
+        public void DefaultSkinBaseIsBrown()
+        {
+            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+
+            Assert.Equal(0.475, c.Base1.R, precision: 3);
+            Assert.Equal(0.305, c.Base1.G, precision: 3);
+            Assert.Equal(0.185, c.Base1.B, precision: 3);
+        }
+
+        /// <summary>Out-of-range skin indices fall back to skin 0.</summary>
+        [Fact]
+        public void OutOfRangeSkinFallsBackToDefault()
+        {
+            RopeDrawColors fallback = RopePalette.GetDrawColors(99, distance: 50, length: 100);
+            RopeDrawColors zero = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+
+            Assert.Equal(zero, fallback);
+        }
+
+        /// <summary>The default skin shade is darker than its base (produces the ramp).</summary>
+        [Fact]
+        public void DefaultSkinShadeIsDarkerThanBase()
+        {
+            RopeDrawColors c = RopePalette.GetDrawColors(0, distance: 50, length: 100);
+
+            Assert.True(c.Shade1.R < c.Base1.R, "shade should be darker than base");
+        }
+
+        /// <summary>A non-stretched custom skin has shade equal to base (no ramp, pure alternation).</summary>
+        [Fact]
+        public void UnstretchedCustomSkinShadeEqualsBase()
+        {
+            // Skin 2 (teal) primary is (0.404, 0.612, 0.635); dark factor is 1.0 when unstretched.
+            RopeDrawColors c = RopePalette.GetDrawColors(2, distance: 50, length: 100);
+
+            Assert.Equal(0.404, c.Base1.R, precision: 3);
+            Assert.Equal(c.Base1, c.Shade1);
+        }
+
+        /// <summary>An over-stretched rope raises the shade red channel above the un-stretched value.</summary>
+        [Fact]
+        public void StretchedRopeBoostsShadeRed()
+        {
+            RopeDrawColors relaxed = RopePalette.GetDrawColors(0, distance: 100, length: 100);
+            RopeDrawColors stretched = RopePalette.GetDrawColors(0, distance: 300, length: 100);
+
+            Assert.True(stretched.Shade1.R > relaxed.Shade1.R, "stretch should increase shade red");
+        }
+
+        /// <summary>Component-wise lerp hits both endpoints and the midpoint.</summary>
+        [Fact]
+        public void LerpInterpolates()
+        {
+            RopeRgb a = new(0, 0, 0);
+            RopeRgb b = new(1, 0.5, 0.25);
+
+            Assert.Equal(a, RopePalette.Lerp(a, b, 0));
+            Assert.Equal(b, RopePalette.Lerp(a, b, 1));
+
+            RopeRgb mid = RopePalette.Lerp(a, b, 0.5);
+            Assert.Equal(0.5, mid.R, precision: 6);
+            Assert.Equal(0.125, mid.B, precision: 6);
+        }
+
+        /// <summary>Skin 0 is the only default skin (drives the outline decision).</summary>
+        [Fact]
+        public void OnlySkinZeroIsDefault()
+        {
+            Assert.True(RopePalette.IsDefaultSkin(0));
+            Assert.False(RopePalette.IsDefaultSkin(1));
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
@@ -113,13 +113,23 @@ namespace CtrDxEditor.Core.Tests
             Assert.True(late.R > early.R);
         }
 
-        /// <summary>Overstretched ropes keep the resting palette (the game's red tint is a transient physics state).</summary>
+        /// <summary>Overstretched ropes get the game's red shade boost (raw channel exceeds 1 before clamping).</summary>
         [Fact]
-        public void BuildOverstretchedKeepsRestingColors()
+        public void BuildOverstretchedTintsRed()
         {
-            List<RopeStrip> stretched = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
-            List<RopeStrip> resting = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
-            Assert.Equal(resting[0].Colors[4], stretched[0].Colors[4]);
+            // Distance 300 vs length 100: far past the 7/105 threshold; shade red *= (300/100)*2.
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
+            Assert.True(strips[0].Colors[4].R > 1);
+        }
+
+        /// <summary>A taut rope below the stretch threshold keeps the resting palette.</summary>
+        [Fact]
+        public void BuildTautButNotStretchedKeepsRestingColors()
+        {
+            // 300 apart, rope 290: taut, but only ~3.4% over rest (threshold is ~6.67%).
+            List<RopeStrip> taut = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            List<RopeStrip> slack = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
+            Assert.Equal(slack[0].Colors[4], taut[0].Colors[4]);
         }
 
         /// <summary>Coincident endpoints produce no strips (all segments degenerate).</summary>

--- a/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for the game-accurate rope strip builder.</summary>
+    public class RopeStripBuilderTests
+    {
+        /// <summary>With two controls the bezier is a straight lerp.</summary>
+        [Fact]
+        public void CalcPathBezier_TwoControls_Lerps()
+        {
+            List<Vec2> controls = [new Vec2(0, 0), new Vec2(10, 20)];
+            Vec2 mid = RopeStripBuilder.CalcPathBezier(controls, 0.5);
+            Assert.Equal(5, mid.X, 9);
+            Assert.Equal(10, mid.Y, 9);
+        }
+
+        /// <summary>The curve interpolates the first and last control points exactly.</summary>
+        [Fact]
+        public void CalcPathBezier_HitsEndpoints()
+        {
+            List<Vec2> controls = [new Vec2(1, 2), new Vec2(50, 90), new Vec2(-4, 30), new Vec2(7, 8)];
+            Vec2 start = RopeStripBuilder.CalcPathBezier(controls, 0);
+            Vec2 end = RopeStripBuilder.CalcPathBezier(controls, 1);
+            Assert.Equal(new Vec2(1, 2), start);
+            Assert.Equal(new Vec2(7, 8), end);
+        }
+
+        /// <summary>Symmetric controls give a symmetric curve: the midpoint sits on the axis of symmetry.</summary>
+        [Fact]
+        public void CalcPathBezier_SymmetricControls_MidpointCentered()
+        {
+            List<Vec2> controls = [new Vec2(0, 0), new Vec2(50, 100), new Vec2(100, 0)];
+            Vec2 mid = RopeStripBuilder.CalcPathBezier(controls, 0.5);
+            Assert.Equal(50, mid.X, 9);
+            Assert.Equal(50, mid.Y, 9); // quadratic: 0.25*0 + 0.5*100 + 0.25*0
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
@@ -12,7 +12,7 @@ namespace CtrDxEditor.Core.Tests
     {
         /// <summary>With two controls the bezier is a straight lerp.</summary>
         [Fact]
-        public void CalcPathBezier_TwoControls_Lerps()
+        public void CalcPathBezierTwoControlsLerps()
         {
             List<Vec2> controls = [new Vec2(0, 0), new Vec2(10, 20)];
             Vec2 mid = RopeStripBuilder.CalcPathBezier(controls, 0.5);
@@ -22,7 +22,7 @@ namespace CtrDxEditor.Core.Tests
 
         /// <summary>The curve interpolates the first and last control points exactly.</summary>
         [Fact]
-        public void CalcPathBezier_HitsEndpoints()
+        public void CalcPathBezierHitsEndpoints()
         {
             List<Vec2> controls = [new Vec2(1, 2), new Vec2(50, 90), new Vec2(-4, 30), new Vec2(7, 8)];
             Vec2 start = RopeStripBuilder.CalcPathBezier(controls, 0);
@@ -33,12 +33,102 @@ namespace CtrDxEditor.Core.Tests
 
         /// <summary>Symmetric controls give a symmetric curve: the midpoint sits on the axis of symmetry.</summary>
         [Fact]
-        public void CalcPathBezier_SymmetricControls_MidpointCentered()
+        public void CalcPathBezierSymmetricControlsMidpointCentered()
         {
             List<Vec2> controls = [new Vec2(0, 0), new Vec2(50, 100), new Vec2(100, 0)];
             Vec2 mid = RopeStripBuilder.CalcPathBezier(controls, 0.5);
             Assert.Equal(50, mid.X, 9);
             Assert.Equal(50, mid.Y, 9); // quadratic: 0.25*0 + 0.5*100 + 0.25*0
+        }
+
+        /// <summary>A taut rope (length &lt; distance, not overstretched) is straight: strip centerlines stay on the chord.</summary>
+        [Fact]
+        public void BuildTautRopeIsStraight()
+        {
+            // 300 apart, rope 290: taut but below the 7/30 stretch threshold (290 * 1.2333 > 300).
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            Assert.NotEmpty(strips);
+            foreach (RopeStrip s in strips)
+            {
+                Assert.Equal(0, s.Points[4].Y, 6); // p1 (centerline)
+                Assert.Equal(0, s.Points[5].Y, 6); // p2 (centerline)
+            }
+        }
+
+        /// <summary>Each strip is the game's 10-vertex cross-section: transparent edges, opaque center.</summary>
+        [Fact]
+        public void BuildStripStructureMatchesGame()
+        {
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            foreach (RopeStrip s in strips)
+            {
+                Assert.Equal(10, s.Points.Length);
+                Assert.Equal(10, s.Colors.Length);
+                Assert.Equal(0, s.Colors[0].A); // AA fade edges
+                Assert.Equal(0, s.Colors[1].A);
+                Assert.Equal(0, s.Colors[8].A);
+                Assert.Equal(0, s.Colors[9].A);
+                Assert.Equal(1, s.Colors[4].A); // centerline opaque
+                Assert.Equal(1, s.Colors[5].A);
+                // Edge band is the center color brightened by the game's +0.15.
+                Assert.Equal(s.Colors[4].R + 0.15, s.Colors[2].R, 9);
+            }
+        }
+
+        /// <summary>A slack rope sags: some centerline point drops below both endpoints (+Y is down).</summary>
+        [Fact]
+        public void BuildSlackRopeSags()
+        {
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
+            bool sagged = false;
+            foreach (RopeStrip s in strips)
+            {
+                if (s.Points[4].Y > 10)
+                {
+                    sagged = true;
+                }
+            }
+
+            Assert.True(sagged);
+        }
+
+        /// <summary>Color batches alternate between the two rope tracks (the twisted-cord look).</summary>
+        [Fact]
+        public void BuildAlternatesColorTracks()
+        {
+            // Length 300 -> 4 constraint points -> 12 samples; batches of 3 segments.
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300);
+            Assert.True(strips.Count >= 4);
+            RopeRgba first = strips[0].Colors[4];  // batch 1: track 2 (Shade2 ramp)
+            RopeRgba fourth = strips[3].Colors[4]; // batch 2: track 1 (Shade1 ramp)
+            Assert.NotEqual(first, fourth);
+        }
+
+        /// <summary>The along-rope ramp brightens: a late strip is brighter than the first (shade -> base).</summary>
+        [Fact]
+        public void BuildRampsShadeToBase()
+        {
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300);
+            RopeRgba early = strips[0].Colors[4];
+            RopeRgba late = strips[^1].Colors[4];
+            Assert.True(late.R > early.R);
+        }
+
+        /// <summary>Overstretched ropes get the game's red shade boost (raw channel exceeds 1 before clamping).</summary>
+        [Fact]
+        public void BuildOverstretchedTintsRed()
+        {
+            // Distance 300 vs length 100: far past the 7/30 threshold; shade red *= (300/100)*2.
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
+            Assert.True(strips[0].Colors[4].R > 1);
+        }
+
+        /// <summary>Coincident endpoints produce no strips (all segments degenerate).</summary>
+        [Fact]
+        public void BuildCoincidentEndpointsReturnsEmpty()
+        {
+            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(50, 50), new Vec2(50, 50), 0);
+            Assert.Empty(strips);
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
@@ -45,7 +45,7 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildTautRopeIsStraight()
         {
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290).Strips;
             Assert.NotEmpty(strips);
             foreach (RopeStrip s in strips)
             {
@@ -58,7 +58,7 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildStripStructureMatchesGame()
         {
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290).Strips;
             foreach (RopeStrip s in strips)
             {
                 Assert.Equal(10, s.Points.Length);
@@ -78,7 +78,7 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildSlackRopeSags()
         {
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400).Strips;
             bool sagged = false;
             foreach (RopeStrip s in strips)
             {
@@ -96,7 +96,7 @@ namespace CtrDxEditor.Core.Tests
         public void BuildAlternatesColorTracks()
         {
             // Length 300 at rest length 35 -> 10 constraint points -> 36 samples; batches of 3 segments.
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300).Strips;
             Assert.True(strips.Count >= 4);
             RopeRgba first = strips[0].Colors[4];  // batch 1: track 2 (Shade2 ramp)
             RopeRgba fourth = strips[3].Colors[4]; // batch 2: track 1 (Shade1 ramp)
@@ -107,7 +107,7 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildRampsShadeToBase()
         {
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300).Strips;
             RopeRgba early = strips[0].Colors[4];
             RopeRgba late = strips[^1].Colors[4];
             Assert.True(late.R > early.R);
@@ -118,7 +118,7 @@ namespace CtrDxEditor.Core.Tests
         public void BuildOverstretchedTintsRed()
         {
             // Distance 300 vs length 100: far past the 7/105 threshold; shade red *= (300/100)*2.
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100).Strips;
             Assert.True(strips[0].Colors[4].R > 1);
         }
 
@@ -127,8 +127,8 @@ namespace CtrDxEditor.Core.Tests
         public void BuildTautButNotStretchedKeepsRestingColors()
         {
             // 300 apart, rope 290: taut, but only ~3.4% over rest (threshold is ~6.67%).
-            List<RopeStrip> taut = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
-            List<RopeStrip> slack = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
+            IReadOnlyList<RopeStrip> taut = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290).Strips;
+            IReadOnlyList<RopeStrip> slack = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400).Strips;
             Assert.Equal(slack[0].Colors[4], taut[0].Colors[4]);
         }
 
@@ -136,8 +136,46 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildCoincidentEndpointsReturnsEmpty()
         {
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(50, 50), new Vec2(50, 50), 0);
+            IReadOnlyList<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(50, 50), new Vec2(50, 50), 0).Strips;
             Assert.Empty(strips);
+        }
+
+        /// <summary>Build exposes the bezier polyline (the game's drawPts): one point per sample, ends pinned.</summary>
+        [Fact]
+        public void BuildExposesSamplePoints()
+        {
+            // Length 290 -> 10 constraint points -> 36 samples -> 37 polyline points (t = 0..1 inclusive).
+            RopeVisual visual = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
+            Assert.Equal(37, visual.SamplePoints.Count);
+            Assert.Equal(new Vec2(0, 0), visual.SamplePoints[0]);
+            Assert.Equal(300, visual.SamplePoints[^1].X, 6);
+        }
+
+        /// <summary>Lights sit on every 6th sample point, skipping 4 points at each end (game cadence).</summary>
+        [Fact]
+        public void ChristmasLightPointsFollowGameCadence()
+        {
+            List<Vec2> samples = [];
+            for (int i = 0; i < 37; i++)
+            {
+                samples.Add(new Vec2(i, 0));
+            }
+
+            List<Vec2> lights = RopeStripBuilder.ChristmasLightPoints(samples);
+            Assert.Equal([4.0, 10.0, 16.0, 22.0, 28.0], lights.ConvertAll(p => p.X));
+        }
+
+        /// <summary>Ropes too short for the end skips get no lights.</summary>
+        [Fact]
+        public void ChristmasLightPointsShortRopeHasNone()
+        {
+            List<Vec2> samples = [];
+            for (int i = 0; i < 8; i++)
+            {
+                samples.Add(new Vec2(i, 0));
+            }
+
+            Assert.Empty(RopeStripBuilder.ChristmasLightPoints(samples));
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RopeStripBuilderTests.cs
@@ -41,11 +41,10 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(50, mid.Y, 9); // quadratic: 0.25*0 + 0.5*100 + 0.25*0
         }
 
-        /// <summary>A taut rope (length &lt; distance, not overstretched) is straight: strip centerlines stay on the chord.</summary>
+        /// <summary>A taut rope (length &lt; distance) is straight: strip centerlines stay on the chord.</summary>
         [Fact]
         public void BuildTautRopeIsStraight()
         {
-            // 300 apart, rope 290: taut but below the 7/30 stretch threshold (290 * 1.2333 > 300).
             List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 290);
             Assert.NotEmpty(strips);
             foreach (RopeStrip s in strips)
@@ -96,7 +95,7 @@ namespace CtrDxEditor.Core.Tests
         [Fact]
         public void BuildAlternatesColorTracks()
         {
-            // Length 300 -> 4 constraint points -> 12 samples; batches of 3 segments.
+            // Length 300 at rest length 35 -> 10 constraint points -> 36 samples; batches of 3 segments.
             List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(200, 0), 300);
             Assert.True(strips.Count >= 4);
             RopeRgba first = strips[0].Colors[4];  // batch 1: track 2 (Shade2 ramp)
@@ -114,13 +113,13 @@ namespace CtrDxEditor.Core.Tests
             Assert.True(late.R > early.R);
         }
 
-        /// <summary>Overstretched ropes get the game's red shade boost (raw channel exceeds 1 before clamping).</summary>
+        /// <summary>Overstretched ropes keep the resting palette (the game's red tint is a transient physics state).</summary>
         [Fact]
-        public void BuildOverstretchedTintsRed()
+        public void BuildOverstretchedKeepsRestingColors()
         {
-            // Distance 300 vs length 100: far past the 7/30 threshold; shade red *= (300/100)*2.
-            List<RopeStrip> strips = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
-            Assert.True(strips[0].Colors[4].R > 1);
+            List<RopeStrip> stretched = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 100);
+            List<RopeStrip> resting = RopeStripBuilder.Build(new Vec2(0, 0), new Vec2(300, 0), 400);
+            Assert.Equal(resting[0].Colors[4], stretched[0].Colors[4]);
         }
 
         /// <summary>Coincident endpoints produce no strips (all segments degenerate).</summary>

--- a/src/CtrDxEditor.Core/Editing/RopeCurve.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeCurve.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Static catenary approximation of a hanging rope. Given two endpoints and a rest
+    /// length, produces the polyline a slack cable settles to under gravity (+Y is down),
+    /// or a straight line when taut. Closed-form - no physics simulation.
+    /// </summary>
+    public static class RopeCurve
+    {
+        // Below this horizontal span (level units) the catenary degenerates (a -> 0,
+        // cosh overflows); fall back to a vertical fold instead.
+        private const double MinSpan = 1e-3;
+
+        /// <summary>
+        /// Samples the rope between <paramref name="a"/> and <paramref name="b"/> in level
+        /// space. Taut (<paramref name="length"/> &lt;= straight distance) -> the two endpoints;
+        /// otherwise a catenary whose parameter is solved from <paramref name="length"/> so
+        /// its arc length equals the rope length.
+        /// </summary>
+        /// <param name="a">First endpoint (e.g. the grab).</param>
+        /// <param name="b">Second endpoint (e.g. the target).</param>
+        /// <param name="length">Rope rest length, in level units.</param>
+        /// <param name="segments">Number of segments (points = segments + 1).</param>
+        public static IReadOnlyList<Vec2> Sample(Vec2 a, Vec2 b, double length, int segments = 20)
+        {
+            if (segments < 1)
+            {
+                segments = 1;
+            }
+
+            Vec2 chordVec = b - a;
+            double chord = Math.Sqrt((chordVec.X * chordVec.X) + (chordVec.Y * chordVec.Y));
+
+            if (length <= chord)
+            {
+                return [a, b];
+            }
+
+            // Orient left -> right so the catenary math assumes increasing x; reverse at the end.
+            bool swapped = b.X < a.X;
+            Vec2 p0 = swapped ? b : a;
+            Vec2 p1 = swapped ? a : b;
+
+            double h = p1.X - p0.X;   // horizontal span >= 0
+            double v = p1.Y - p0.Y;   // vertical gap (+Y down)
+
+            Vec2[] pts = h < MinSpan
+                ? BuildVerticalFold(p0, p1, length, segments)
+                : BuildCatenary(p0, h, v, length, segments);
+
+            if (swapped)
+            {
+                Array.Reverse(pts);
+            }
+            return pts;
+        }
+
+        private static Vec2[] BuildCatenary(Vec2 p0, double h, double v, double length, int segments)
+        {
+            // sqrt(length^2 - v^2) = 2a*sinh(h/2a). Sub u = h/2a -> sinh(u)/u = D/h.
+            double d = Math.Sqrt(Math.Max(0, (length * length) - (v * v)));
+            double u = SolveSinhOverU(d / h);
+            double a = h / (2 * u);
+
+            double x0 = (h / 2) + (a * Math.Asinh(v / d)); // vertex x, relative to p0.X
+            double lambda = p0.Y + (a * Math.Cosh(-x0 / a)); // so y(0) == p0.Y
+
+            Vec2[] pts = new Vec2[segments + 1];
+            for (int i = 0; i <= segments; i++)
+            {
+                double x = (double)i / segments * h;
+                double y = lambda - (a * Math.Cosh((x - x0) / a)); // minus-cosh -> sags toward +Y
+                pts[i] = new Vec2(p0.X + x, y);
+            }
+
+            // Pin exact endpoints against tiny numeric drift.
+            pts[0] = p0;
+            pts[segments] = new Vec2(p0.X + h, p0.Y + v);
+            return pts;
+        }
+
+        private static Vec2[] BuildVerticalFold(Vec2 p0, Vec2 p1, double length, int segments)
+        {
+            // Endpoints share ~the same x. Drop straight down and back so the path length ~= length.
+            double drop = (length - Math.Abs(p1.Y - p0.Y)) / 2;
+            double lowY = Math.Max(p0.Y, p1.Y) + drop;
+
+            Vec2[] pts = new Vec2[segments + 1];
+            for (int i = 0; i <= segments; i++)
+            {
+                double t = (double)i / segments;
+                double y = t <= 0.5
+                    ? p0.Y + ((lowY - p0.Y) * (t / 0.5))
+                    : lowY + ((p1.Y - lowY) * ((t - 0.5) / 0.5));
+                pts[i] = new Vec2(p0.X, y);
+            }
+
+            pts[0] = p0;
+            pts[segments] = p1;
+            return pts;
+        }
+
+        // Solves sinh(u)/u = r for u > 0. The ratio rises monotonically from 1 (u -> 0) to infinity.
+        private static double SolveSinhOverU(double r)
+        {
+            if (r <= 1)
+            {
+                return 1e-6; // effectively straight
+            }
+
+            double lo = 1e-6;
+            double hi = 1;
+            while (Math.Sinh(hi) / hi < r && hi < 1e4)
+            {
+                hi *= 2;
+            }
+            for (int i = 0; i < 60; i++)
+            {
+                double mid = (lo + hi) / 2;
+                if (Math.Sinh(mid) / mid < r)
+                {
+                    lo = mid;
+                }
+                else
+                {
+                    hi = mid;
+                }
+            }
+            return (lo + hi) / 2;
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/RopePalette.cs
+++ b/src/CtrDxEditor.Core/Editing/RopePalette.cs
@@ -1,0 +1,95 @@
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>An RGB color with channels in the 0-1 range. Framework-free.</summary>
+    public readonly record struct RopeRgb(double R, double G, double B);
+
+    /// <summary>
+    /// The four colors used to draw a rope: two bright base colors and their darker
+    /// shades. The renderer ramps each track from shade to base and alternates between
+    /// the two tracks to produce the twisted-cord look.
+    /// </summary>
+    public readonly record struct RopeDrawColors(RopeRgb Base1, RopeRgb Base2, RopeRgb Shade1, RopeRgb Shade2);
+
+    /// <summary>
+    /// Rope skin palettes, shading, and the over-stretch red tint. A static reduction
+    /// of the game's <c>RopeColorHelper</c> for the editor (the game's highlight state
+    /// and per-alpha are not modeled; the editor has neither).
+    /// </summary>
+    public static class RopePalette
+    {
+        /// <summary>Number of available rope skins (indices 0..SkinCount-1).</summary>
+        public static int SkinCount => 9;
+
+        // The desktop game's stretch trigger is segmentLength > restLength + 7, with
+        // BUNGEE_REST_LEN = 105. Applied whole-rope: stretched when distance exceeds
+        // length by 7/105.
+        private const double StretchThresholdRatio = 7.0 / 105.0;
+
+        /// <summary>True only for the default brown skin (index 0).</summary>
+        public static bool IsDefaultSkin(int skin)
+        {
+            return skin == 0;
+        }
+
+        /// <summary>Component-wise linear interpolation between two colors.</summary>
+        public static RopeRgb Lerp(RopeRgb a, RopeRgb b, double t)
+        {
+            return new RopeRgb(
+                a.R + ((b.R - a.R) * t),
+                a.G + ((b.G - a.G) * t),
+                a.B + ((b.B - a.B) * t));
+        }
+
+        /// <summary>
+        /// Gets the four draw colors for a rope of the given <paramref name="skin"/>,
+        /// stretched by the ratio of <paramref name="distance"/> to <paramref name="length"/>.
+        /// Mirrors the game's <c>RopeColorHelper.GetDrawColors</c> (alpha = 1, not highlighted).
+        /// </summary>
+        public static RopeDrawColors GetDrawColors(int skin, double distance, double length)
+        {
+            int normalizedSkin = skin is >= 0 and < 9 ? skin : 0;
+            (RopeRgb primary, RopeRgb secondary) = GetSkin(normalizedSkin);
+
+            bool stretched = length > 0 && distance > length + (StretchThresholdRatio * length);
+
+            // Base colors: when stretched, custom skins draw toward the default brown
+            // palette (matches the game); the shade colors keep the skin's own palette.
+            (RopeRgb baseSrc1, RopeRgb baseSrc2) = stretched && !IsDefaultSkin(normalizedSkin)
+                ? GetSkin(0)
+                : (primary, secondary);
+
+            // Default skin (and any stretched skin) is shaded dark to bright; custom skins
+            // at rest use full brightness, so shade == base and only alternation shows.
+            double darkFactor1 = IsDefaultSkin(normalizedSkin) || stretched ? 0.4 : 1.0;
+            double darkFactor2 = IsDefaultSkin(normalizedSkin) || stretched ? 0.45 : 1.0;
+            RopeRgb shade1 = new(primary.R * darkFactor1, primary.G * darkFactor1, primary.B * darkFactor1);
+            RopeRgb shade2 = new(secondary.R * darkFactor2, secondary.G * darkFactor2, secondary.B * darkFactor2);
+
+            if (stretched)
+            {
+                // The game reddens via the shade end: shade red *= segmentLength/restLength * 2.
+                double redScale = distance / length * 2.0;
+                shade1 = shade1 with { R = shade1.R * redScale };
+                shade2 = shade2 with { R = shade2.R * redScale };
+            }
+
+            return new RopeDrawColors(baseSrc1, baseSrc2, shade1, shade2);
+        }
+
+        private static (RopeRgb Primary, RopeRgb Secondary) GetSkin(int skin)
+        {
+            return skin switch
+            {
+                1 => (new RopeRgb(0.624, 0.294, 0.114), new RopeRgb(1, 0.627, 0.463)),
+                2 => (new RopeRgb(0.404, 0.612, 0.635), new RopeRgb(0.773, 0.898, 0.902)),
+                3 => (new RopeRgb(0.757, 0.533, 0), new RopeRgb(0.98, 0.843, 0.2)),
+                4 => (new RopeRgb(0.980, 0.243, 0.243), new RopeRgb(0.282, 0.525, 0.153)),
+                5 => (new RopeRgb(0.176, 0.318, 0.659), new RopeRgb(1, 1, 1)),
+                6 => (new RopeRgb(0.631, 0.957, 1), new RopeRgb(0.996, 0.631, 0.953)),
+                7 => (new RopeRgb(1, 0.329, 0.318), new RopeRgb(1, 0.992, 0.941)),
+                8 => (new RopeRgb(1, 0.831, 0.404), new RopeRgb(0.251, 0.239, 0.278)),
+                _ => (new RopeRgb(0.475, 0.305, 0.185), new RopeRgb(0.6755555555555556, 0.44, 0.27555555555555555)),
+            };
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/RopePalette.cs
+++ b/src/CtrDxEditor.Core/Editing/RopePalette.cs
@@ -20,10 +20,9 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Number of available rope skins (indices 0..SkinCount-1).</summary>
         public static int SkinCount => 9;
 
-        // The desktop game's stretch trigger is segmentLength > restLength + 7, with
-        // BUNGEE_REST_LEN = 105. Applied whole-rope: stretched when distance exceeds
-        // length by 7/105.
-        private const double StretchThresholdRatio = 7.0 / 105.0;
+        // The desktop game's stretch trigger is segmentLength > restLength + 7. Applied whole-rope: stretched when distance exceeds
+        // length by 7/30.
+        private const double StretchThresholdRatio = 7.0 / 30.0;
 
         /// <summary>True only for the default brown skin (index 0).</summary>
         public static bool IsDefaultSkin(int skin)

--- a/src/CtrDxEditor.Core/Editing/RopePalette.cs
+++ b/src/CtrDxEditor.Core/Editing/RopePalette.cs
@@ -11,18 +11,15 @@ namespace CtrDxEditor.Core.Editing
     public readonly record struct RopeDrawColors(RopeRgb Base1, RopeRgb Base2, RopeRgb Shade1, RopeRgb Shade2);
 
     /// <summary>
-    /// Rope skin palettes, shading, and the over-stretch red tint. A static reduction
-    /// of the game's <c>RopeColorHelper</c> for the editor (the game's highlight state
-    /// and per-alpha are not modeled; the editor has neither).
+    /// Rope skin palettes and shading. A static reduction of the game's
+    /// <c>RopeColorHelper</c> for the editor (the game's highlight state, per-alpha,
+    /// and transient stretch tint are not modeled; they are physics/interaction states
+    /// the static editor doesn't have).
     /// </summary>
     public static class RopePalette
     {
         /// <summary>Number of available rope skins (indices 0..SkinCount-1).</summary>
         public static int SkinCount => 9;
-
-        // The desktop game's stretch trigger is segmentLength > restLength + 7. Applied whole-rope: stretched when distance exceeds
-        // length by 7/30.
-        private const double StretchThresholdRatio = 7.0 / 30.0;
 
         /// <summary>True only for the default brown skin (index 0).</summary>
         public static bool IsDefaultSkin(int skin)
@@ -40,39 +37,23 @@ namespace CtrDxEditor.Core.Editing
         }
 
         /// <summary>
-        /// Gets the four draw colors for a rope of the given <paramref name="skin"/>,
-        /// stretched by the ratio of <paramref name="distance"/> to <paramref name="length"/>.
-        /// Mirrors the game's <c>RopeColorHelper.GetDrawColors</c> (alpha = 1, not highlighted).
+        /// Gets the four draw colors for a rope of the given <paramref name="skin"/>.
+        /// Mirrors the game's <c>RopeColorHelper.GetDrawColors</c> at rest
+        /// (alpha = 1, not highlighted, not stretched).
         /// </summary>
-        public static RopeDrawColors GetDrawColors(int skin, double distance, double length)
+        public static RopeDrawColors GetDrawColors(int skin)
         {
             int normalizedSkin = skin is >= 0 and < 9 ? skin : 0;
             (RopeRgb primary, RopeRgb secondary) = GetSkin(normalizedSkin);
 
-            bool stretched = length > 0 && distance > length + (StretchThresholdRatio * length);
-
-            // Base colors: when stretched, custom skins draw toward the default brown
-            // palette (matches the game); the shade colors keep the skin's own palette.
-            (RopeRgb baseSrc1, RopeRgb baseSrc2) = stretched && !IsDefaultSkin(normalizedSkin)
-                ? GetSkin(0)
-                : (primary, secondary);
-
-            // Default skin (and any stretched skin) is shaded dark to bright; custom skins
-            // at rest use full brightness, so shade == base and only alternation shows.
-            double darkFactor1 = IsDefaultSkin(normalizedSkin) || stretched ? 0.4 : 1.0;
-            double darkFactor2 = IsDefaultSkin(normalizedSkin) || stretched ? 0.45 : 1.0;
+            // The default skin is shaded dark to bright; custom skins use full
+            // brightness, so shade == base and only alternation shows.
+            double darkFactor1 = IsDefaultSkin(normalizedSkin) ? 0.4 : 1.0;
+            double darkFactor2 = IsDefaultSkin(normalizedSkin) ? 0.45 : 1.0;
             RopeRgb shade1 = new(primary.R * darkFactor1, primary.G * darkFactor1, primary.B * darkFactor1);
             RopeRgb shade2 = new(secondary.R * darkFactor2, secondary.G * darkFactor2, secondary.B * darkFactor2);
 
-            if (stretched)
-            {
-                // The game reddens via the shade end: shade red *= segmentLength/restLength * 2.
-                double redScale = distance / length * 2.0;
-                shade1 = shade1 with { R = shade1.R * redScale };
-                shade2 = shade2 with { R = shade2.R * redScale };
-            }
-
-            return new RopeDrawColors(baseSrc1, baseSrc2, shade1, shade2);
+            return new RopeDrawColors(primary, secondary, shade1, shade2);
         }
 
         private static (RopeRgb Primary, RopeRgb Secondary) GetSkin(int skin)

--- a/src/CtrDxEditor.Core/Editing/RopePalette.cs
+++ b/src/CtrDxEditor.Core/Editing/RopePalette.cs
@@ -11,15 +11,20 @@ namespace CtrDxEditor.Core.Editing
     public readonly record struct RopeDrawColors(RopeRgb Base1, RopeRgb Base2, RopeRgb Shade1, RopeRgb Shade2);
 
     /// <summary>
-    /// Rope skin palettes and shading. A static reduction of the game's
-    /// <c>RopeColorHelper</c> for the editor (the game's highlight state, per-alpha,
-    /// and transient stretch tint are not modeled; they are physics/interaction states
-    /// the static editor doesn't have).
+    /// Rope skin palettes, shading, and the over-stretch red tint. A static reduction
+    /// of the game's <c>RopeColorHelper</c> for the editor (the game's highlight state
+    /// and per-alpha are not modeled; the editor has neither).
     /// </summary>
     public static class RopePalette
     {
         /// <summary>Number of available rope skins (indices 0..SkinCount-1).</summary>
         public static int SkinCount => 9;
+
+        // The game flags a segment as stretched when its length exceeds rest + 7
+        // (desktop: rest 105). A taut rope stretches uniformly, so per-segment
+        // length/rest equals whole-rope distance/length and the check reduces to
+        // this dimensionless ratio.
+        private const double StretchThresholdRatio = 7.0 / 105.0;
 
         /// <summary>True only for the default brown skin (index 0).</summary>
         public static bool IsDefaultSkin(int skin)
@@ -37,23 +42,42 @@ namespace CtrDxEditor.Core.Editing
         }
 
         /// <summary>
-        /// Gets the four draw colors for a rope of the given <paramref name="skin"/>.
-        /// Mirrors the game's <c>RopeColorHelper.GetDrawColors</c> at rest
-        /// (alpha = 1, not highlighted, not stretched).
+        /// Gets the four draw colors for a rope of the given <paramref name="skin"/>,
+        /// stretched by the ratio of <paramref name="distance"/> to <paramref name="length"/>.
+        /// Mirrors the game's <c>RopeColorHelper.GetDrawColors</c> (alpha = 1, not
+        /// highlighted); the red stretch tint fires when the endpoints sit further
+        /// apart than the rope's rest length plus the game's threshold.
         /// </summary>
-        public static RopeDrawColors GetDrawColors(int skin)
+        public static RopeDrawColors GetDrawColors(int skin, double distance, double length)
         {
             int normalizedSkin = skin is >= 0 and < 9 ? skin : 0;
             (RopeRgb primary, RopeRgb secondary) = GetSkin(normalizedSkin);
 
-            // The default skin is shaded dark to bright; custom skins use full
-            // brightness, so shade == base and only alternation shows.
-            double darkFactor1 = IsDefaultSkin(normalizedSkin) ? 0.4 : 1.0;
-            double darkFactor2 = IsDefaultSkin(normalizedSkin) ? 0.45 : 1.0;
+            bool stretched = length > 0 && distance > length * (1 + StretchThresholdRatio);
+
+            // Base colors: when stretched, custom skins draw toward the default brown
+            // palette (matches the game); the shade colors keep the skin's own palette.
+            (RopeRgb base1, RopeRgb base2) = stretched && !IsDefaultSkin(normalizedSkin)
+                ? GetSkin(0)
+                : (primary, secondary);
+
+            // The default skin (and any stretched skin) is shaded dark to bright; custom
+            // skins at rest use full brightness, so shade == base and only alternation shows.
+            double darkFactor1 = IsDefaultSkin(normalizedSkin) || stretched ? 0.4 : 1.0;
+            double darkFactor2 = IsDefaultSkin(normalizedSkin) || stretched ? 0.45 : 1.0;
             RopeRgb shade1 = new(primary.R * darkFactor1, primary.G * darkFactor1, primary.B * darkFactor1);
             RopeRgb shade2 = new(secondary.R * darkFactor2, secondary.G * darkFactor2, secondary.B * darkFactor2);
 
-            return new RopeDrawColors(primary, secondary, shade1, shade2);
+            if (stretched)
+            {
+                // The game reddens via the shade end: shade red *= segmentLength/restLength * 2,
+                // which for a uniformly stretched rope is distance/length * 2.
+                double redScale = distance / length * 2.0;
+                shade1 = shade1 with { R = shade1.R * redScale };
+                shade2 = shade2 with { R = shade2.R * redScale };
+            }
+
+            return new RopeDrawColors(base1, base2, shade1, shade2);
         }
 
         private static (RopeRgb Primary, RopeRgb Secondary) GetSkin(int skin)

--- a/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
@@ -67,13 +67,14 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>
         /// Builds the triangle strips for a rope from <paramref name="a"/> (the grab) to
         /// <paramref name="b"/> (the target) with rest length <paramref name="length"/>.
-        /// Slack ropes hang on the catenary; taut ropes run straight.
+        /// Slack ropes hang on the catenary; taut ropes run straight, and ropes pulled
+        /// past their rest length pick up the game's red stretch tint.
         /// </summary>
         public static List<RopeStrip> Build(Vec2 a, Vec2 b, double length)
         {
             Vec2 chord = b - a;
             double distance = Math.Sqrt((chord.X * chord.X) + (chord.Y * chord.Y));
-            RopeDrawColors palette = RopePalette.GetDrawColors(0);
+            RopeDrawColors palette = RopePalette.GetDrawColors(0, distance, length);
 
             // The physics chain has 2 + floor(len/restLen) parts; the game's draw loop needs >= 3.
             int count = Math.Max(3, 2 + (int)(length / RestLength));

--- a/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>An RGBA color with straight (non-premultiplied) 0-1 channels. Channels may exceed 1 (clamped at raster time).</summary>
+    public readonly record struct RopeRgba(double R, double G, double B, double A);
+
+    /// <summary>One triangle strip of a rendered rope: parallel position/color arrays in strip order.</summary>
+    public sealed record RopeStrip(Vec2[] Points, RopeRgba[] Colors);
+
+    /// <summary>
+    /// Builds the triangle strips that draw a rope exactly like the game's
+    /// <c>Bungee.DrawBungee</c> / <c>DrawAntialiasedLineContinued</c> (default skin,
+    /// alpha 1, not highlighted). Coordinates are level-space; the game's pixel
+    /// constants (half-width 5, 1-unit edge fade) scale with the view like sprite art.
+    /// </summary>
+    public static class RopeStripBuilder
+    {
+        // Desktop game constants: BUNGEE_REST_LEN, BungeeDrawSamplePoints, main strip half-width.
+        private const double RestLength = 105;
+        private const int SamplesPerSegment = 4;
+        private const double HalfWidth = 5;
+
+        /// <summary>
+        /// Evaluates the game's <c>DrawHelper.CalcPathBezier</c>: a de Casteljau reduction
+        /// where every input point is a control point (the curve only interpolates the ends).
+        /// </summary>
+        public static Vec2 CalcPathBezier(IReadOnlyList<Vec2> controls, double t)
+        {
+            int n = controls.Count;
+            if (n == 0)
+            {
+                return default;
+            }
+
+            if (n == 1)
+            {
+                return controls[0];
+            }
+
+            Vec2[] scratch = new Vec2[n];
+            for (int i = 0; i < n; i++)
+            {
+                scratch[i] = controls[i];
+            }
+
+            for (int level = n - 1; level >= 1; level--)
+            {
+                for (int i = 0; i < level; i++)
+                {
+                    scratch[i] = new Vec2(
+                        (scratch[i].X * (1 - t)) + (scratch[i + 1].X * t),
+                        (scratch[i].Y * (1 - t)) + (scratch[i + 1].Y * t));
+                }
+            }
+
+            return scratch[0];
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
@@ -12,6 +12,12 @@ namespace CtrDxEditor.Core.Editing
     public sealed record RopeStrip(Vec2[] Points, RopeRgba[] Colors);
 
     /// <summary>
+    /// A built rope visual: the triangle strips plus the bezier sample polyline
+    /// (the game's <c>drawPts</c>, which also anchors the Christmas lights).
+    /// </summary>
+    public sealed record RopeVisual(IReadOnlyList<RopeStrip> Strips, IReadOnlyList<Vec2> SamplePoints);
+
+    /// <summary>
     /// Builds the triangle strips that draw a rope exactly like the game's
     /// <c>Bungee.DrawBungee</c> / <c>DrawAntialiasedLineContinued</c> (default skin,
     /// alpha 1, not highlighted). Coordinates are level-space; the rope width scales
@@ -70,7 +76,7 @@ namespace CtrDxEditor.Core.Editing
         /// Slack ropes hang on the catenary; taut ropes run straight, and ropes pulled
         /// past their rest length pick up the game's red stretch tint.
         /// </summary>
-        public static List<RopeStrip> Build(Vec2 a, Vec2 b, double length)
+        public static RopeVisual Build(Vec2 a, Vec2 b, double length)
         {
             Vec2 chord = b - a;
             double distance = Math.Sqrt((chord.X * chord.X) + (chord.Y * chord.Y));
@@ -99,11 +105,27 @@ namespace CtrDxEditor.Core.Editing
             return BuildStrips(pts, palette);
         }
 
+        /// <summary>
+        /// Positions of the rope's Christmas lights, ported from the game's
+        /// <c>Bungee.DrawChristmasLights</c>: every 6th bezier sample point, skipping
+        /// 4 points at each end of the rope.
+        /// </summary>
+        public static List<Vec2> ChristmasLightPoints(IReadOnlyList<Vec2> samplePoints)
+        {
+            List<Vec2> lights = [];
+            for (int i = 4; i < samplePoints.Count - 4; i += 6)
+            {
+                lights.Add(samplePoints[i]);
+            }
+            return lights;
+        }
+
         // Port of the DrawBungee sampling loop: bezier samples batched 4 points at a time,
         // alternating the two color tracks per batch while both ramp shade -> base.
-        private static List<RopeStrip> BuildStrips(Vec2[] pts, RopeDrawColors palette)
+        private static RopeVisual BuildStrips(Vec2[] pts, RopeDrawColors palette)
         {
             List<RopeStrip> strips = [];
+            List<Vec2> samples = [];
             int sampleCount = (pts.Length - 1) * SamplesPerSegment;
             double sampleStep = 1.0 / sampleCount;
 
@@ -127,7 +149,9 @@ namespace CtrDxEditor.Core.Editing
                     t = 1;
                 }
 
-                batch.Add(CalcPathBezier(pts, t));
+                Vec2 sample = CalcPathBezier(pts, t);
+                samples.Add(sample);
+                batch.Add(sample);
                 if (batch.Count >= 4 || t == 1)
                 {
                     RopeRgb c = useTrack1 ? track1 : track2;
@@ -158,7 +182,7 @@ namespace CtrDxEditor.Core.Editing
                 t += sampleStep;
             }
 
-            return strips;
+            return new RopeVisual(strips, samples);
         }
 
         // Port of DrawAntialiasedLineContinued (non-highlighted): one 10-vertex strip per

--- a/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
@@ -14,15 +14,19 @@ namespace CtrDxEditor.Core.Editing
     /// <summary>
     /// Builds the triangle strips that draw a rope exactly like the game's
     /// <c>Bungee.DrawBungee</c> / <c>DrawAntialiasedLineContinued</c> (default skin,
-    /// alpha 1, not highlighted). Coordinates are level-space; the game's pixel
-    /// constants (half-width 5, 1-unit edge fade) scale with the view like sprite art.
+    /// alpha 1, not highlighted). Coordinates are level-space; the rope width scales
+    /// with the view like sprite art.
     /// </summary>
     public static class RopeStripBuilder
     {
-        // Desktop game constants: BUNGEE_REST_LEN, BungeeDrawSamplePoints, main strip half-width.
-        private const double RestLength = 105;
-        private const int SamplesPerSegment = 4;
-        private const double HalfWidth = 5;
+        // The game loads levels at mapScale = 3 (GameScene.Show), so its rope constants
+        // (BUNGEE_REST_LEN 105, half-width 5, 1-unit edge fade) live in XML x 3 world
+        // space. The editor draws in raw XML space, so divide them back down.
+        private const double MapScale = 3;
+        private const double RestLength = 105 / MapScale;
+        private const int SamplesPerSegment = 4; // BungeeDrawSamplePoints (dimensionless)
+        private const double HalfWidth = 5 / MapScale;
+        private const double EdgeFade = 1 / MapScale;
 
         /// <summary>
         /// Evaluates the game's <c>DrawHelper.CalcPathBezier</c>: a de Casteljau reduction
@@ -63,16 +67,15 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>
         /// Builds the triangle strips for a rope from <paramref name="a"/> (the grab) to
         /// <paramref name="b"/> (the target) with rest length <paramref name="length"/>.
-        /// Slack ropes hang on the catenary; taut/overstretched ropes run straight and
-        /// pick up the palette's red stretch tint.
+        /// Slack ropes hang on the catenary; taut ropes run straight.
         /// </summary>
         public static List<RopeStrip> Build(Vec2 a, Vec2 b, double length)
         {
             Vec2 chord = b - a;
             double distance = Math.Sqrt((chord.X * chord.X) + (chord.Y * chord.Y));
-            RopeDrawColors palette = RopePalette.GetDrawColors(0, distance, length);
+            RopeDrawColors palette = RopePalette.GetDrawColors(0);
 
-            // The physics chain has 2 + floor(len/105) parts; the game's draw loop needs >= 3.
+            // The physics chain has 2 + floor(len/restLen) parts; the game's draw loop needs >= 3.
             int count = Math.Max(3, 2 + (int)(length / RestLength));
             Vec2[] pts = new Vec2[count];
             if (length > distance)
@@ -159,8 +162,8 @@ namespace CtrDxEditor.Core.Editing
 
         // Port of DrawAntialiasedLineContinued (non-highlighted): one 10-vertex strip per
         // segment. Cross-section: transparent at +/-halfWidth, +0.15 brightened color one
-        // unit in, base color on the centerline. Far edge overdrawn 2% to hide seams;
-        // start edges continue from the previous segment so the ribbon is seamless.
+        // edge-fade width in, base color on the centerline. Far edge overdrawn 2% to hide
+        // seams; start edges continue from the previous segment so the ribbon is seamless.
         private static RopeStrip? BuildSegmentStrip(
             Vec2 p1, Vec2 p2, double size, RopeRgba color,
             ref double lx, ref double ly, ref double rx, ref double ry)
@@ -188,10 +191,11 @@ namespace CtrDxEditor.Core.Editing
             rx = rightFar.X;
             ry = rightFar.Y;
 
-            Vec2 leftStartIn = leftStart - unit;
-            Vec2 leftFarIn = leftFarOver - unit;
-            Vec2 rightStartIn = rightStart + unit;
-            Vec2 rightFarIn = rightFarOver + unit;
+            Vec2 inset = new(unit.X * EdgeFade, unit.Y * EdgeFade);
+            Vec2 leftStartIn = leftStart - inset;
+            Vec2 leftFarIn = leftFarOver - inset;
+            Vec2 rightStartIn = rightStart + inset;
+            Vec2 rightFarIn = rightFarOver + inset;
 
             RopeRgba bright = new(color.R + 0.15, color.G + 0.15, color.B + 0.15, color.A);
             RopeRgba fade = color with { A = 0 };

--- a/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
+++ b/src/CtrDxEditor.Core/Editing/RopeStripBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CtrDxEditor.Core.Geometry;
@@ -57,6 +58,151 @@ namespace CtrDxEditor.Core.Editing
             }
 
             return scratch[0];
+        }
+
+        /// <summary>
+        /// Builds the triangle strips for a rope from <paramref name="a"/> (the grab) to
+        /// <paramref name="b"/> (the target) with rest length <paramref name="length"/>.
+        /// Slack ropes hang on the catenary; taut/overstretched ropes run straight and
+        /// pick up the palette's red stretch tint.
+        /// </summary>
+        public static List<RopeStrip> Build(Vec2 a, Vec2 b, double length)
+        {
+            Vec2 chord = b - a;
+            double distance = Math.Sqrt((chord.X * chord.X) + (chord.Y * chord.Y));
+            RopeDrawColors palette = RopePalette.GetDrawColors(0, distance, length);
+
+            // The physics chain has 2 + floor(len/105) parts; the game's draw loop needs >= 3.
+            int count = Math.Max(3, 2 + (int)(length / RestLength));
+            Vec2[] pts = new Vec2[count];
+            if (length > distance)
+            {
+                IReadOnlyList<Vec2> sag = RopeCurve.Sample(a, b, length, count - 1);
+                for (int i = 0; i < count; i++)
+                {
+                    pts[i] = sag[i];
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    double f = (double)i / (count - 1);
+                    pts[i] = new Vec2(a.X + (chord.X * f), a.Y + (chord.Y * f));
+                }
+            }
+
+            return BuildStrips(pts, palette);
+        }
+
+        // Port of the DrawBungee sampling loop: bezier samples batched 4 points at a time,
+        // alternating the two color tracks per batch while both ramp shade -> base.
+        private static List<RopeStrip> BuildStrips(Vec2[] pts, RopeDrawColors palette)
+        {
+            List<RopeStrip> strips = [];
+            int sampleCount = (pts.Length - 1) * SamplesPerSegment;
+            double sampleStep = 1.0 / sampleCount;
+
+            double redStep = (palette.Base1.R - palette.Shade1.R) / (sampleCount - 1);
+            double greenStep = (palette.Base1.G - palette.Shade1.G) / (sampleCount - 1);
+            double blueStep = (palette.Base1.B - palette.Shade1.B) / (sampleCount - 1);
+            double redStepAlt = (palette.Base2.R - palette.Shade2.R) / (sampleCount - 1);
+            double greenStepAlt = (palette.Base2.G - palette.Shade2.G) / (sampleCount - 1);
+            double blueStepAlt = (palette.Base2.B - palette.Shade2.B) / (sampleCount - 1);
+            RopeRgb track1 = palette.Shade1;
+            RopeRgb track2 = palette.Shade2;
+            bool useTrack1 = false; // game: flag=false -> first batch draws rgbaColor6 (track 2)
+
+            List<Vec2> batch = new(4);
+            double lx = -1, ly = 0, rx = 0, ry = 0; // continued edge vertices; lx == -1 means none yet
+            double t = 0;
+            while (true)
+            {
+                if (t > 1)
+                {
+                    t = 1;
+                }
+
+                batch.Add(CalcPathBezier(pts, t));
+                if (batch.Count >= 4 || t == 1)
+                {
+                    RopeRgb c = useTrack1 ? track1 : track2;
+                    RopeRgba color = new(c.R, c.G, c.B, 1);
+                    for (int i = 0; i < batch.Count - 1; i++)
+                    {
+                        if (BuildSegmentStrip(batch[i], batch[i + 1], HalfWidth, color,
+                                ref lx, ref ly, ref rx, ref ry) is { } strip)
+                        {
+                            strips.Add(strip);
+                        }
+                    }
+
+                    int steps = batch.Count - 1;
+                    Vec2 carry = batch[^1];
+                    batch.Clear();
+                    batch.Add(carry);
+                    useTrack1 = !useTrack1;
+                    track1 = new RopeRgb(track1.R + (redStep * steps), track1.G + (greenStep * steps), track1.B + (blueStep * steps));
+                    track2 = new RopeRgb(track2.R + (redStepAlt * steps), track2.G + (greenStepAlt * steps), track2.B + (blueStepAlt * steps));
+                }
+
+                if (t == 1)
+                {
+                    break;
+                }
+
+                t += sampleStep;
+            }
+
+            return strips;
+        }
+
+        // Port of DrawAntialiasedLineContinued (non-highlighted): one 10-vertex strip per
+        // segment. Cross-section: transparent at +/-halfWidth, +0.15 brightened color one
+        // unit in, base color on the centerline. Far edge overdrawn 2% to hide seams;
+        // start edges continue from the previous segment so the ribbon is seamless.
+        private static RopeStrip? BuildSegmentStrip(
+            Vec2 p1, Vec2 p2, double size, RopeRgba color,
+            ref double lx, ref double ly, ref double rx, ref double ry)
+        {
+            Vec2 dir = p2 - p1;
+            if (dir.X == 0 && dir.Y == 0)
+            {
+                return null;
+            }
+
+            Vec2 dirOver = new(dir.X * 1.02, dir.Y * 1.02);
+            double len = Math.Sqrt((dir.X * dir.X) + (dir.Y * dir.Y));
+            Vec2 unit = new(-dir.Y / len, dir.X / len); // game VectPerp: (-y, x), normalized
+            Vec2 n = new(unit.X * size, unit.Y * size);
+
+            Vec2 leftFar = new(p1.X + n.X + dir.X, p1.Y + n.Y + dir.Y);
+            Vec2 rightFar = new(p1.X - n.X + dir.X, p1.Y - n.Y + dir.Y);
+            Vec2 leftFarOver = new(p1.X + n.X + dirOver.X, p1.Y + n.Y + dirOver.Y);
+            Vec2 rightFarOver = new(p1.X - n.X + dirOver.X, p1.Y - n.Y + dirOver.Y);
+
+            Vec2 leftStart = lx == -1 ? new Vec2(p1.X + n.X, p1.Y + n.Y) : new Vec2(lx, ly);
+            Vec2 rightStart = lx == -1 ? new Vec2(p1.X - n.X, p1.Y - n.Y) : new Vec2(rx, ry);
+            lx = leftFar.X;
+            ly = leftFar.Y;
+            rx = rightFar.X;
+            ry = rightFar.Y;
+
+            Vec2 leftStartIn = leftStart - unit;
+            Vec2 leftFarIn = leftFarOver - unit;
+            Vec2 rightStartIn = rightStart + unit;
+            Vec2 rightFarIn = rightFarOver + unit;
+
+            RopeRgba bright = new(color.R + 0.15, color.G + 0.15, color.B + 0.15, color.A);
+            RopeRgba fade = color with { A = 0 };
+
+            Vec2[] points =
+            [
+                leftStart, leftFarOver, leftStartIn, leftFarIn, p1,
+                p2, rightStartIn, rightFarIn, rightStart, rightFarOver
+            ];
+            RopeRgba[] colors = [fade, fade, bright, bright, color, color, bright, bright, fade, fade];
+            return new RopeStrip(points, colors);
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/SpecialEvents.cs
+++ b/src/CtrDxEditor.Core/Editing/SpecialEvents.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>Seasonal event windows, ported from Cut the Rope: DX's <c>SpecialEvents</c>.</summary>
+    public static class SpecialEvents
+    {
+        /// <summary>Christmas event period: December and January (matches the game).</summary>
+        public static bool IsXmas => DateTime.Now.Month is 12 or 1;
+    }
+}

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -19,9 +19,15 @@ namespace CtrDxEditor.Content
     /// <summary>A fully resolved, composited object sprite: ordered layers plus per-object scale.</summary>
     public sealed record ObjectSprite(IReadOnlyList<SpriteLayerDraw> Layers, double Scale);
 
+    /// <summary>The rope Christmas lights atlas: its bitmap and the light bulb frames.</summary>
+    public sealed record ChristmasLightsArt(Bitmap Bitmap, IReadOnlyList<AtlasFrame> Frames);
+
     /// <summary>Reads sprite atlases from a preloaded platform content store.</summary>
     public sealed class SpriteCache(IContentStore store, string imageExtension = ".png")
     {
+        private const string XmasLightsJson = "images/christmas_lights.json";
+        private const string XmasLightsImageBase = "images/christmas_lights";
+
         private readonly Dictionary<string, Bitmap> _bitmaps = [];
         private readonly Dictionary<string, Atlas> _atlases = [];
         private readonly Dictionary<string, Bitmap?> _thumbnails = [];
@@ -54,6 +60,37 @@ namespace CtrDxEditor.Content
                     }
                 }
             }
+
+            // Seasonal rope lights. Optional: a bundle without the atlas just renders
+            // ropes bare, so a load failure must not break the whole preload.
+            try
+            {
+                string imagePath = XmasLightsImageBase + imageExtension;
+                if (!_bitmaps.ContainsKey(imagePath))
+                {
+                    byte[] bytes = await store.ReadBytesAsync(imagePath);
+                    using MemoryStream ms = new(bytes);
+                    _bitmaps[imagePath] = new Bitmap(ms);
+                }
+                if (!_atlases.ContainsKey(XmasLightsJson))
+                {
+                    string json = await store.ReadTextAsync(XmasLightsJson);
+                    _atlases[XmasLightsJson] = new Atlas(AtlasJsonLoader.ParseFrames(json));
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        /// <summary>The rope Christmas lights art, or null when the bundle doesn't include it.</summary>
+        public ChristmasLightsArt? GetChristmasLights()
+        {
+            Bitmap? bitmap = LoadBitmap(XmasLightsImageBase + imageExtension);
+            Atlas? atlas = LoadAtlas(XmasLightsJson);
+            return bitmap is null || atlas is null || atlas.Frames.Count == 0
+                ? null
+                : new ChristmasLightsArt(bitmap, atlas.Frames);
         }
 
         /// <summary>A small composited preview of an object's sprite, for the palette. Cached per element.</summary>

--- a/src/CtrDxEditor.Shared/CtrDxEditor.Shared.csproj
+++ b/src/CtrDxEditor.Shared/CtrDxEditor.Shared.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Skia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="AvaloniaDialogs" />

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -193,6 +194,7 @@ namespace CtrDxEditor.Rendering
             }
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
+            List<RopeStrip> ropeStrips = [];
             foreach (LevelObject obj in objects)
             {
                 if (obj.Type != "grab")
@@ -206,11 +208,18 @@ namespace CtrDxEditor.Rendering
                     continue;
                 }
 
-                Vec2 a = v.LevelToScreen(new Vec2(obj.X, obj.Y));
-                Vec2 b = v.LevelToScreen(new Vec2(rope.Target.X, rope.Target.Y));
-                IBrush brush = rope.Kind == RopeTargetKind.Bulb ? Brushes.Khaki : Brushes.IndianRed;
-                Pen pen = new(brush, 3) { DashStyle = new DashStyle([4, 3], 0) };
-                context.DrawLine(pen, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                // The game reads the grab's length attribute for the bungee rest length;
+                // missing/0 renders as a taut straight rope.
+                double ropeLength = double.TryParse(
+                    obj.GetAttr("length"), NumberStyles.Float, CultureInfo.InvariantCulture, out double len)
+                    ? len
+                    : 0;
+                ropeStrips.AddRange(RopeStripBuilder.Build(
+                    new Vec2(obj.X, obj.Y), new Vec2(rope.Target.X, rope.Target.Y), ropeLength));
+            }
+            if (ropeStrips.Count > 0)
+            {
+                context.Custom(new RopeDrawOperation(new Rect(Bounds.Size), v, ropeStrips));
             }
 
             foreach (LevelObject obj in objects)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -8,7 +7,6 @@ using Avalonia.Input;
 using Avalonia.Media;
 
 using CtrDxEditor.Content;
-using CtrDxEditor.Core.Atlas;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
@@ -92,10 +90,6 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Callback raised when a canvas drag moves the selected object, so bound views can refresh.</summary>
         public Action? SelectedObjectMoved { get; set; }
-
-        // The game shows rope Christmas lights only in Dec/Jan (SpecialEvents.IsXmas).
-        // Forced on while the port is verified out of season; flip to false to restore gating.
-        private const bool ForceChristmasLights = true;
 
         private bool _dragging;
         private Vec2 _dragOffset;
@@ -199,40 +193,7 @@ namespace CtrDxEditor.Rendering
             }
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
-            List<RopeStrip> ropeStrips = [];
-            List<List<Vec2>> ropeLightPoints = [];
-            foreach (LevelObject obj in objects)
-            {
-                if (obj.Type != "grab")
-                {
-                    continue;
-                }
-
-                RopeTarget rope = RopeResolver.Resolve(obj, objects, doc.TwoParts);
-                if (rope.Target is null)
-                {
-                    continue;
-                }
-
-                // The game reads the grab's length attribute for the bungee rest length;
-                // missing/0 renders as a taut straight rope.
-                double ropeLength = double.TryParse(
-                    obj.GetAttr("length"), NumberStyles.Float, CultureInfo.InvariantCulture, out double len)
-                    ? len
-                    : 0;
-                RopeVisual ropeVisual = RopeStripBuilder.Build(
-                    new Vec2(obj.X, obj.Y), new Vec2(rope.Target.X, rope.Target.Y), ropeLength);
-                ropeStrips.AddRange(ropeVisual.Strips);
-                ropeLightPoints.Add(RopeStripBuilder.ChristmasLightPoints(ropeVisual.SamplePoints));
-            }
-            if (ropeStrips.Count > 0)
-            {
-                context.Custom(new RopeDrawOperation(new Rect(Bounds.Size), v, ropeStrips));
-            }
-            if (ForceChristmasLights || SpecialEvents.IsXmas)
-            {
-                DrawChristmasLights(context, v, sprites, ropeLightPoints);
-            }
+            RopeRenderer.Draw(context, v, sprites, doc, new Rect(Bounds.Size));
 
             foreach (LevelObject obj in objects)
             {
@@ -307,39 +268,6 @@ namespace CtrDxEditor.Rendering
             double w = maxX - minX, h = maxY - minY;
             const double grow = 0.25;
             return new LevelBounds(minX - (w * grow / 2.0), minY - (h * grow / 2.0), w * (1 + grow), h * (1 + grow));
-        }
-
-        // Port of Bungee.DrawChristmasLights: one random light frame per anchor point,
-        // centered on the frame's trimmed rect at world pixels (level units = world / mapScale).
-        // Frames are seeded per rope so they stay put across redraws (the game randomizes
-        // once per bungee instance).
-        private static void DrawChristmasLights(
-            DrawingContext ctx,
-            ViewTransform v,
-            SpriteCache sprites,
-            List<List<Vec2>> ropeLightPoints)
-        {
-            if (sprites.GetChristmasLights() is not { } art)
-            {
-                return;
-            }
-
-            for (int ropeIndex = 0; ropeIndex < ropeLightPoints.Count; ropeIndex++)
-            {
-                Random frameRandom = new(ropeIndex);
-                foreach (Vec2 p in ropeLightPoints[ropeIndex])
-                {
-                    AtlasFrame frame = art.Frames[frameRandom.Next(art.Frames.Count)];
-                    double w = frame.Frame.W / SpritePlacement.MapScale;
-                    double h = frame.Frame.H / SpritePlacement.MapScale;
-                    Vec2 tl = v.LevelToScreen(new Vec2(p.X - (w / 2), p.Y - (h / 2)));
-                    Vec2 br = v.LevelToScreen(new Vec2(p.X + (w / 2), p.Y + (h / 2)));
-                    ctx.DrawImage(
-                        art.Bitmap,
-                        new Rect(frame.Frame.X, frame.Frame.Y, frame.Frame.W, frame.Frame.H),
-                        new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
-                }
-            }
         }
 
         private static void DrawObject(DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Media;
 
 using CtrDxEditor.Content;
+using CtrDxEditor.Core.Atlas;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
@@ -91,6 +92,10 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Callback raised when a canvas drag moves the selected object, so bound views can refresh.</summary>
         public Action? SelectedObjectMoved { get; set; }
+
+        // The game shows rope Christmas lights only in Dec/Jan (SpecialEvents.IsXmas).
+        // Forced on while the port is verified out of season; flip to false to restore gating.
+        private const bool ForceChristmasLights = true;
 
         private bool _dragging;
         private Vec2 _dragOffset;
@@ -195,6 +200,7 @@ namespace CtrDxEditor.Rendering
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
             List<RopeStrip> ropeStrips = [];
+            List<List<Vec2>> ropeLightPoints = [];
             foreach (LevelObject obj in objects)
             {
                 if (obj.Type != "grab")
@@ -214,12 +220,18 @@ namespace CtrDxEditor.Rendering
                     obj.GetAttr("length"), NumberStyles.Float, CultureInfo.InvariantCulture, out double len)
                     ? len
                     : 0;
-                ropeStrips.AddRange(RopeStripBuilder.Build(
-                    new Vec2(obj.X, obj.Y), new Vec2(rope.Target.X, rope.Target.Y), ropeLength));
+                RopeVisual ropeVisual = RopeStripBuilder.Build(
+                    new Vec2(obj.X, obj.Y), new Vec2(rope.Target.X, rope.Target.Y), ropeLength);
+                ropeStrips.AddRange(ropeVisual.Strips);
+                ropeLightPoints.Add(RopeStripBuilder.ChristmasLightPoints(ropeVisual.SamplePoints));
             }
             if (ropeStrips.Count > 0)
             {
                 context.Custom(new RopeDrawOperation(new Rect(Bounds.Size), v, ropeStrips));
+            }
+            if (ForceChristmasLights || SpecialEvents.IsXmas)
+            {
+                DrawChristmasLights(context, v, sprites, ropeLightPoints);
             }
 
             foreach (LevelObject obj in objects)
@@ -295,6 +307,39 @@ namespace CtrDxEditor.Rendering
             double w = maxX - minX, h = maxY - minY;
             const double grow = 0.25;
             return new LevelBounds(minX - (w * grow / 2.0), minY - (h * grow / 2.0), w * (1 + grow), h * (1 + grow));
+        }
+
+        // Port of Bungee.DrawChristmasLights: one random light frame per anchor point,
+        // centered on the frame's trimmed rect at world pixels (level units = world / mapScale).
+        // Frames are seeded per rope so they stay put across redraws (the game randomizes
+        // once per bungee instance).
+        private static void DrawChristmasLights(
+            DrawingContext ctx,
+            ViewTransform v,
+            SpriteCache sprites,
+            List<List<Vec2>> ropeLightPoints)
+        {
+            if (sprites.GetChristmasLights() is not { } art)
+            {
+                return;
+            }
+
+            for (int ropeIndex = 0; ropeIndex < ropeLightPoints.Count; ropeIndex++)
+            {
+                Random frameRandom = new(ropeIndex);
+                foreach (Vec2 p in ropeLightPoints[ropeIndex])
+                {
+                    AtlasFrame frame = art.Frames[frameRandom.Next(art.Frames.Count)];
+                    double w = frame.Frame.W / SpritePlacement.MapScale;
+                    double h = frame.Frame.H / SpritePlacement.MapScale;
+                    Vec2 tl = v.LevelToScreen(new Vec2(p.X - (w / 2), p.Y - (h / 2)));
+                    Vec2 br = v.LevelToScreen(new Vec2(p.X + (w / 2), p.Y + (h / 2)));
+                    ctx.DrawImage(
+                        art.Bitmap,
+                        new Rect(frame.Frame.X, frame.Frame.Y, frame.Frame.W, frame.Frame.H),
+                        new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
+                }
+            }
         }
 
         private static void DrawObject(DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj)

--- a/src/CtrDxEditor.Shared/Rendering/RopeDrawOperation.cs
+++ b/src/CtrDxEditor.Shared/Rendering/RopeDrawOperation.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
+
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+using SkiaSharp;
+
+namespace CtrDxEditor.Rendering
+{
+    /// <summary>
+    /// Renders rope triangle strips through SkiaSharp, reproducing the game's
+    /// per-vertex color gradients (Avalonia's DrawingContext cannot express them).
+    /// Vertices are level-space; the view transform is applied on the Skia canvas
+    /// so rope width zooms with the art.
+    /// </summary>
+    internal sealed class RopeDrawOperation(Rect bounds, ViewTransform view, IReadOnlyList<RopeStrip> strips)
+        : ICustomDrawOperation
+    {
+        /// <inheritdoc />
+        public Rect Bounds { get; } = bounds;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc />
+        public bool HitTest(Point p)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ICustomDrawOperation? other)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public void Render(ImmediateDrawingContext context)
+        {
+            ISkiaSharpApiLeaseFeature? leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (leaseFeature is null)
+            {
+                return; // Non-Skia backend: ropes simply aren't drawn.
+            }
+            using ISkiaSharpApiLease lease = leaseFeature.Lease();
+            SKCanvas canvas = lease.SkCanvas;
+            int save = canvas.Save();
+            canvas.Translate((float)view.PanX, (float)view.PanY);
+            canvas.Scale((float)view.Zoom);
+            using SKPaint paint = new() { IsAntialias = true };
+            foreach (RopeStrip strip in strips)
+            {
+                SKPoint[] points = new SKPoint[strip.Points.Length];
+                SKColor[] colors = new SKColor[strip.Colors.Length];
+                for (int i = 0; i < points.Length; i++)
+                {
+                    points[i] = new SKPoint((float)strip.Points[i].X, (float)strip.Points[i].Y);
+                    colors[i] = ToSKColor(strip.Colors[i]);
+                }
+                using SKVertices vertices = SKVertices.CreateCopy(SKVertexMode.TriangleStrip, points, colors);
+                // Dst keeps the interpolated vertex colors (the paint contributes nothing).
+                canvas.DrawVertices(vertices, SKBlendMode.Dst, paint);
+            }
+            canvas.RestoreToCount(save);
+        }
+
+        private static SKColor ToSKColor(RopeRgba c)
+        {
+            return new SKColor(
+                (byte)Math.Clamp(c.R * 255, 0, 255),
+                (byte)Math.Clamp(c.G * 255, 0, 255),
+                (byte)Math.Clamp(c.B * 255, 0, 255),
+                (byte)Math.Clamp(c.A * 255, 0, 255));
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/RopeRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/RopeRenderer.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Avalonia;
+using Avalonia.Media;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Atlas;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Rendering
+{
+    /// <summary>
+    /// Draws every grab rope in a level - the game-accurate cord strips plus the
+    /// seasonal Christmas lights - as one pass under the object sprites.
+    /// </summary>
+    internal static class RopeRenderer
+    {
+        // The game shows rope Christmas lights only in Dec/Jan (SpecialEvents.IsXmas).
+        // Forced on while the port is verified out of season; flip to false to restore gating.
+        private const bool ForceChristmasLights = true;
+
+        /// <summary>Draws all ropes for <paramref name="doc"/> into <paramref name="ctx"/>.</summary>
+        /// <param name="ctx">Target drawing context.</param>
+        /// <param name="v">Current level-to-screen transform.</param>
+        /// <param name="sprites">Sprite cache holding the lights atlas.</param>
+        /// <param name="doc">The level being rendered.</param>
+        /// <param name="opBounds">Control bounds for the custom draw operation.</param>
+        public static void Draw(DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelDocument doc, Rect opBounds)
+        {
+            IReadOnlyList<LevelObject> objects = doc.Objects;
+            List<RopeStrip> ropeStrips = [];
+            List<List<Vec2>> ropeLightPoints = [];
+            foreach (LevelObject obj in objects)
+            {
+                if (obj.Type != "grab")
+                {
+                    continue;
+                }
+
+                RopeTarget rope = RopeResolver.Resolve(obj, objects, doc.TwoParts);
+                if (rope.Target is null)
+                {
+                    continue;
+                }
+
+                // The game reads the grab's length attribute for the bungee rest length;
+                // missing/0 renders as a taut straight rope.
+                double ropeLength = double.TryParse(
+                    obj.GetAttr("length"), NumberStyles.Float, CultureInfo.InvariantCulture, out double len)
+                    ? len
+                    : 0;
+                RopeVisual ropeVisual = RopeStripBuilder.Build(
+                    new Vec2(obj.X, obj.Y), new Vec2(rope.Target.X, rope.Target.Y), ropeLength);
+                ropeStrips.AddRange(ropeVisual.Strips);
+                ropeLightPoints.Add(RopeStripBuilder.ChristmasLightPoints(ropeVisual.SamplePoints));
+            }
+            if (ropeStrips.Count > 0)
+            {
+                ctx.Custom(new RopeDrawOperation(opBounds, v, ropeStrips));
+            }
+            if (ForceChristmasLights || SpecialEvents.IsXmas)
+            {
+                DrawChristmasLights(ctx, v, sprites, ropeLightPoints);
+            }
+        }
+
+        // Port of Bungee.DrawChristmasLights: one random light frame per anchor point,
+        // centered on the frame's trimmed rect at world pixels (level units = world / mapScale).
+        // Frames are seeded per rope so they stay put across redraws (the game randomizes
+        // once per bungee instance).
+        private static void DrawChristmasLights(
+            DrawingContext ctx,
+            ViewTransform v,
+            SpriteCache sprites,
+            List<List<Vec2>> ropeLightPoints)
+        {
+            if (sprites.GetChristmasLights() is not { } art)
+            {
+                return;
+            }
+
+            for (int ropeIndex = 0; ropeIndex < ropeLightPoints.Count; ropeIndex++)
+            {
+                Random frameRandom = new(ropeIndex);
+                foreach (Vec2 p in ropeLightPoints[ropeIndex])
+                {
+                    AtlasFrame frame = art.Frames[frameRandom.Next(art.Frames.Count)];
+                    double w = frame.Frame.W / SpritePlacement.MapScale;
+                    double h = frame.Frame.H / SpritePlacement.MapScale;
+                    Vec2 tl = v.LevelToScreen(new Vec2(p.X - (w / 2), p.Y - (h / 2)));
+                    Vec2 br = v.LevelToScreen(new Vec2(p.X + (w / 2), p.Y + (h / 2)));
+                    ctx.DrawImage(
+                        art.Bitmap,
+                        new Rect(frame.Frame.X, frame.Frame.Y, frame.Frame.W, frame.Frame.H),
+                        new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
+                }
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/RopeRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/RopeRenderer.cs
@@ -19,10 +19,6 @@ namespace CtrDxEditor.Rendering
     /// </summary>
     internal static class RopeRenderer
     {
-        // The game shows rope Christmas lights only in Dec/Jan (SpecialEvents.IsXmas).
-        // Forced on while the port is verified out of season; flip to false to restore gating.
-        private const bool ForceChristmasLights = true;
-
         /// <summary>Draws all ropes for <paramref name="doc"/> into <paramref name="ctx"/>.</summary>
         /// <param name="ctx">Target drawing context.</param>
         /// <param name="v">Current level-to-screen transform.</param>
@@ -62,7 +58,7 @@ namespace CtrDxEditor.Rendering
             {
                 ctx.Custom(new RopeDrawOperation(opBounds, v, ropeStrips));
             }
-            if (ForceChristmasLights || SpecialEvents.IsXmas)
+            if (SpecialEvents.IsXmas)
             {
                 DrawChristmasLights(ctx, v, sprites, ropeLightPoints);
             }


### PR DESCRIPTION
## Description

Replaces the dashed straight-line rope indicator with a 1:1 port of Cut the Rope DX's bungee rendering, so grab ropes in the editor look like they do in-game.

## What changed

- Rope shape: slack ropes hang on a closed-form catenary (`RopeCurve`) sampled at the game's constraint-point spacing, then smoothed with the game's recursive de Casteljau bezier (`CalcPathBezier`, 4 samples per segment). Taut ropes run straight. No physics simulation needed.
- Rope look: exact port of `Bungee.DrawBungee` / `DrawAntialiasedLineContinued`: per-segment 10-vertex triangle strips with antialiased edge fade, +0.15 edge brightening, and two color tracks that ramp shade→base while alternating every 4 samples (the twisted-cord look). Rendered via `ICustomDrawOperation` + SkiaSharp `DrawVertices`, since Avalonia's `DrawingContext` can't express per-vertex gradients. Adds an `Avalonia.Skia` package reference (desktop and browser both run on Skia already).
- Coordinate correctness: the game loads levels at `mapScale = 3`, so its rope constants (rest length 105, half-width 5) live in XML×3 world space. The editor draws in raw XML space, so the constants are divided back down (rest 35, half-width 5/3); rope width scales with zoom like sprite art.
- Stretch tint: ropes pulled past rest + 7/105 (~6.7%, the desktop threshold) get the game's red shade boost (`distance/length × 2`).
- Christmas lights — port of `Bungee.DrawChristmasLights`: in December and January (`SpecialEvents.IsXmas`, same window as the game), a light bulb from the 5-frame `christmas_lights` atlas hangs on every 6th bezier sample point, skipping 4 points at each end. Frames are randomized per rope but seeded stably so they don't reshuffle between redraws. The atlas loads opportunistically — bundles without it just render bare ropes.