### PR TITLE
feat: render light bulb lit-glow with game-exact additive blend

### DIFF
--- a/src/CtrDxEditor.Core/Editing/GlowBlend.cs
+++ b/src/CtrDxEditor.Core/Editing/GlowBlend.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Per-pixel math for the light-bulb glow's additive blend. The game builds
+    /// obj_lighter.png premultiplied (content.mgcb PremultiplyAlpha=True), tints the glow white @ 0.6 alpha
+    /// (LightBulb.cs, and 0.6f rounds to exactly 153/255), and draws it through a BasicEffect that
+    /// premultiplies diffuse by alpha, so the shader emits src = (p * 0.6, a * 0.6). Its blendingMode=2 maps
+    /// to GL_SRC_ALPHA/GL_ONE (BlendParams.cs), which multiplies src.rgb by src.a once more before adding:
+    /// each texel contributes p * a * 0.36 to the framebuffer. Baking that product into the texture lets a
+    /// plain additive (Plus) draw with an opaque paint reproduce the game's glow exactly.
+    /// </summary>
+    public static class GlowBlend
+    {
+        /// <summary>The game's 0.6 glow alpha, applied twice: once by BasicEffect, once by GL_SRC_ALPHA.</summary>
+        public const double AdditiveFactor = 0.6 * 0.6;
+
+        /// <summary>
+        /// The additive framebuffer contribution of one premultiplied channel value under the game's glow
+        /// blend: <c>premul * (alpha/255) * 0.36</c>, rounded like a GPU framebuffer write.
+        /// </summary>
+        public static byte BakeChannel(byte premul, byte alpha)
+        {
+            return (byte)Math.Round(premul * (alpha / 255.0) * AdditiveFactor, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// Rewrites premultiplied BGRA pixels in place so each pixel holds its additive glow contribution.
+        /// Color channels become <c>p * a * 0.36</c>; alpha becomes <c>a * a * 0.36</c> (the game's
+        /// GL_SRC_ALPHA/GL_ONE alpha write), which also keeps the buffer valid premultiplied color.
+        /// </summary>
+        public static void BakeBgraInPlace(Span<byte> bgra)
+        {
+            for (int i = 0; i + 3 < bgra.Length; i += 4)
+            {
+                byte alpha = bgra[i + 3];
+                bgra[i] = BakeChannel(bgra[i], alpha);
+                bgra[i + 1] = BakeChannel(bgra[i + 1], alpha);
+                bgra[i + 2] = BakeChannel(bgra[i + 2], alpha);
+                bgra[i + 3] = BakeChannel(alpha, alpha);
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/GlowQuad.cs
+++ b/src/CtrDxEditor.Core/Editing/GlowQuad.cs
@@ -1,0 +1,26 @@
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Geometry for the light-bulb lit-glow halo, kept 1:1 with the game (LightBulb.ApplyGlowScale). The glow
+    /// quad is drawn centered on the bulb, its width spanning 1.5x the litRadius on each side — the game's
+    /// 1.5f visual multiplier, after its WorldScale (2) and mapScale (3) cancel against the editor's
+    /// atlas-pixel-to-level-unit conversion — and its height scaled by the quad's own aspect ratio so the
+    /// texture is never distorted.
+    /// </summary>
+    public static class GlowQuad
+    {
+        /// <summary>The game's decorative glow multiplier over the semantic lit radius.</summary>
+        public const double VisualMultiplier = 1.5;
+
+        /// <summary>
+        /// Half the on-canvas glow box in level units for a bulb of <paramref name="litRadius"/>, given the
+        /// glow quad's pixel size. Width half is litRadius * 1.5; height half preserves the quad's aspect.
+        /// </summary>
+        public static (double HalfW, double HalfH) DestRadii(double litRadius, int frameW, int frameH)
+        {
+            double halfW = litRadius * VisualMultiplier;
+            double halfH = frameW > 0 ? halfW * frameH / frameW : halfW;
+            return (halfW, halfH);
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/RadiusRing.cs
+++ b/src/CtrDxEditor.Core/Editing/RadiusRing.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+
+using CtrDxEditor.Core.Document;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Resolves the resizable radius ring an object exposes: a grab's auto-catch <c>radius</c> or a light
+    /// bulb's <c>litRadius</c>, both in level units. Returns null when the object has no ring or a
+    /// non-positive radius. The circle geometry itself (edge hit-testing, drag mapping) lives in
+    /// <see cref="GrabRadius"/>; this only maps an object to its radius value and the attribute that stores it,
+    /// so one rendering + resize path covers both object types.
+    /// </summary>
+    public static class RadiusRing
+    {
+        /// <summary>The object's radius ring and the attribute holding it, or null when it has none.</summary>
+        public static (double Radius, string Attr)? Of(LevelObject obj)
+        {
+            return obj.Type switch
+            {
+                "grab" => GrabRadius.Of(obj) is double r ? (r, "radius") : null,
+                "lightBulb" => Lit(obj) is double lr ? (lr, "litRadius") : null,
+                _ => null,
+            };
+        }
+
+        // The bulb's lit radius, or null when missing / non-positive (the game emits no glow then).
+        private static double? Lit(LevelObject bulb)
+        {
+            return double.TryParse(
+                       bulb.GetAttr("litRadius"), NumberStyles.Float, CultureInfo.InvariantCulture, out double r)
+                   && r > 0
+                ? r
+                : null;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
+++ b/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
@@ -158,6 +158,13 @@ namespace CtrDxEditor.Content
                 new SpriteLayer(LighterJson, LighterImageBase, "02_bottle.png"),
                 new SpriteLayer(LighterJson, LighterImageBase, "03_top.png"),
             ]),
+
+            // Lit-glow halo quad, drawn additively under the bottle at 1.5x litRadius by GlowDrawOperation.
+            // A separate element so it is never composited into the static bulb thumbnail or selection bounds.
+            new("lightBulb_glow",
+            [
+                new SpriteLayer(LighterJson, LighterImageBase, "01_light.png"),
+            ]),
         ];
 
         /// <summary>All visual descriptors keyed by object element name.</summary>

--- a/src/CtrDxEditor.Shared/Rendering/GlowDrawOperation.cs
+++ b/src/CtrDxEditor.Shared/Rendering/GlowDrawOperation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using Avalonia;
 using Avalonia.Media;
@@ -15,11 +16,14 @@ using SkiaSharp;
 namespace CtrDxEditor.Rendering
 {
     /// <summary>
-    /// Renders light-bulb lit-glow halos through SkiaSharp so they use the game's additive blend
-    /// (SKBlendMode.Plus at 0.6 alpha, matching LightBulb.cs blendingMode=2 and the glow color alpha). The
-    /// halo is the 01_light.png glow quad stretched to 1.5x litRadius (LightBulb.ApplyGlowScale's 1.5f
-    /// multiplier) and centered on the bulb, drawn in level space with the view transform applied on the
-    /// Skia canvas so it zooms with the art. On a non-Skia backend the glow is simply not drawn.
+    /// Renders light-bulb lit-glow halos through SkiaSharp with the game's exact additive blend: each texel
+    /// adds p * a * 0.36 to the framebuffer (LightBulb.cs white @ 0.6 glow color through BasicEffect's
+    /// premultiplied diffuse, then blendingMode=2 = GL_SRC_ALPHA/GL_ONE). That contribution is baked into
+    /// the cached glow image by <see cref="GlowBlend"/> so a plain SKBlendMode.Plus draw with an opaque
+    /// paint reproduces it. The halo is the 01_light.png glow quad stretched to 1.5x litRadius
+    /// (LightBulb.ApplyGlowScale's 1.5f multiplier) and centered on the bulb, drawn in level space with the
+    /// view transform applied on the Skia canvas so it zooms with the art. On a non-Skia backend the glow
+    /// is simply not drawn.
     /// </summary>
     internal sealed class GlowDrawOperation(
         Rect bounds,
@@ -74,8 +78,8 @@ namespace CtrDxEditor.Rendering
             using SKPaint paint = new()
             {
                 IsAntialias = true,
-                BlendMode = SKBlendMode.Plus,           // additive, matching the game's blendingMode=2
-                Color = new SKColor(255, 255, 255, 153), // white @ ~0.6 alpha (game glow alpha)
+                BlendMode = SKBlendMode.Plus, // additive; the 0.6-alpha-squared factor is baked into the image
+                Color = SKColors.White,
             };
 
             foreach ((Vec2 center, double radius) in bulbs)
@@ -90,8 +94,9 @@ namespace CtrDxEditor.Rendering
             canvas.RestoreToCount(save);
         }
 
-        // Snapshots the Avalonia bitmap's pixels into a standalone SKImage (BGRA premultiplied, as Avalonia
-        // decodes PNGs). FromPixelCopy copies, so the temporary SKBitmap is safe to dispose.
+        // Snapshots the Avalonia bitmap's pixels (BGRA premultiplied, as Avalonia decodes PNGs — same as the
+        // game's PremultiplyAlpha=True atlas) and bakes the game's additive glow contribution into them, so
+        // the cached SKImage holds ready-to-add pixels for the Plus draw.
         private static SKImage ImageFor(Bitmap bmp)
         {
             if (ImageCache.TryGetValue(bmp, out SKImage? cached))
@@ -100,9 +105,18 @@ namespace CtrDxEditor.Rendering
             }
             PixelSize size = bmp.PixelSize;
             SKImageInfo info = new(size.Width, size.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
-            using SKBitmap sk = new(info);
-            bmp.CopyPixels(new PixelRect(0, 0, size.Width, size.Height), sk.GetPixels(), info.BytesSize, info.RowBytes);
-            SKImage image = SKImage.FromPixelCopy(info, sk.GetPixels(), info.RowBytes);
+            byte[] pixels = new byte[info.BytesSize];
+            GCHandle handle = GCHandle.Alloc(pixels, GCHandleType.Pinned);
+            try
+            {
+                bmp.CopyPixels(new PixelRect(0, 0, size.Width, size.Height), handle.AddrOfPinnedObject(), info.BytesSize, info.RowBytes);
+            }
+            finally
+            {
+                handle.Free();
+            }
+            GlowBlend.BakeBgraInPlace(pixels);
+            SKImage image = SKImage.FromPixelCopy(info, pixels, info.RowBytes);
             ImageCache.Add(bmp, image);
             return image;
         }

--- a/src/CtrDxEditor.Shared/Rendering/GlowDrawOperation.cs
+++ b/src/CtrDxEditor.Shared/Rendering/GlowDrawOperation.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
+
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+using SkiaSharp;
+
+namespace CtrDxEditor.Rendering
+{
+    /// <summary>
+    /// Renders light-bulb lit-glow halos through SkiaSharp so they use the game's additive blend
+    /// (SKBlendMode.Plus at 0.6 alpha, matching LightBulb.cs blendingMode=2 and the glow color alpha). The
+    /// halo is the 01_light.png glow quad stretched to 1.5x litRadius (LightBulb.ApplyGlowScale's 1.5f
+    /// multiplier) and centered on the bulb, drawn in level space with the view transform applied on the
+    /// Skia canvas so it zooms with the art. On a non-Skia backend the glow is simply not drawn.
+    /// </summary>
+    internal sealed class GlowDrawOperation(
+        Rect bounds,
+        ViewTransform view,
+        Bitmap atlas,
+        IntRect frame,
+        IReadOnlyList<(Vec2 Center, double Radius)> bulbs)
+        : ICustomDrawOperation
+    {
+        // One SKImage per atlas bitmap for the process lifetime, keyed weakly so it is collected with the
+        // bitmap. Converting the already-decoded Avalonia bitmap avoids decoding the atlas a second time.
+        private static readonly ConditionalWeakTable<Bitmap, SKImage> ImageCache = [];
+
+        /// <inheritdoc />
+        public Rect Bounds { get; } = bounds;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc />
+        public bool HitTest(Point p)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ICustomDrawOperation? other)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public void Render(ImmediateDrawingContext context)
+        {
+            ISkiaSharpApiLeaseFeature? leaseFeature = context.TryGetFeature<ISkiaSharpApiLeaseFeature>();
+            if (leaseFeature is null)
+            {
+                return; // Non-Skia backend: the glow simply isn't drawn (same as ropes).
+            }
+            using ISkiaSharpApiLease lease = leaseFeature.Lease();
+            SKCanvas canvas = lease.SkCanvas;
+            SKImage image = ImageFor(atlas);
+
+            int save = canvas.Save();
+            canvas.Translate((float)view.PanX, (float)view.PanY);
+            canvas.Scale((float)view.Zoom);
+
+            SKRect src = new(frame.X, frame.Y, frame.X + frame.W, frame.Y + frame.H);
+            SKSamplingOptions sampling = new(SKFilterMode.Linear);
+            using SKPaint paint = new()
+            {
+                IsAntialias = true,
+                BlendMode = SKBlendMode.Plus,           // additive, matching the game's blendingMode=2
+                Color = new SKColor(255, 255, 255, 153), // white @ ~0.6 alpha (game glow alpha)
+            };
+
+            foreach ((Vec2 center, double radius) in bulbs)
+            {
+                (double halfW, double halfH) = GlowQuad.DestRadii(radius, frame.W, frame.H);
+                SKRect dest = new(
+                    (float)(center.X - halfW), (float)(center.Y - halfH),
+                    (float)(center.X + halfW), (float)(center.Y + halfH));
+                canvas.DrawImage(image, src, dest, sampling, paint);
+            }
+
+            canvas.RestoreToCount(save);
+        }
+
+        // Snapshots the Avalonia bitmap's pixels into a standalone SKImage (BGRA premultiplied, as Avalonia
+        // decodes PNGs). FromPixelCopy copies, so the temporary SKBitmap is safe to dispose.
+        private static SKImage ImageFor(Bitmap bmp)
+        {
+            if (ImageCache.TryGetValue(bmp, out SKImage? cached))
+            {
+                return cached;
+            }
+            PixelSize size = bmp.PixelSize;
+            SKImageInfo info = new(size.Width, size.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+            using SKBitmap sk = new(info);
+            bmp.CopyPixels(new PixelRect(0, 0, size.Width, size.Height), sk.GetPixels(), info.BytesSize, info.RowBytes);
+            SKImage image = SKImage.FromPixelCopy(info, sk.GetPixels(), info.RowBytes);
+            ImageCache.Add(bmp, image);
+            return image;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
@@ -122,22 +122,26 @@ namespace CtrDxEditor.Rendering
         }
 
         /// <summary>
-        /// Draws the auto-catch radius as an orange dashed ring (distinct from the blue/red selection box)
-        /// around every auto-catch grab, so its reach stays visible without selecting it; it disappears
-        /// only when auto-catch is turned off. The game draws this circle blue and solid in-play; here it
-        /// is purely an editor guide, resized by dragging the selected grab's ring edge.
+        /// Draws each object's resizable radius as a dashed ring: orange for a grab's auto-catch reach,
+        /// gold for a light bulb's lit radius. The ring stays visible without selecting the object and
+        /// disappears only when the radius is turned off (non-positive). It is an editor guide — the game
+        /// draws the grab circle blue in-play and the bulb reach as a soft glow; here the ring marks the
+        /// draggable edge, resized by dragging the selected object's ring.
         /// </summary>
         public static void DrawRadiusRings(DrawingContext ctx, ViewTransform v, IReadOnlyList<LevelObject> objects)
         {
-            Pen radiusPen = new(Brushes.Orange, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
+            Pen grabPen = new(Brushes.Orange, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
+            Pen bulbPen = new(Brushes.Gold, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
             foreach (LevelObject obj in objects)
             {
-                if (obj.Type == "grab" && GrabRadius.Of(obj) is double rr)
+                if (RadiusRing.Of(obj) is not { } ring)
                 {
-                    Vec2 c = v.LevelToScreen(new Vec2(obj.X, obj.Y));
-                    double screenR = rr * v.Zoom;
-                    ctx.DrawEllipse(null, radiusPen, new Point(c.X, c.Y), screenR, screenR);
+                    continue;
                 }
+                Vec2 c = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+                double screenR = ring.Radius * v.Zoom;
+                Pen pen = obj.Type == "lightBulb" ? bulbPen : grabPen;
+                ctx.DrawEllipse(null, pen, new Point(c.X, c.Y), screenR, screenR);
             }
         }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -636,7 +636,8 @@ namespace CtrDxEditor.Rendering
         // ~6px screen tolerance (converted to level units by the current zoom).
         private bool OnRadiusEdge(Vec2 levelPt)
         {
-            return SelectedObject is { Type: "grab" } g && View.Zoom > 0 && GrabRadius.Of(g) is double r && GrabRadius.OnEdge(new Vec2(g.X, g.Y), r, levelPt, 6 / View.Zoom);
+            return SelectedObject is { } g && View.Zoom > 0 && RadiusRing.Of(g) is { } ring
+                && GrabRadius.OnEdge(new Vec2(g.X, g.Y), ring.Radius, levelPt, 6 / View.Zoom);
         }
 
         // What part of the selected movable grab's rail a level point is over, or None. The hit-testing
@@ -855,10 +856,10 @@ namespace CtrDxEditor.Rendering
             Point p = e.GetPosition(this);
             Vec2 levelPt = View.ScreenToLevel(new Vec2(p.X, p.Y));
 
-            if (_resizingRadius && SelectedObject is { } g)
+            if (_resizingRadius && SelectedObject is { } g && RadiusRing.Of(g) is { } ring)
             {
                 double r = GrabRadius.FromDrag(new Vec2(g.X, g.Y), levelPt);
-                g.SetAttr("radius", ((int)Math.Round(r)).ToString(CultureInfo.InvariantCulture));
+                g.SetAttr(ring.Attr, ((int)Math.Round(r)).ToString(CultureInfo.InvariantCulture));
                 SelectedObjectMoved?.Invoke();
                 InvalidateVisual();
                 return;

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -333,6 +333,23 @@ namespace CtrDxEditor.Rendering
             // (Grab.DrawBack + Grab.Draw). Ropes with no target resolve to null and are skipped, keeping the
             // per-rope seed (for seasonal light frames) in step with the grabs that actually have a rope.
             Rect opBounds = new(Bounds.Size);
+
+            // Light-bulb lit-glow halos: an additive Skia pass under the bottles, matching the game's
+            // DrawLight-then-bottle order. Drawn once for every bulb with a positive litRadius.
+            List<(Vec2 Center, double Radius)> glowBulbs = [];
+            foreach (LevelObject o in objects)
+            {
+                if (o.Type == "lightBulb" && RadiusRing.Of(o) is { } ring)
+                {
+                    glowBulbs.Add((new Vec2(o.X, o.Y), ring.Radius));
+                }
+            }
+            if (glowBulbs.Count > 0 && sprites.GetSprite("lightBulb_glow") is { Layers.Count: >= 1 } glow)
+            {
+                SpriteLayerDraw glowLayer = glow.Layers[0];
+                context.Custom(new GlowDrawOperation(opBounds, v, glowLayer.Bitmap, glowLayer.Frame.Frame, glowBulbs));
+            }
+
             int ropeSeed = 0;
             foreach (LevelObject obj in objects)
             {

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -362,7 +362,19 @@ namespace CtrDxEditor.Rendering
                         ropeSeed++;
                     }
                 }
-                else
+                else if (obj.Type != "lightBulb")
+                {
+                    DrawObject(context, v, sprites, obj);
+                }
+            }
+
+            // Light-bulb bottles draw in a pass of their own, above every rope, matching the game's
+            // order (GameScene.Draw: all bungee ropes first, then LightBulb.DrawBottleAndFirefly last).
+            // Drawing them inline would let a grab later in the object list paint its rope over an
+            // already-drawn bottle.
+            foreach (LevelObject obj in objects)
+            {
+                if (obj.Type == "lightBulb")
                 {
                     DrawObject(context, v, sprites, obj);
                 }

--- a/src/CtrDxEditor.Tests/GlowBlendTests.cs
+++ b/src/CtrDxEditor.Tests/GlowBlendTests.cs
@@ -1,0 +1,63 @@
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>
+    /// Tests the 1:1 light-bulb glow additive bake. The game draws the premultiplied glow texture through
+    /// a BasicEffect with white @ 0.6 alpha (which premultiplies diffuse by alpha, giving src = (p*0.6, a*0.6))
+    /// and blends with GL_SRC_ALPHA/GL_ONE, so each pixel adds p * a * 0.36 to the framebuffer.
+    /// </summary>
+    public class GlowBlendTests
+    {
+        /// <summary>The additive factor is the game's 0.6 glow alpha squared (153/255 is exactly 0.6).</summary>
+        [Fact]
+        public void AdditiveFactorIsGlowAlphaSquared()
+        {
+            Assert.Equal(0.36, GlowBlend.AdditiveFactor, 10);
+        }
+
+        /// <summary>A fully transparent pixel contributes nothing.</summary>
+        [Fact]
+        public void TransparentPixelBakesToZero()
+        {
+            Assert.Equal(0, GlowBlend.BakeChannel(0, 0));
+        }
+
+        /// <summary>An opaque white pixel adds 0.36 of full brightness (255 * 0.36 = 91.8 -> 92).</summary>
+        [Fact]
+        public void OpaqueWhitePixelBakesToThirtySixPercent()
+        {
+            Assert.Equal(92, GlowBlend.BakeChannel(255, 255));
+        }
+
+        /// <summary>The contribution is quadratic in alpha: half-alpha white adds a quarter of the opaque amount.</summary>
+        [Fact]
+        public void HalfAlphaWhiteBakesQuadratically()
+        {
+            // Premultiplied half-alpha white: p = 128, a = 128 -> 128 * (128/255) * 0.36 = 23.13 -> 23.
+            Assert.Equal(23, GlowBlend.BakeChannel(128, 128));
+        }
+
+        /// <summary>Baking a BGRA buffer scales every color channel by alpha * 0.36 and squares the alpha itself.</summary>
+        [Fact]
+        public void BakeBgraInPlaceTransformsEveryPixel()
+        {
+            // Pixel 1: b=50 g=100 r=150 a=200; pixel 2: opaque white.
+            byte[] bgra = [50, 100, 150, 200, 255, 255, 255, 255];
+            GlowBlend.BakeBgraInPlace(bgra);
+            Assert.Equal(new byte[] { 14, 28, 42, 56, 92, 92, 92, 92 }, bgra);
+        }
+
+        /// <summary>Baked pixels stay valid premultiplied colors (channels never exceed the baked alpha).</summary>
+        [Fact]
+        public void BakePreservesPremultipliedInvariant()
+        {
+            for (int a = 0; a <= 255; a++)
+            {
+                Assert.True(GlowBlend.BakeChannel((byte)a, (byte)a) >= GlowBlend.BakeChannel((byte)(a * 3 / 4), (byte)a));
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/GlowQuadTests.cs
+++ b/src/CtrDxEditor.Tests/GlowQuadTests.cs
@@ -8,6 +8,7 @@ namespace CtrDxEditor.Tests
     public class GlowQuadTests
     {
         // Glow quad 01_light.png is 405x425 (obj_lighter atlas). litRadius 50 -> half-width 75.
+        /// <summary>The glow's half-width is litRadius times the game's 1.5x visual multiplier.</summary>
         [Fact]
         public void WidthIsLitRadiusTimesOneAndAHalf()
         {
@@ -15,6 +16,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal(75.0, halfW);
         }
 
+        /// <summary>The glow's half-height scales with the source frame's aspect ratio, so the texture is never distorted.</summary>
         [Fact]
         public void HeightPreservesQuadAspectRatio()
         {
@@ -22,6 +24,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal(halfW * 425.0 / 405.0, halfH, 6);
         }
 
+        /// <summary>A zero-width source frame falls back to a square glow box instead of dividing by zero.</summary>
         [Fact]
         public void ZeroWidthFallsBackToSquare()
         {

--- a/src/CtrDxEditor.Tests/GlowQuadTests.cs
+++ b/src/CtrDxEditor.Tests/GlowQuadTests.cs
@@ -1,0 +1,32 @@
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests the 1:1 light-bulb glow sizing (game's 1.5x multiplier + aspect-preserving height).</summary>
+    public class GlowQuadTests
+    {
+        // Glow quad 01_light.png is 405x425 (obj_lighter atlas). litRadius 50 -> half-width 75.
+        [Fact]
+        public void WidthIsLitRadiusTimesOneAndAHalf()
+        {
+            (double halfW, _) = GlowQuad.DestRadii(50, 405, 425);
+            Assert.Equal(75.0, halfW);
+        }
+
+        [Fact]
+        public void HeightPreservesQuadAspectRatio()
+        {
+            (double halfW, double halfH) = GlowQuad.DestRadii(50, 405, 425);
+            Assert.Equal(halfW * 425.0 / 405.0, halfH, 6);
+        }
+
+        [Fact]
+        public void ZeroWidthFallsBackToSquare()
+        {
+            (double halfW, double halfH) = GlowQuad.DestRadii(50, 0, 425);
+            Assert.Equal(halfW, halfH);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/RadiusRingTests.cs
+++ b/src/CtrDxEditor.Tests/RadiusRingTests.cs
@@ -1,0 +1,59 @@
+using System.Xml.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests the object→radius-ring resolver shared by grabs and light bulbs.</summary>
+    public class RadiusRingTests
+    {
+        private static LevelObject Obj(string type, string attr, string? value)
+        {
+            XElement e = new(type, new XAttribute("x", "0"), new XAttribute("y", "0"));
+            if (value is not null)
+            {
+                e.SetAttributeValue(attr, value);
+            }
+            return new LevelObject(e);
+        }
+
+        [Theory]
+        [InlineData("100", 100.0)]
+        [InlineData(null, null)]
+        [InlineData("-1", null)]
+        [InlineData("0", null)]
+        public void GrabResolvesToRadiusAttr(string? value, double? expected)
+        {
+            (double Radius, string Attr)? ring = RadiusRing.Of(Obj("grab", "radius", value));
+            Assert.Equal(expected, ring?.Radius);
+            if (expected is not null)
+            {
+                Assert.Equal("radius", ring!.Value.Attr);
+            }
+        }
+
+        [Theory]
+        [InlineData("50", 50.0)]
+        [InlineData(null, null)]
+        [InlineData("-1", null)]
+        [InlineData("0", null)]
+        public void LightBulbResolvesToLitRadiusAttr(string? value, double? expected)
+        {
+            (double Radius, string Attr)? ring = RadiusRing.Of(Obj("lightBulb", "litRadius", value));
+            Assert.Equal(expected, ring?.Radius);
+            if (expected is not null)
+            {
+                Assert.Equal("litRadius", ring!.Value.Attr);
+            }
+        }
+
+        [Fact]
+        public void OtherTypesHaveNoRing()
+        {
+            Assert.Null(RadiusRing.Of(Obj("candy", "radius", "100")));
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/RadiusRingTests.cs
+++ b/src/CtrDxEditor.Tests/RadiusRingTests.cs
@@ -20,6 +20,7 @@ namespace CtrDxEditor.Tests
             return new LevelObject(e);
         }
 
+        /// <summary>A grab with a positive radius resolves to its "radius" attribute; missing/non-positive does not.</summary>
         [Theory]
         [InlineData("100", 100.0)]
         [InlineData(null, null)]
@@ -35,6 +36,7 @@ namespace CtrDxEditor.Tests
             }
         }
 
+        /// <summary>A light bulb with a positive litRadius resolves to its "litRadius" attribute; missing/non-positive does not.</summary>
         [Theory]
         [InlineData("50", 50.0)]
         [InlineData(null, null)]
@@ -50,6 +52,7 @@ namespace CtrDxEditor.Tests
             }
         }
 
+        /// <summary>An object type with no radius ring (e.g. candy) never resolves, even if it happens to carry a radius attribute.</summary>
         [Fact]
         public void OtherTypesHaveNoRing()
         {

--- a/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
+++ b/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
@@ -52,5 +52,17 @@ namespace CtrDxEditor.Tests
             Assert.Equal("images/obj_star_idle", layer.AtlasImageBasePath);
             Assert.Equal("frame_0056.png", layer.FrameName);
         }
+
+        /// <summary>The additive lit-glow halo is registered as its own quad, separate from the bulb sprite.</summary>
+        [Fact]
+        public void LightBulbGlowUsesLightQuad()
+        {
+            VisualDescriptor glow = VisualDescriptorMap.For("lightBulb_glow")!;
+
+            SpriteLayer layer = Assert.Single(glow.Layers);
+            Assert.Equal("images/obj_lighter.json", layer.AtlasJsonRelPath);
+            Assert.Equal("images/obj_lighter", layer.AtlasImageBasePath);
+            Assert.Equal("01_light.png", layer.FrameName);
+        }
     }
 }


### PR DESCRIPTION
## Description

Renders the light bulb's lit glow in the editor and makes its `litRadius` resizable, reusing the grab's radius-ring interaction. The glow reproduces the game's additive blend exactly rather than approximating it.

## What's changed

### Glow rendering

- `GlowDrawOperation` draws the `01_light.png` glow quad through SkiaSharp with `SKBlendMode.Plus`, stretched to 1.5x `litRadius` and centered on the bulb (matching `LightBulb.ApplyGlowScale`).
- `GlowBlend` bakes the game's exact contribution (`p * a * 0.36`) into the cached glow image, so a plain additive draw reproduces white @ 0.6 alpha applied twice—once by `BasicEffect`'s premultiplied diffuse, once by `blendingMode=2` (`GL_SRC_ALPHA/GL_ONE`).
- `GlowQuad` keeps the halo geometry 1:1 with the game and preserves the quad's aspect ratio so the texture is never distorted.
- Registered a separate `lightBulb_glow` visual element so the halo is never composited into the static bulb thumbnail or selection bounds.

### Draw order

- Light-bulb bottles now draw in their own pass above every rope, matching the game's order (all bungee ropes first, then `LightBulb.DrawBottleAndFirefly` last). This fixes a grab's rope being painted over an already-drawn bottle.

### Resizable lit radius

- `RadiusRing` resolves the resizable radius an object exposes—a grab's `radius` or a bulb's `litRadius`—so one rendering + resize path covers both.
- The radius ring is drawn gold for bulbs and orange for grabs; dragging the ring edge resizes either object.
