### PR TITLE
feat: Add level close and save actions

### DIFF
--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -4,7 +4,9 @@
     "Menu.File": "_File",
     "Menu.File.New": "_New...",
     "Menu.File.Open": "_Open...",
+    "Menu.File.Save": "_Save",
     "Menu.File.SaveAs": "Save _As...",
+    "Menu.File.Close": "_Close",
 
     "Menu.Edit": "_Edit",
     "Menu.Edit.LevelSettings": "Level _Settings...",
@@ -106,6 +108,9 @@
     "Dialog.Validation.SaveProceed": "Save anyway",
     "Dialog.Validation.EditPrompt": "Would you like to edit it anyway?",
     "Dialog.Validation.EditProceed": "Edit anyway",
+    "Dialog.Close.Header": "Confirm your action",
+    "Dialog.Close.Body": "Close the current level?",
+    "Dialog.Close.Proceed": "Close level",
 
     "Object.target": "Om Nom",
     "Object.candy": "Candy",

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -61,6 +61,9 @@ namespace CtrDxEditor.ViewModels
         /// <summary>The current level's editable settings, or null when no level is loaded.</summary>
         public LevelSettings? CurrentSettings => Document?.Settings;
 
+        /// <summary>True when a level is open and editor-only commands can run.</summary>
+        public bool HasDocument => Document is not null;
+
         /// <summary>Loads a level from its XML text into the editor.</summary>
         public void LoadLevelXml(string xml)
         {
@@ -71,6 +74,17 @@ namespace CtrDxEditor.ViewModels
             RefreshPalette();
             RefreshObjectList();
             LevelLoaded?.Invoke();
+        }
+
+        /// <summary>Closes the current level and clears document-scoped editor state.</summary>
+        public void CloseLevel()
+        {
+            Document = null;
+            SelectedObject = null;
+            LockedObject = null;
+            Palette.Clear();
+            ObjectList.Clear();
+            Fields.Clear();
         }
 
         /// <summary>
@@ -238,6 +252,11 @@ namespace CtrDxEditor.ViewModels
         partial void OnSelectedObjectChanged(LevelObject? value)
         {
             PopulateFields(value);
+        }
+
+        partial void OnDocumentChanged(LevelDocument? value)
+        {
+            OnPropertyChanged(nameof(HasDocument));
         }
 
         // The candy skin changes the candy sprites, so the palette thumbnails must be rebuilt. (The

--- a/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml
@@ -1,0 +1,38 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:views="using:CtrDxEditor.Views"
+             x:Class="CtrDxEditor.Views.ConfirmDialog"
+             x:CompileBindings="True"
+             x:DataType="views:ConfirmDialog">
+  <UserControl.Styles>
+    <Style Selector="Button.danger">
+      <Setter Property="Background" Value="#C42B1C" />
+      <Setter Property="BorderBrush" Value="#C42B1C" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.danger:pointerover">
+      <Setter Property="Background" Value="#D83B2D" />
+      <Setter Property="BorderBrush" Value="#D83B2D" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.danger:pressed">
+      <Setter Property="Background" Value="#A4261D" />
+      <Setter Property="BorderBrush" Value="#A4261D" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+  </UserControl.Styles>
+  <StackPanel Margin="24" Spacing="16" Width="380">
+    <TextBlock FontSize="18" FontWeight="SemiBold" Text="{Binding Header}" />
+    <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
+    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+      <Button Content="{Binding NegativeText}" Click="Cancel_Click"
+              MinWidth="96" Padding="16,6"
+              HorizontalContentAlignment="Center"
+              VerticalContentAlignment="Center" />
+      <Button Classes="danger" Content="{Binding PositiveText}" Click="Confirm_Click"
+              MinWidth="96" Padding="16,6"
+              HorizontalContentAlignment="Center"
+              VerticalContentAlignment="Center" />
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml.cs
@@ -1,0 +1,73 @@
+using Avalonia;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+using AvaloniaDialogs.Views;
+
+namespace CtrDxEditor.Views
+{
+    /// <summary>A headed confirmation dialog with explicit confirm and cancel actions.</summary>
+    public partial class ConfirmDialog : BaseDialog<bool>
+    {
+        /// <summary>The <see cref="Header"/> property.</summary>
+        public static readonly StyledProperty<string> HeaderProperty =
+            AvaloniaProperty.Register<ConfirmDialog, string>(nameof(Header));
+
+        /// <summary>The <see cref="Message"/> property.</summary>
+        public static readonly StyledProperty<string> MessageProperty =
+            AvaloniaProperty.Register<ConfirmDialog, string>(nameof(Message));
+
+        /// <summary>The <see cref="PositiveText"/> property.</summary>
+        public static readonly StyledProperty<string> PositiveTextProperty =
+            AvaloniaProperty.Register<ConfirmDialog, string>(nameof(PositiveText));
+
+        /// <summary>The <see cref="NegativeText"/> property.</summary>
+        public static readonly StyledProperty<string> NegativeTextProperty =
+            AvaloniaProperty.Register<ConfirmDialog, string>(nameof(NegativeText));
+
+        /// <summary>The dialog's title line.</summary>
+        public string Header
+        {
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+
+        /// <summary>The dialog's body text.</summary>
+        public string Message
+        {
+            get => GetValue(MessageProperty);
+            set => SetValue(MessageProperty, value);
+        }
+
+        /// <summary>The label for the confirming action.</summary>
+        public string PositiveText
+        {
+            get => GetValue(PositiveTextProperty);
+            set => SetValue(PositiveTextProperty, value);
+        }
+
+        /// <summary>The label for the canceling action.</summary>
+        public string NegativeText
+        {
+            get => GetValue(NegativeTextProperty);
+            set => SetValue(NegativeTextProperty, value);
+        }
+
+        /// <summary>Creates the confirmation dialog.</summary>
+        public ConfirmDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = this;
+        }
+
+        private void Confirm_Click(object? sender, RoutedEventArgs e)
+        {
+            Close(true);
+        }
+
+        private void Cancel_Click(object? sender, RoutedEventArgs e)
+        {
+            Close(false);
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -24,9 +24,23 @@
             <icons:MaterialIcon Kind="FolderOpenOutline" />
           </MenuItem.Icon>
         </MenuItem>
-        <MenuItem Header="{loc:Tr Menu.File.SaveAs}" Click="SaveAs_Click">
+        <MenuItem Header="{loc:Tr Menu.File.Save}" Click="Save_Click"
+                  IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="ContentSave" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="{loc:Tr Menu.File.SaveAs}" Click="SaveAs_Click"
+                  IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="ContentSaveEdit" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <Separator />
+        <MenuItem Header="{loc:Tr Menu.File.Close}" Click="Close_Click"
+                  IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="CloseBoxOutline" />
           </MenuItem.Icon>
         </MenuItem>
       </MenuItem>
@@ -41,7 +55,7 @@
       <MenuItem Header="{loc:Tr Menu.View}">
         <!-- Shortcut text lives in the header (KeyGesture can't render "Ctrl +"/"Ctrl 0"); the keys
              themselves are handled in MainWindow's KeyDown. A fixed MinWidth right-aligns the hint. -->
-        <MenuItem Click="ZoomIn_Click">
+        <MenuItem Click="ZoomIn_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="MagnifyPlusOutline" />
           </MenuItem.Icon>
@@ -52,7 +66,7 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
-        <MenuItem Click="ZoomOut_Click">
+        <MenuItem Click="ZoomOut_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="MagnifyMinusOutline" />
           </MenuItem.Icon>
@@ -63,7 +77,7 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
-        <MenuItem Click="ZoomFit_Click">
+        <MenuItem Click="ZoomFit_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="FitToScreen" />
           </MenuItem.Icon>
@@ -77,7 +91,7 @@
         <Separator />
         <!-- Transparent icon placeholder reserves the icon column so the check lines up with the
              zoom shortcuts above; the check sits at the header's right edge via the same MinWidth. -->
-        <MenuItem Click="SnapToggle_Click">
+        <MenuItem Click="SnapToggle_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <Border Width="16" Height="16" Background="Transparent" />
           </MenuItem.Icon>
@@ -89,7 +103,7 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
-        <MenuItem Click="ShowHitboxesToggle_Click">
+        <MenuItem Click="ShowHitboxesToggle_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <Border Width="16" Height="16" Background="Transparent" />
           </MenuItem.Icon>
@@ -101,7 +115,7 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
-        <MenuItem Click="ShowMobileHitboxesToggle_Click">
+        <MenuItem Click="ShowMobileHitboxesToggle_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <Border Width="16" Height="16" Background="Transparent" />
           </MenuItem.Icon>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -29,6 +29,7 @@ namespace CtrDxEditor.Views
     {
         private EditorViewModel? _mutatedSubscription;
         private readonly Action _invalidateCanvas;
+        private IStorageFile? _currentLevelFile;
 
         /// <summary>Creates the main editor view and wires input gestures.</summary>
         public MainView()
@@ -70,16 +71,25 @@ namespace CtrDxEditor.Views
                         e.Handled = true;
                         break;
                     case Key.OemPlus or Key.Add when ctrl:
-                        canvas.ZoomBy(1.2);
-                        e.Handled = true;
+                        if (DataContext is EditorViewModel { HasDocument: true })
+                        {
+                            canvas.ZoomBy(1.2);
+                            e.Handled = true;
+                        }
                         break;
                     case Key.OemMinus or Key.Subtract when ctrl:
-                        canvas.ZoomBy(1 / 1.2);
-                        e.Handled = true;
+                        if (DataContext is EditorViewModel { HasDocument: true })
+                        {
+                            canvas.ZoomBy(1 / 1.2);
+                            e.Handled = true;
+                        }
                         break;
                     case Key.D0 or Key.NumPad0 when ctrl:
-                        canvas.FitToView();
-                        e.Handled = true;
+                        if (DataContext is EditorViewModel { HasDocument: true })
+                        {
+                            canvas.FitToView();
+                            e.Handled = true;
+                        }
                         break;
                 }
 #pragma warning restore IDE0010
@@ -255,6 +265,7 @@ namespace CtrDxEditor.Views
             Optional<LevelSettings> result = await dialog.ShowAsync();
             if (result.GetValueOrDefault() is { } settings)
             {
+                _currentLevelFile = null;
                 (int ropeSkin, int background, int candySkin, int omNomSupport) = dialogVm.ResolveDecoration(Random.Shared);
                 vm.NewLevel(settings, ropeSkin, background, candySkin, omNomSupport);
 
@@ -357,6 +368,19 @@ namespace CtrDxEditor.Views
             return confirmed.GetValueOrDefault();
         }
 
+        private static async Task<bool> ConfirmCloseAsync()
+        {
+            ConfirmDialog dialog = new()
+            {
+                Header = Localizer.Get("Dialog.Close.Header"),
+                Message = Localizer.Get("Dialog.Close.Body"),
+                PositiveText = Localizer.Get("Dialog.Close.Proceed"),
+                NegativeText = Localizer.Get("Dialog.Common.Cancel"),
+            };
+            Optional<bool> confirmed = await dialog.ShowAsync();
+            return confirmed.GetValueOrDefault();
+        }
+
         private async void Open_Click(object? sender, RoutedEventArgs e)
         {
             if (DataContext is not EditorViewModel vm)
@@ -385,24 +409,57 @@ namespace CtrDxEditor.Views
                     return;
                 }
                 vm.LoadLevelXml(xml);
+                _currentLevelFile = files[0];
+            }
+        }
+
+        private async void Close_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is not EditorViewModel vm || !vm.HasDocument)
+            {
+                return;
+            }
+
+            if (await ConfirmCloseAsync())
+            {
+                vm.CloseLevel();
+                _currentLevelFile = null;
+                this.FindControl<LevelCanvas>("Canvas")!.InvalidateVisual();
+            }
+        }
+
+        private async void Save_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is not EditorViewModel vm || !vm.HasDocument)
+            {
+                return;
+            }
+
+            if (_currentLevelFile is null)
+            {
+                await SaveAsAsync(vm);
+                return;
+            }
+
+            if (await CanSaveAsync(vm) && vm.ToXml() is { } xml)
+            {
+                await WriteXmlAsync(_currentLevelFile, xml);
             }
         }
 
         private async void SaveAs_Click(object? sender, RoutedEventArgs e)
         {
-            if (DataContext is not EditorViewModel vm)
+            if (DataContext is EditorViewModel vm)
+            {
+                await SaveAsAsync(vm);
+            }
+        }
+
+        private async Task SaveAsAsync(EditorViewModel vm)
+        {
+            if (!vm.HasDocument || !await CanSaveAsync(vm))
             {
                 return;
-            }
-
-            if (vm.Document is { } doc)
-            {
-                IReadOnlyList<string> warnings = LevelValidator.Validate(doc);
-                if (warnings.Count > 0
-                    && !await ConfirmValidationAsync(warnings, "Dialog.Validation.SavePrompt", "Dialog.Validation.SaveProceed"))
-                {
-                    return;
-                }
             }
 
             IStorageFile? file = await TopLevel.GetTopLevel(this)!.StorageProvider.SaveFilePickerAsync(
@@ -410,16 +467,41 @@ namespace CtrDxEditor.Views
                 {
                     Title = Localizer.Get("Dialog.Save.Title"),
                     DefaultExtension = "xml",
-                    SuggestedFileName = "level.xml",
+                    SuggestedFileName = _currentLevelFile?.Name ?? "level.xml",
                     FileTypeChoices = [new FilePickerFileType(Localizer.Get("Dialog.FileType.LevelXml")) { Patterns = ["*.xml"] }],
                 });
 
             if (file is not null && vm.ToXml() is { } xml)
             {
-                await using Stream stream = await file.OpenWriteAsync();
-                await using StreamWriter writer = new(stream);
-                await writer.WriteAsync(xml);
+                await WriteXmlAsync(file, xml);
+                _currentLevelFile = file;
             }
+        }
+
+        private static async Task<bool> CanSaveAsync(EditorViewModel vm)
+        {
+            if (vm.Document is { } doc)
+            {
+                IReadOnlyList<string> warnings = LevelValidator.Validate(doc);
+                if (warnings.Count > 0
+                    && !await ConfirmValidationAsync(warnings, "Dialog.Validation.SavePrompt", "Dialog.Validation.SaveProceed"))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static async Task WriteXmlAsync(IStorageFile file, string xml)
+        {
+            await using Stream stream = await file.OpenWriteAsync();
+            if (stream.CanSeek)
+            {
+                stream.SetLength(0);
+            }
+            await using StreamWriter writer = new(stream);
+            await writer.WriteAsync(xml);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
+++ b/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
@@ -43,12 +43,35 @@ namespace CtrDxEditor.Tests
 
             vm.LoadLevelXml(xml);
 
+            Assert.True(vm.HasDocument);
             Assert.NotNull(vm.Document);
             Assert.Equal(100, vm.Document.Width);
             Assert.Equal(80, vm.Document.Height);
             string? saved = vm.ToXml();
             Assert.NotNull(saved);
             Assert.Contains("width=\"100\"", saved);
+        }
+
+        /// <summary>Verifies that closing a level resets the editable document state.</summary>
+        [Fact]
+        public void CloseLevelClearsDocumentAndEditorState()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            const string xml = "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer></map>";
+            vm.LoadLevelXml(xml);
+            _ = vm.PlaceObject("target", 50, 60);
+            vm.ToggleLock(vm.SelectedObject);
+
+            vm.CloseLevel();
+
+            Assert.False(vm.HasDocument);
+            Assert.Null(vm.Document);
+            Assert.Null(vm.SelectedObject);
+            Assert.Null(vm.LockedObject);
+            Assert.Empty(vm.ObjectList);
+            Assert.Empty(vm.Palette);
+            Assert.Empty(vm.Fields);
+            Assert.Null(vm.ToXml());
         }
 
         /// <summary>Verifies that loading XML notifies the view after the document has been replaced.</summary>

--- a/src/CtrDxEditor.Tests/LocalizationTests.cs
+++ b/src/CtrDxEditor.Tests/LocalizationTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests localized UI strings that are easy to miss during dialog wiring.</summary>
+    public class LocalizationTests
+    {
+        /// <summary>Verifies the close confirmation dialog has a visible action-confirmation header.</summary>
+        [Fact]
+        public void CloseConfirmationHeaderIsLocalized()
+        {
+            string path = FindRepositoryFile("src/CtrDxEditor.Shared/Localization/en.json");
+            Dictionary<string, string> strings = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                File.ReadAllText(path))!;
+
+            Assert.Equal("Confirm your action", strings["Dialog.Close.Header"]);
+        }
+
+        private static string FindRepositoryFile(string relativePath)
+        {
+            DirectoryInfo? dir = new(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                string candidate = Path.Combine(dir.FullName, relativePath);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                dir = dir.Parent;
+            }
+
+            throw new FileNotFoundException("Could not find repository file.", relativePath);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add File > Save, Save As, and Close actions
- Track the current opened/saved level file so Save can overwrite it
- Show a confirmation dialog before closing the current level
- Disable Save As, zoom, snap, and hitbox options when no level is open
- Style the destructive Close level confirmation button as a red danger action
- Add tests for document close/reset state and close-dialog localization