### PR TITLE
enhancement: improve level canvas navigation

### DIFF
--- a/src/CtrDxEditor.Core.Tests/ViewTransformTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ViewTransformTests.cs
@@ -28,5 +28,53 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(level.X, round.X, precision: 9);
             Assert.Equal(level.Y, round.Y, precision: 9);
         }
+
+        /// <summary>Verifies that viewport scrolling clamps offsets to the scaled level content.</summary>
+        [Fact]
+        public void ScrollToClampsOffsetsToContentSize()
+        {
+            ViewTransform t = ViewNavigation.ScrollTo(
+                new ViewTransform(Zoom: 2.0, PanX: 0, PanY: 0),
+                levelWidth: 640,
+                levelHeight: 960,
+                viewportWidth: 300,
+                viewportHeight: 400,
+                offsetX: 1200,
+                offsetY: -50);
+
+            Assert.Equal(-980, t.PanX);
+            Assert.Equal(0, t.PanY);
+        }
+
+        /// <summary>Verifies that scrolling centers content on axes smaller than the viewport.</summary>
+        [Fact]
+        public void ScrollToCentersContentWhenSmallerThanViewport()
+        {
+            ViewTransform t = ViewNavigation.ScrollTo(
+                new ViewTransform(Zoom: 0.5, PanX: 0, PanY: 0),
+                levelWidth: 320,
+                levelHeight: 240,
+                viewportWidth: 400,
+                viewportHeight: 300,
+                offsetX: 100,
+                offsetY: 100);
+
+            Assert.Equal(120, t.PanX);
+            Assert.Equal(90, t.PanY);
+        }
+
+        /// <summary>Verifies that pointer-centered zoom preserves the level point under the pointer.</summary>
+        [Fact]
+        public void ZoomByKeepsAnchorLevelPointUnderPointer()
+        {
+            ViewTransform t = new(Zoom: 2.0, PanX: -40, PanY: -80);
+            Vec2 anchor = new(120, 140);
+            Vec2 before = t.ScreenToLevel(anchor);
+
+            ViewTransform zoomed = ViewNavigation.ZoomBy(t, factor: 1.25, anchor, minZoom: 0.1, maxZoom: 10.0);
+
+            Assert.Equal(before.X, zoomed.ScreenToLevel(anchor).X, precision: 9);
+            Assert.Equal(before.Y, zoomed.ScreenToLevel(anchor).Y, precision: 9);
+        }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/ViewTransformTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ViewTransformTests.cs
@@ -76,5 +76,21 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(before.X, zoomed.ScreenToLevel(anchor).X, precision: 9);
             Assert.Equal(before.Y, zoomed.ScreenToLevel(anchor).Y, precision: 9);
         }
+
+        /// <summary>Verifies that cumulative pinch scale is converted to the next incremental zoom factor.</summary>
+        [Fact]
+        public void PinchScaleToZoomFactorUsesScaleRatio()
+        {
+            Assert.Equal(1.25, ViewNavigation.PinchScaleToZoomFactor(previousScale: 1.2, currentScale: 1.5));
+        }
+
+        /// <summary>Verifies that touchpad magnify deltas are bounded before becoming zoom factors.</summary>
+        [Fact]
+        public void MagnifyDeltaToZoomFactorClampsExtremeDeltas()
+        {
+            Assert.Equal(1.1, ViewNavigation.MagnifyDeltaToZoomFactor(0.1));
+            Assert.Equal(0.5, ViewNavigation.MagnifyDeltaToZoomFactor(-10));
+            Assert.Equal(2.0, ViewNavigation.MagnifyDeltaToZoomFactor(10));
+        }
     }
 }

--- a/src/CtrDxEditor.Core/Geometry/ViewNavigation.cs
+++ b/src/CtrDxEditor.Core/Geometry/ViewNavigation.cs
@@ -38,5 +38,17 @@ namespace CtrDxEditor.Core.Geometry
             double panY = contentHeight <= viewportHeight ? (viewportHeight - contentHeight) / 2 : -Math.Clamp(offsetY, 0, maxY);
             return new ViewTransform(view.Zoom, panX, panY);
         }
+
+        /// <summary>Converts cumulative pinch scale into an incremental zoom factor.</summary>
+        public static double PinchScaleToZoomFactor(double previousScale, double currentScale)
+        {
+            return previousScale <= 0 || currentScale <= 0 ? 1 : currentScale / previousScale;
+        }
+
+        /// <summary>Converts platform touchpad magnify delta into a bounded zoom factor.</summary>
+        public static double MagnifyDeltaToZoomFactor(double delta)
+        {
+            return Math.Clamp(1 + delta, 0.5, 2.0);
+        }
     }
 }

--- a/src/CtrDxEditor.Core/Geometry/ViewNavigation.cs
+++ b/src/CtrDxEditor.Core/Geometry/ViewNavigation.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace CtrDxEditor.Core.Geometry
+{
+    /// <summary>Viewport navigation helpers for zooming and scrolling a level view.</summary>
+    public static class ViewNavigation
+    {
+        /// <summary>Zooms around a screen-space anchor so the anchored level point remains under the pointer.</summary>
+        public static ViewTransform ZoomBy(
+            ViewTransform view,
+            double factor,
+            Vec2 anchor,
+            double minZoom,
+            double maxZoom)
+        {
+            double newZoom = Math.Clamp(view.Zoom * factor, minZoom, maxZoom);
+            double ratio = newZoom / view.Zoom;
+            double panX = anchor.X - ((anchor.X - view.PanX) * ratio);
+            double panY = anchor.Y - ((anchor.Y - view.PanY) * ratio);
+            return new ViewTransform(newZoom, panX, panY);
+        }
+
+        /// <summary>Returns a view transform for the requested scroll offsets, clamped to scaled content bounds.</summary>
+        public static ViewTransform ScrollTo(
+            ViewTransform view,
+            double levelWidth,
+            double levelHeight,
+            double viewportWidth,
+            double viewportHeight,
+            double offsetX,
+            double offsetY)
+        {
+            double contentWidth = Math.Max(0, levelWidth * view.Zoom);
+            double contentHeight = Math.Max(0, levelHeight * view.Zoom);
+            double maxX = Math.Max(0, contentWidth - viewportWidth);
+            double maxY = Math.Max(0, contentHeight - viewportHeight);
+            double panX = contentWidth <= viewportWidth ? (viewportWidth - contentWidth) / 2 : -Math.Clamp(offsetX, 0, maxX);
+            double panY = contentHeight <= viewportHeight ? (viewportHeight - contentHeight) / 2 : -Math.Clamp(offsetY, 0, maxY);
+            return new ViewTransform(view.Zoom, panX, panY);
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 
 using CtrDxEditor.Content;
@@ -140,11 +141,21 @@ namespace CtrDxEditor.Rendering
         private int _lastHitIndex = -1;
         private bool _panning;
         private Point _panLast;
+        private double _lastPinchScale = 1;
         private bool _syncingScroll;
         private bool _pendingFit;
         private bool _ghostActive;
         private string? _ghostElement;
         private Vec2 _ghostLevel;
+
+        /// <summary>Creates the canvas and enables native touch gestures.</summary>
+        public LevelCanvas()
+        {
+            GestureRecognizers.Add(new PinchGestureRecognizer());
+            AddHandler(PinchEvent, Canvas_Pinch, RoutingStrategies.Bubble);
+            AddHandler(PinchEndedEvent, Canvas_PinchEnded, RoutingStrategies.Bubble);
+            AddHandler(PointerTouchPadGestureMagnifyEvent, Canvas_TouchPadMagnify, RoutingStrategies.Bubble);
+        }
 
         /// <inheritdoc />
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -591,6 +602,27 @@ namespace CtrDxEditor.Rendering
                 }
                 ScrollBy(deltaX, deltaY);
             }
+            e.Handled = true;
+        }
+
+        private void Canvas_Pinch(object? sender, PinchEventArgs e)
+        {
+            double factor = ViewNavigation.PinchScaleToZoomFactor(_lastPinchScale, e.Scale);
+            _lastPinchScale = e.Scale;
+            ZoomBy(factor, e.ScaleOrigin);
+            e.Handled = true;
+        }
+
+        private void Canvas_PinchEnded(object? sender, PinchEndedEventArgs e)
+        {
+            _lastPinchScale = 1;
+            e.Handled = true;
+        }
+
+        private void Canvas_TouchPadMagnify(object? sender, PointerDeltaEventArgs e)
+        {
+            double delta = Math.Abs(e.Delta.Y) > double.Epsilon ? e.Delta.Y : e.Delta.X;
+            ZoomBy(ViewNavigation.MagnifyDeltaToZoomFactor(delta), e.GetPosition(this));
             e.Handled = true;
         }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -50,6 +50,32 @@ namespace CtrDxEditor.Rendering
         public static readonly StyledProperty<bool> ShowMobileHitboxesProperty =
             AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowMobileHitboxes));
 
+        /// <summary>Avalonia property backing <see cref="HorizontalScrollMaximum"/>.</summary>
+        public static readonly StyledProperty<double> HorizontalScrollMaximumProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(nameof(HorizontalScrollMaximum));
+
+        /// <summary>Avalonia property backing <see cref="VerticalScrollMaximum"/>.</summary>
+        public static readonly StyledProperty<double> VerticalScrollMaximumProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(nameof(VerticalScrollMaximum));
+
+        /// <summary>Avalonia property backing <see cref="HorizontalScrollViewport"/>.</summary>
+        public static readonly StyledProperty<double> HorizontalScrollViewportProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(nameof(HorizontalScrollViewport));
+
+        /// <summary>Avalonia property backing <see cref="VerticalScrollViewport"/>.</summary>
+        public static readonly StyledProperty<double> VerticalScrollViewportProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(nameof(VerticalScrollViewport));
+
+        /// <summary>Avalonia property backing <see cref="HorizontalScrollValue"/>.</summary>
+        public static readonly StyledProperty<double> HorizontalScrollValueProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(
+                nameof(HorizontalScrollValue), defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
+
+        /// <summary>Avalonia property backing <see cref="VerticalScrollValue"/>.</summary>
+        public static readonly StyledProperty<double> VerticalScrollValueProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(
+                nameof(VerticalScrollValue), defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
+
         static LevelCanvas()
         {
             AffectsRender<LevelCanvas>(
@@ -82,6 +108,24 @@ namespace CtrDxEditor.Rendering
         /// <summary>Whether phone hitboxes are drawn over objects.</summary>
         public bool ShowMobileHitboxes { get => GetValue(ShowMobileHitboxesProperty); set => SetValue(ShowMobileHitboxesProperty, value); }
 
+        /// <summary>Largest horizontal scroll offset in screen pixels.</summary>
+        public double HorizontalScrollMaximum { get => GetValue(HorizontalScrollMaximumProperty); private set => SetValue(HorizontalScrollMaximumProperty, value); }
+
+        /// <summary>Largest vertical scroll offset in screen pixels.</summary>
+        public double VerticalScrollMaximum { get => GetValue(VerticalScrollMaximumProperty); private set => SetValue(VerticalScrollMaximumProperty, value); }
+
+        /// <summary>Visible canvas width used by the horizontal scrollbar thumb.</summary>
+        public double HorizontalScrollViewport { get => GetValue(HorizontalScrollViewportProperty); private set => SetValue(HorizontalScrollViewportProperty, value); }
+
+        /// <summary>Visible canvas height used by the vertical scrollbar thumb.</summary>
+        public double VerticalScrollViewport { get => GetValue(VerticalScrollViewportProperty); private set => SetValue(VerticalScrollViewportProperty, value); }
+
+        /// <summary>Current horizontal scroll offset in screen pixels.</summary>
+        public double HorizontalScrollValue { get => GetValue(HorizontalScrollValueProperty); set => SetValue(HorizontalScrollValueProperty, value); }
+
+        /// <summary>Current vertical scroll offset in screen pixels.</summary>
+        public double VerticalScrollValue { get => GetValue(VerticalScrollValueProperty); set => SetValue(VerticalScrollValueProperty, value); }
+
         /// <summary>Callback used to place a new object at level coordinates.</summary>
         public Func<string, int, int, LevelObject?>? PlaceAt { get; set; }
 
@@ -96,6 +140,7 @@ namespace CtrDxEditor.Rendering
         private int _lastHitIndex = -1;
         private bool _panning;
         private Point _panLast;
+        private bool _syncingScroll;
         private bool _pendingFit;
         private bool _ghostActive;
         private string? _ghostElement;
@@ -113,6 +158,15 @@ namespace CtrDxEditor.Rendering
             else if (change.Property == BoundsProperty && _pendingFit)
             {
                 TryFit();
+            }
+            else if (change.Property == BoundsProperty || change.Property == ViewProperty || change.Property == DocumentProperty)
+            {
+                UpdateScrollState();
+            }
+            else if ((change.Property == HorizontalScrollValueProperty || change.Property == VerticalScrollValueProperty)
+                     && !_syncingScroll)
+            {
+                ScrollTo(HorizontalScrollValue, VerticalScrollValue);
             }
         }
 
@@ -144,17 +198,73 @@ namespace CtrDxEditor.Rendering
             double panX = (Bounds.Width - (doc.Width * zoom)) / 2;
             double panY = (Bounds.Height - (doc.Height * zoom)) / 2;
             View = new ViewTransform(zoom, panX, panY);
+            UpdateScrollState();
         }
 
         /// <summary>Zooms about the viewport center (for menu/keyboard zoom).</summary>
         public void ZoomBy(double factor)
         {
-            ViewTransform v = View;
-            double newZoom = Math.Clamp(v.Zoom * factor, 0.1, 10.0);
-            double cx = Bounds.Width / 2, cy = Bounds.Height / 2;
-            double panX = cx - ((cx - v.PanX) * (newZoom / v.Zoom));
-            double panY = cy - ((cy - v.PanY) * (newZoom / v.Zoom));
-            View = new ViewTransform(newZoom, panX, panY);
+            ZoomBy(factor, new Point(Bounds.Width / 2, Bounds.Height / 2));
+        }
+
+        /// <summary>Zooms about a screen-space point in this canvas.</summary>
+        public void ZoomBy(double factor, Point anchor)
+        {
+            View = ViewNavigation.ZoomBy(View, factor, new Vec2(anchor.X, anchor.Y), 0.1, 10.0);
+            UpdateScrollState();
+        }
+
+        /// <summary>Scrolls the level viewport by screen-space pixels.</summary>
+        public void ScrollBy(double deltaX, double deltaY)
+        {
+            ScrollTo(HorizontalScrollValue + deltaX, VerticalScrollValue + deltaY);
+        }
+
+        private void ScrollTo(double offsetX, double offsetY)
+        {
+            if (Document is not { } doc)
+            {
+                return;
+            }
+
+            View = ViewNavigation.ScrollTo(View, doc.Width, doc.Height, Bounds.Width, Bounds.Height, offsetX, offsetY);
+            UpdateScrollState();
+        }
+
+        private void UpdateScrollState()
+        {
+            LevelDocument? doc = Document;
+            double viewportWidth = Math.Max(0, Bounds.Width);
+            double viewportHeight = Math.Max(0, Bounds.Height);
+            double maxX = 0;
+            double maxY = 0;
+            double valueX = 0;
+            double valueY = 0;
+
+            if (doc is not null)
+            {
+                double contentWidth = Math.Max(0, doc.Width * View.Zoom);
+                double contentHeight = Math.Max(0, doc.Height * View.Zoom);
+                maxX = Math.Max(0, contentWidth - viewportWidth);
+                maxY = Math.Max(0, contentHeight - viewportHeight);
+                valueX = Math.Clamp(-View.PanX, 0, maxX);
+                valueY = Math.Clamp(-View.PanY, 0, maxY);
+            }
+
+            _syncingScroll = true;
+            try
+            {
+                HorizontalScrollViewport = viewportWidth;
+                VerticalScrollViewport = viewportHeight;
+                HorizontalScrollMaximum = maxX;
+                VerticalScrollMaximum = maxY;
+                HorizontalScrollValue = valueX;
+                VerticalScrollValue = valueY;
+            }
+            finally
+            {
+                _syncingScroll = false;
+            }
         }
 
         /// <inheritdoc />
@@ -366,6 +476,10 @@ namespace CtrDxEditor.Rendering
                 e.Pointer.Capture(this);
                 return;
             }
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
 
             Point p = e.GetPosition(this);
             Vec2 levelPt = View.ScreenToLevel(new Vec2(p.X, p.Y));
@@ -408,6 +522,9 @@ namespace CtrDxEditor.Rendering
             if (hit < 0)
             {
                 SelectedObject = null;
+                _panning = true;
+                _panLast = p;
+                e.Pointer.Capture(this);
                 return;
             }
 
@@ -425,7 +542,7 @@ namespace CtrDxEditor.Rendering
             if (_panning)
             {
                 Point now = e.GetPosition(this);
-                View = new ViewTransform(View.Zoom, View.PanX + (now.X - _panLast.X), View.PanY + (now.Y - _panLast.Y));
+                ScrollBy(_panLast.X - now.X, _panLast.Y - now.Y);
                 _panLast = now;
                 return;
             }
@@ -457,13 +574,24 @@ namespace CtrDxEditor.Rendering
         protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
         {
             base.OnPointerWheelChanged(e);
-            Point p = e.GetPosition(this);
-            ViewTransform v = View;
-            double factor = e.Delta.Y > 0 ? 1.1 : 1 / 1.1;
-            double newZoom = Math.Clamp(v.Zoom * factor, 0.1, 10.0);
-            double panX = p.X - ((p.X - v.PanX) * (newZoom / v.Zoom));
-            double panY = p.Y - ((p.Y - v.PanY) * (newZoom / v.Zoom));
-            View = new ViewTransform(newZoom, panX, panY);
+            const double wheelPixels = 48;
+            if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            {
+                double factor = e.Delta.Y > 0 ? 1.1 : 1 / 1.1;
+                ZoomBy(factor, e.GetPosition(this));
+            }
+            else
+            {
+                double deltaX = e.Delta.X * -wheelPixels;
+                double deltaY = e.Delta.Y * -wheelPixels;
+                if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) && Math.Abs(deltaX) < double.Epsilon)
+                {
+                    deltaX = deltaY;
+                    deltaY = 0;
+                }
+                ScrollBy(deltaX, deltaY);
+            }
+            e.Handled = true;
         }
 
         /// <summary>Shows a translucent preview of <paramref name="element"/> at the snapped drop position.</summary>

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -42,6 +42,9 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Raised when a selected object's editable values change.</summary>
         public event Action? ObjectMutated;
 
+        /// <summary>Raised after a level XML document has loaded into the editor.</summary>
+        public event Action? LevelLoaded;
+
         /// <summary>Loads a level from its XML text into the editor.</summary>
         public void LoadLevelXml(string xml)
         {
@@ -51,6 +54,7 @@ namespace CtrDxEditor.ViewModels
             // The canvas fits the level to the viewport once it is laid out (LevelCanvas.FitToView).
             RefreshPalette();
             RefreshObjectList();
+            LevelLoaded?.Invoke();
         }
 
         /// <summary>Deletes the currently selected object, if one exists.</summary>

--- a/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml
@@ -6,7 +6,7 @@
              x:DataType="vm:ContentSetupViewModel">
   <!-- MaxHeight + Auto scrollbar: a long invalid-files list (see ErrorMessage below) can otherwise
        grow the dialog taller than the window/viewport, cutting off the buttons beneath it. -->
-  <ScrollViewer MaxHeight="500" VerticalScrollBarVisibility="Auto">
+  <ScrollViewer MaxHeight="500" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
     <StackPanel Margin="24" Spacing="16" Width="500">
       <!-- Title reflects the current phase. -->
       <TextBlock FontSize="18" FontWeight="SemiBold" IsVisible="{Binding !IsBusy}"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -120,16 +120,35 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
       </Border>
-      <render:LevelCanvas Grid.Column="1" x:Name="Canvas" Focusable="True"
-                          ClipToBounds="True"
-                          Document="{Binding Document}"
-                          Sprites="{Binding Sprites}"
-                          View="{Binding View, Mode=TwoWay}"
-                          SnapEnabled="{Binding SnapEnabled}"
-                          ShowHitboxes="{Binding ShowHitboxes}"
-                          ShowMobileHitboxes="{Binding ShowMobileHitboxes}"
-                          SelectedObject="{Binding SelectedObject, Mode=TwoWay}"
-                          LockedObject="{Binding LockedObject, Mode=TwoWay}" />
+      <Grid Grid.Column="1" RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">
+        <render:LevelCanvas Grid.Row="0" Grid.Column="0" x:Name="Canvas" Focusable="True"
+                            ClipToBounds="True"
+                            Document="{Binding Document}"
+                            Sprites="{Binding Sprites}"
+                            View="{Binding View, Mode=TwoWay}"
+                            SnapEnabled="{Binding SnapEnabled}"
+                            ShowHitboxes="{Binding ShowHitboxes}"
+                            ShowMobileHitboxes="{Binding ShowMobileHitboxes}"
+                            SelectedObject="{Binding SelectedObject, Mode=TwoWay}"
+                            LockedObject="{Binding LockedObject, Mode=TwoWay}" />
+        <ScrollBar Grid.Row="0" Grid.Column="1"
+                   Orientation="Vertical"
+                   Minimum="0"
+                   Maximum="{Binding #Canvas.VerticalScrollMaximum}"
+                   Value="{Binding #Canvas.VerticalScrollValue, Mode=TwoWay}"
+                   ViewportSize="{Binding #Canvas.VerticalScrollViewport}"
+                   SmallChange="48"
+                   LargeChange="{Binding #Canvas.VerticalScrollViewport}" />
+        <ScrollBar Grid.Row="1" Grid.Column="0"
+                   Orientation="Horizontal"
+                   Minimum="0"
+                   Maximum="{Binding #Canvas.HorizontalScrollMaximum}"
+                   Value="{Binding #Canvas.HorizontalScrollValue, Mode=TwoWay}"
+                   ViewportSize="{Binding #Canvas.HorizontalScrollViewport}"
+                   SmallChange="48"
+                   LargeChange="{Binding #Canvas.HorizontalScrollViewport}" />
+        <Border Grid.Row="1" Grid.Column="1" Background="#202329" />
+      </Grid>
       <Grid Grid.Column="2" Background="#202329" RowDefinitions="Auto,2*,Auto,3*">
         <TextBlock Grid.Row="0" Text="{loc:Tr Panel.Objects}" FontWeight="Bold" Margin="8,8,8,4" />
         <ListBox Grid.Row="1" Margin="4,0,4,4" x:Name="ObjectsListBox"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -214,9 +214,21 @@ namespace CtrDxEditor.Views
             }
 
             _mutatedSubscription?.ObjectMutated -= _invalidateCanvas;
+            _mutatedSubscription?.LevelLoaded -= FocusCanvasAfterLevelLoaded;
 
             _mutatedSubscription = DataContext as EditorViewModel;
-            _mutatedSubscription?.ObjectMutated += _invalidateCanvas;
+            if (_mutatedSubscription is not null)
+            {
+                _mutatedSubscription.ObjectMutated += _invalidateCanvas;
+                _mutatedSubscription.LevelLoaded += FocusCanvasAfterLevelLoaded;
+            }
+        }
+
+        private void FocusCanvasAfterLevelLoaded()
+        {
+            LevelCanvas canvas = this.FindControl<LevelCanvas>("Canvas")!;
+            canvas.FitToView();
+            _ = canvas.Focus();
         }
 
         private async void Open_Click(object? sender, RoutedEventArgs e)
@@ -239,7 +251,6 @@ namespace CtrDxEditor.Views
                 await using Stream stream = await files[0].OpenReadAsync();
                 using StreamReader reader = new(stream);
                 vm.LoadLevelXml(await reader.ReadToEndAsync());
-                this.FindControl<LevelCanvas>("Canvas")!.FitToView();
             }
         }
 

--- a/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
+++ b/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
@@ -50,5 +50,24 @@ namespace CtrDxEditor.Tests
             Assert.NotNull(saved);
             Assert.Contains("width=\"100\"", saved);
         }
+
+        /// <summary>Verifies that loading XML notifies the view after the document has been replaced.</summary>
+        [Fact]
+        public void LoadLevelXmlRaisesLevelLoadedAfterDocumentIsAvailable()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            const string xml = "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer></map>";
+            bool raised = false;
+
+            vm.LevelLoaded += () =>
+            {
+                Assert.NotNull(vm.Document);
+                raised = true;
+            };
+
+            vm.LoadLevelXml(xml);
+
+            Assert.True(raised);
+        }
     }
 }


### PR DESCRIPTION
## Description

- Add horizontal and vertical scrollbars to the level canvas
- Make normal mouse wheel / trackpad scroll pan the canvas
- Keep <kbd>Ctrl</kbd>+scroll for zooming around the pointer
- Add empty-canvas drag panning
- Focus the level canvas after loading a level
- Add pinch-to-zoom support for touch and macOS trackpad magnify gestures