### PR TITLE
feat: Theme-aware editor UI colors and canvas chrome

### DIFF
--- a/src/CtrDxEditor.Shared/App.axaml
+++ b/src/CtrDxEditor.Shared/App.axaml
@@ -4,9 +4,18 @@
              xmlns:dialogHostAvalonia="using:DialogHostAvalonia"
              x:Class="CtrDxEditor.App"
              RequestedThemeVariant="Dark">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://CtrDxEditor.Shared/Styles/EditorTheme.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
+
   <Application.Styles>
     <FluentTheme />
     <icons:MaterialIconStyles />
     <dialogHostAvalonia:DialogHostStyles />
+    <StyleInclude Source="avares://CtrDxEditor.Shared/Styles/EditorStyles.axaml" />
   </Application.Styles>
 </Application>

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -1,0 +1,84 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace CtrDxEditor.Rendering
+{
+    /// <summary>
+    /// The editor-chrome brushes and pens for <see cref="LevelCanvas"/>, resolved from the active theme.
+    /// Kept out of the canvas so it holds only interaction/drawing logic; the palette is re-resolved once
+    /// per theme change via <see cref="Refresh"/>, never during <see cref="LevelCanvas.Render"/>.
+    /// The initial values are the pre-theming literals, used until the first <see cref="Refresh"/> and as
+    /// fallbacks if a resource key is ever missing.
+    /// </summary>
+    internal sealed class CanvasPalette
+    {
+        /// <summary>Solid backdrop filling the canvas behind the level.</summary>
+        public IBrush Background { get; private set; } = new SolidColorBrush(Color.FromRgb(40, 44, 52));
+
+        /// <summary>Outline of the level rectangle.</summary>
+        public Pen LevelBorder { get; private set; } = new(new SolidColorBrush(Colors.DimGray), 1);
+
+        /// <summary>Dashed grid lines inside the level rectangle.</summary>
+        public Pen Grid { get; private set; } = new(new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)), 1)
+        {
+            DashStyle = new DashStyle([4, 4], 0),
+        };
+
+        /// <summary>A grab's auto-catch radius ring.</summary>
+        public Pen GrabRadius { get; private set; } = OverlayPen(Brushes.Orange, 1.5);
+
+        /// <summary>A light bulb's lit-radius ring.</summary>
+        public Pen BulbRadius { get; private set; } = OverlayPen(Brushes.Gold, 1.5);
+
+        /// <summary>Desktop hitbox overlay.</summary>
+        public Pen HitboxDesktop { get; private set; } = OverlayPen(Brushes.LimeGreen, 1.5);
+
+        /// <summary>Phone hitbox overlay.</summary>
+        public Pen HitboxPhone { get; private set; } = OverlayPen(Brushes.Magenta, 1.5);
+
+        /// <summary>Selection marquee for the locked object.</summary>
+        public Pen ObjectLocked { get; private set; } = OverlayPen(Brushes.Red, 2);
+
+        /// <summary>Selection marquee for an unlocked object.</summary>
+        public Pen ObjectSelected { get; private set; } = OverlayPen(Brushes.DeepSkyBlue, 1.5);
+
+        /// <summary>Re-resolves every brush and pen for <paramref name="host"/>'s active theme variant.</summary>
+        public void Refresh(Control host)
+        {
+            Background = new SolidColorBrush(ThemeColor(host, "EditorColor.SurfacePanel", Color.FromRgb(40, 44, 52)));
+            LevelBorder = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.CanvasBorder", Colors.DimGray)), 1);
+            Grid = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.CanvasGrid", Color.FromArgb(40, 255, 255, 255))), 1)
+            {
+                DashStyle = new DashStyle([4, 4], 0),
+            };
+
+            GrabRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayGrabRadius", Colors.Orange), 1.5);
+            BulbRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayBulbRadius", Colors.Gold), 1.5);
+            HitboxDesktop = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxDesktop", Colors.LimeGreen), 1.5);
+            HitboxPhone = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
+            ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
+            ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
+        }
+
+        /// <summary>Resolves a themed <see cref="Color"/> resource for the host's active theme variant,
+        /// falling back to <paramref name="fallback"/> when the key is missing.</summary>
+        private static Color ThemeColor(Control host, string key, Color fallback)
+        {
+            return host.TryFindResource(key, host.ActualThemeVariant, out object? value) && value is Color color
+                ? color
+                : fallback;
+        }
+
+        /// <summary>Builds a dashed overlay pen with the shared editor dash pattern.</summary>
+        private static Pen OverlayPen(IBrush brush, double thickness)
+        {
+            return new Pen(brush, thickness) { DashStyle = new DashStyle([4, 3], 0) };
+        }
+
+        /// <summary>Builds a dashed overlay pen from a solid color.</summary>
+        private static Pen OverlayPen(Color color, double thickness)
+        {
+            return OverlayPen(new SolidColorBrush(color), thickness);
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
@@ -128,10 +128,8 @@ namespace CtrDxEditor.Rendering
         /// draws the grab circle blue in-play and the bulb reach as a soft glow; here the ring marks the
         /// draggable edge, resized by dragging the selected object's ring.
         /// </summary>
-        public static void DrawRadiusRings(DrawingContext ctx, ViewTransform v, IReadOnlyList<LevelObject> objects)
+        public static void DrawRadiusRings(DrawingContext ctx, ViewTransform v, IReadOnlyList<LevelObject> objects, Pen grabPen, Pen bulbPen)
         {
-            Pen grabPen = new(Brushes.Orange, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
-            Pen bulbPen = new(Brushes.Gold, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
             foreach (LevelObject obj in objects)
             {
                 if (RadiusRing.Of(obj) is not { } ring)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -202,6 +202,14 @@ namespace CtrDxEditor.Rendering
             DashStyle = new DashStyle([4, 4], 0),
         };
 
+        // Dashed overlay-indicator pens, resolved from the theme (fallbacks match the pre-theming literals).
+        private Pen _grabRadiusPen = OverlayPen(Brushes.Orange, 1.5);
+        private Pen _bulbRadiusPen = OverlayPen(Brushes.Gold, 1.5);
+        private Pen _hitboxDesktopPen = OverlayPen(Brushes.LimeGreen, 1.5);
+        private Pen _hitboxPhonePen = OverlayPen(Brushes.Magenta, 1.5);
+        private Pen _objectLockedPen = OverlayPen(Brushes.Red, 2);
+        private Pen _objectSelectedPen = OverlayPen(Brushes.DeepSkyBlue, 1.5);
+
         /// <summary>Creates the canvas and enables native touch gestures.</summary>
         public LevelCanvas()
         {
@@ -242,6 +250,25 @@ namespace CtrDxEditor.Rendering
             {
                 DashStyle = new DashStyle([4, 4], 0),
             };
+
+            _grabRadiusPen = OverlayPen(ThemeColor("EditorColor.OverlayGrabRadius", Colors.Orange), 1.5);
+            _bulbRadiusPen = OverlayPen(ThemeColor("EditorColor.OverlayBulbRadius", Colors.Gold), 1.5);
+            _hitboxDesktopPen = OverlayPen(ThemeColor("EditorColor.OverlayHitboxDesktop", Colors.LimeGreen), 1.5);
+            _hitboxPhonePen = OverlayPen(ThemeColor("EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
+            _objectLockedPen = OverlayPen(ThemeColor("EditorColor.OverlayObjectLocked", Colors.Red), 2);
+            _objectSelectedPen = OverlayPen(ThemeColor("EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
+        }
+
+        /// <summary>Builds a dashed overlay pen with the shared editor dash pattern.</summary>
+        private static Pen OverlayPen(IBrush brush, double thickness)
+        {
+            return new Pen(brush, thickness) { DashStyle = new DashStyle([4, 3], 0) };
+        }
+
+        /// <summary>Builds a dashed overlay pen from a solid color.</summary>
+        private static Pen OverlayPen(Color color, double thickness)
+        {
+            return OverlayPen(new SolidColorBrush(color), thickness);
         }
 
         /// <inheritdoc />
@@ -515,7 +542,7 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            GrabRenderer.DrawRadiusRings(context, v, objects);
+            GrabRenderer.DrawRadiusRings(context, v, objects, _grabRadiusPen, _bulbRadiusPen);
 
             if (ShowHitboxes || ShowMobileHitboxes)
             {
@@ -527,11 +554,11 @@ namespace CtrDxEditor.Rendering
                     }
                     if (ShowHitboxes)
                     {
-                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, Brushes.LimeGreen);
+                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _hitboxDesktopPen);
                     }
                     if (ShowMobileHitboxes)
                     {
-                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, Brushes.Magenta);
+                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _hitboxPhonePen);
                     }
                 }
             }
@@ -543,9 +570,7 @@ namespace CtrDxEditor.Rendering
                 Vec2 stl = v.LevelToScreen(new Vec2(sb.X, sb.Y));
                 Vec2 sbr = v.LevelToScreen(new Vec2(sb.X + sb.W, sb.Y + sb.H));
                 // Both boxes are dashed; a locked object is red, an unlocked one blue.
-                Pen pen = Equals(LockedObject, selected)
-                    ? new Pen(Brushes.Red, 2) { DashStyle = new DashStyle([4, 3], 0) }
-                    : new Pen(Brushes.DeepSkyBlue, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
+                Pen pen = Equals(LockedObject, selected) ? _objectLockedPen : _objectSelectedPen;
                 context.DrawRectangle(null, pen, new Rect(stl.X, stl.Y, sbr.X - stl.X, sbr.Y - stl.Y));
             }
 
@@ -806,7 +831,7 @@ namespace CtrDxEditor.Rendering
             LevelObject obj,
             double scale,
             HitboxModel model,
-            IBrush brush)
+            Pen pen)
         {
             if (HitboxTable.Compute(obj.Type, obj.X, obj.Y, scale, model) is not { } b)
             {
@@ -814,7 +839,6 @@ namespace CtrDxEditor.Rendering
             }
             Vec2 tl = v.LevelToScreen(new Vec2(b.X, b.Y));
             Vec2 br = v.LevelToScreen(new Vec2(b.X + b.W, b.Y + b.H));
-            Pen pen = new(brush, 1.5) { DashStyle = new DashStyle([4, 3], 0) };
             ctx.DrawRectangle(null, pen, new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
         }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -193,6 +193,15 @@ namespace CtrDxEditor.Rendering
         private string? _ghostElement;
         private Vec2 _ghostLevel;
 
+        // Editor-chrome brushes/pens resolved from the theme once per theme change, not per Render.
+        // Fallbacks match the pre-theming literals in case a resource key is ever missing.
+        private IBrush _canvasBackgroundBrush = new SolidColorBrush(Color.FromRgb(40, 44, 52));
+        private Pen _levelBorderPen = new(new SolidColorBrush(Colors.DimGray), 1);
+        private Pen _gridPen = new(new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)), 1)
+        {
+            DashStyle = new DashStyle([4, 4], 0),
+        };
+
         /// <summary>Creates the canvas and enables native touch gestures.</summary>
         public LevelCanvas()
         {
@@ -200,6 +209,39 @@ namespace CtrDxEditor.Rendering
             AddHandler(PinchEvent, Canvas_Pinch, RoutingStrategies.Bubble);
             AddHandler(PinchEndedEvent, Canvas_PinchEnded, RoutingStrategies.Bubble);
             AddHandler(PointerTouchPadGestureMagnifyEvent, Canvas_TouchPadMagnify, RoutingStrategies.Bubble);
+        }
+
+        /// <inheritdoc />
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            RefreshThemeColors();
+            ActualThemeVariantChanged += OnActualThemeVariantChanged;
+        }
+
+        /// <inheritdoc />
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            ActualThemeVariantChanged -= OnActualThemeVariantChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnActualThemeVariantChanged(object? sender, EventArgs e)
+        {
+            RefreshThemeColors();
+            InvalidateVisual();
+        }
+
+        /// <summary>Re-resolves the cached editor-chrome brushes/pens for the active theme variant.
+        /// Called on attach and whenever the theme changes, so <see cref="Render"/> never resolves resources.</summary>
+        private void RefreshThemeColors()
+        {
+            _canvasBackgroundBrush = new SolidColorBrush(ThemeColor("EditorColor.SurfacePanel", Color.FromRgb(40, 44, 52)));
+            _levelBorderPen = new Pen(new SolidColorBrush(ThemeColor("EditorColor.CanvasBorder", Colors.DimGray)), 1);
+            _gridPen = new Pen(new SolidColorBrush(ThemeColor("EditorColor.CanvasGrid", Color.FromArgb(40, 255, 255, 255))), 1)
+            {
+                DashStyle = new DashStyle([4, 4], 0),
+            };
         }
 
         /// <inheritdoc />
@@ -331,12 +373,21 @@ namespace CtrDxEditor.Rendering
             return new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y);
         }
 
+        /// <summary>Resolves a themed <see cref="Color"/> resource for the control's active theme variant,
+        /// falling back to <paramref name="fallback"/> when the key is missing.</summary>
+        private Color ThemeColor(string key, Color fallback)
+        {
+            return this.TryFindResource(key, ActualThemeVariant, out object? value) && value is Color color
+                ? color
+                : fallback;
+        }
+
         /// <inheritdoc />
         public override void Render(DrawingContext context)
         {
             base.Render(context);
 
-            context.FillRectangle(new SolidColorBrush(Color.FromRgb(40, 44, 52)), new Rect(Bounds.Size));
+            context.FillRectangle(_canvasBackgroundBrush, new Rect(Bounds.Size));
 
             LevelDocument? doc = Document;
             SpriteCache? sprites = Sprites;
@@ -402,22 +453,21 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            context.DrawRectangle(null, new Pen(Brushes.DimGray, 1),
+            context.DrawRectangle(null, _levelBorderPen,
                 new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
 
             int grid = doc.GridSize > 0 ? doc.GridSize : 32;
-            Pen gridPen = new(new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)), 1);
             for (int gx = 0; gx <= doc.Width; gx += grid)
             {
                 Vec2 a = v.LevelToScreen(new Vec2(gx, 0));
                 Vec2 b = v.LevelToScreen(new Vec2(gx, doc.Height));
-                context.DrawLine(gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                context.DrawLine(_gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
             }
             for (int gy = 0; gy <= doc.Height; gy += grid)
             {
                 Vec2 a = v.LevelToScreen(new Vec2(0, gy));
                 Vec2 b = v.LevelToScreen(new Vec2(doc.Width, gy));
-                context.DrawLine(gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                context.DrawLine(_gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
             }
 
             IReadOnlyList<LevelObject> objects = doc.Objects;

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -194,21 +194,7 @@ namespace CtrDxEditor.Rendering
         private Vec2 _ghostLevel;
 
         // Editor-chrome brushes/pens resolved from the theme once per theme change, not per Render.
-        // Fallbacks match the pre-theming literals in case a resource key is ever missing.
-        private IBrush _canvasBackgroundBrush = new SolidColorBrush(Color.FromRgb(40, 44, 52));
-        private Pen _levelBorderPen = new(new SolidColorBrush(Colors.DimGray), 1);
-        private Pen _gridPen = new(new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)), 1)
-        {
-            DashStyle = new DashStyle([4, 4], 0),
-        };
-
-        // Dashed overlay-indicator pens, resolved from the theme (fallbacks match the pre-theming literals).
-        private Pen _grabRadiusPen = OverlayPen(Brushes.Orange, 1.5);
-        private Pen _bulbRadiusPen = OverlayPen(Brushes.Gold, 1.5);
-        private Pen _hitboxDesktopPen = OverlayPen(Brushes.LimeGreen, 1.5);
-        private Pen _hitboxPhonePen = OverlayPen(Brushes.Magenta, 1.5);
-        private Pen _objectLockedPen = OverlayPen(Brushes.Red, 2);
-        private Pen _objectSelectedPen = OverlayPen(Brushes.DeepSkyBlue, 1.5);
+        private readonly CanvasPalette _palette = new();
 
         /// <summary>Creates the canvas and enables native touch gestures.</summary>
         public LevelCanvas()
@@ -223,7 +209,7 @@ namespace CtrDxEditor.Rendering
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            RefreshThemeColors();
+            _palette.Refresh(this);
             ActualThemeVariantChanged += OnActualThemeVariantChanged;
         }
 
@@ -236,39 +222,8 @@ namespace CtrDxEditor.Rendering
 
         private void OnActualThemeVariantChanged(object? sender, EventArgs e)
         {
-            RefreshThemeColors();
+            _palette.Refresh(this);
             InvalidateVisual();
-        }
-
-        /// <summary>Re-resolves the cached editor-chrome brushes/pens for the active theme variant.
-        /// Called on attach and whenever the theme changes, so <see cref="Render"/> never resolves resources.</summary>
-        private void RefreshThemeColors()
-        {
-            _canvasBackgroundBrush = new SolidColorBrush(ThemeColor("EditorColor.SurfacePanel", Color.FromRgb(40, 44, 52)));
-            _levelBorderPen = new Pen(new SolidColorBrush(ThemeColor("EditorColor.CanvasBorder", Colors.DimGray)), 1);
-            _gridPen = new Pen(new SolidColorBrush(ThemeColor("EditorColor.CanvasGrid", Color.FromArgb(40, 255, 255, 255))), 1)
-            {
-                DashStyle = new DashStyle([4, 4], 0),
-            };
-
-            _grabRadiusPen = OverlayPen(ThemeColor("EditorColor.OverlayGrabRadius", Colors.Orange), 1.5);
-            _bulbRadiusPen = OverlayPen(ThemeColor("EditorColor.OverlayBulbRadius", Colors.Gold), 1.5);
-            _hitboxDesktopPen = OverlayPen(ThemeColor("EditorColor.OverlayHitboxDesktop", Colors.LimeGreen), 1.5);
-            _hitboxPhonePen = OverlayPen(ThemeColor("EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
-            _objectLockedPen = OverlayPen(ThemeColor("EditorColor.OverlayObjectLocked", Colors.Red), 2);
-            _objectSelectedPen = OverlayPen(ThemeColor("EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
-        }
-
-        /// <summary>Builds a dashed overlay pen with the shared editor dash pattern.</summary>
-        private static Pen OverlayPen(IBrush brush, double thickness)
-        {
-            return new Pen(brush, thickness) { DashStyle = new DashStyle([4, 3], 0) };
-        }
-
-        /// <summary>Builds a dashed overlay pen from a solid color.</summary>
-        private static Pen OverlayPen(Color color, double thickness)
-        {
-            return OverlayPen(new SolidColorBrush(color), thickness);
         }
 
         /// <inheritdoc />
@@ -400,21 +355,12 @@ namespace CtrDxEditor.Rendering
             return new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y);
         }
 
-        /// <summary>Resolves a themed <see cref="Color"/> resource for the control's active theme variant,
-        /// falling back to <paramref name="fallback"/> when the key is missing.</summary>
-        private Color ThemeColor(string key, Color fallback)
-        {
-            return this.TryFindResource(key, ActualThemeVariant, out object? value) && value is Color color
-                ? color
-                : fallback;
-        }
-
         /// <inheritdoc />
         public override void Render(DrawingContext context)
         {
             base.Render(context);
 
-            context.FillRectangle(_canvasBackgroundBrush, new Rect(Bounds.Size));
+            context.FillRectangle(_palette.Background, new Rect(Bounds.Size));
 
             LevelDocument? doc = Document;
             SpriteCache? sprites = Sprites;
@@ -480,7 +426,7 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            context.DrawRectangle(null, _levelBorderPen,
+            context.DrawRectangle(null, _palette.LevelBorder,
                 new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
 
             int grid = doc.GridSize > 0 ? doc.GridSize : 32;
@@ -488,13 +434,13 @@ namespace CtrDxEditor.Rendering
             {
                 Vec2 a = v.LevelToScreen(new Vec2(gx, 0));
                 Vec2 b = v.LevelToScreen(new Vec2(gx, doc.Height));
-                context.DrawLine(_gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
             }
             for (int gy = 0; gy <= doc.Height; gy += grid)
             {
                 Vec2 a = v.LevelToScreen(new Vec2(0, gy));
                 Vec2 b = v.LevelToScreen(new Vec2(doc.Width, gy));
-                context.DrawLine(_gridPen, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
             }
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
@@ -542,7 +488,7 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            GrabRenderer.DrawRadiusRings(context, v, objects, _grabRadiusPen, _bulbRadiusPen);
+            GrabRenderer.DrawRadiusRings(context, v, objects, _palette.GrabRadius, _palette.BulbRadius);
 
             if (ShowHitboxes || ShowMobileHitboxes)
             {
@@ -554,11 +500,11 @@ namespace CtrDxEditor.Rendering
                     }
                     if (ShowHitboxes)
                     {
-                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _hitboxDesktopPen);
+                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop);
                     }
                     if (ShowMobileHitboxes)
                     {
-                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _hitboxPhonePen);
+                        DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone);
                     }
                 }
             }
@@ -570,7 +516,7 @@ namespace CtrDxEditor.Rendering
                 Vec2 stl = v.LevelToScreen(new Vec2(sb.X, sb.Y));
                 Vec2 sbr = v.LevelToScreen(new Vec2(sb.X + sb.W, sb.Y + sb.H));
                 // Both boxes are dashed; a locked object is red, an unlocked one blue.
-                Pen pen = Equals(LockedObject, selected) ? _objectLockedPen : _objectSelectedPen;
+                Pen pen = Equals(LockedObject, selected) ? _palette.ObjectLocked : _palette.ObjectSelected;
                 context.DrawRectangle(null, pen, new Rect(stl.X, stl.Y, sbr.X - stl.X, sbr.Y - stl.Y));
             }
 

--- a/src/CtrDxEditor.Shared/Styles/EditorStyles.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorStyles.axaml
@@ -1,0 +1,25 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!--
+    App-wide control styles that layer on top of FluentTheme.
+    Interactive states target the button's template part (PART_ContentPresenter)
+    so FluentTheme's own :pointerover/:pressed setters don't override the color.
+  -->
+
+  <!-- Destructive action button. -->
+  <Style Selector="Button.danger /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource EditorBrush.Danger}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.Danger}" />
+    <Setter Property="Foreground" Value="{DynamicResource EditorBrush.OnPrimary}" />
+  </Style>
+  <Style Selector="Button.danger:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource EditorBrush.DangerHover}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.DangerHover}" />
+    <Setter Property="Foreground" Value="{DynamicResource EditorBrush.OnPrimary}" />
+  </Style>
+  <Style Selector="Button.danger:pressed /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="{DynamicResource EditorBrush.DangerPressed}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.DangerPressed}" />
+    <Setter Property="Foreground" Value="{DynamicResource EditorBrush.OnPrimary}" />
+  </Style>
+</Styles>

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -1,207 +1,319 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <!-- Bootstrap 5.3 color tokens -->
+  <!--
+    Tailwind CSS v4 color tokens.
+    Raw hex values converted from Tailwind's canonical OKLCH definitions to sRGB.
+    Consume the semantic EditorBrush.* layer in views, not these raw tokens.
+  -->
   <Color x:Key="white">#FFFFFF</Color>
   <Color x:Key="black">#000000</Color>
 
-  <Color x:Key="gray-100">#F8F9FA</Color>
-  <Color x:Key="gray-200">#E9ECEF</Color>
-  <Color x:Key="gray-300">#DEE2E6</Color>
-  <Color x:Key="gray-400">#CED4DA</Color>
-  <Color x:Key="gray-500">#ADB5BD</Color>
-  <Color x:Key="gray-600">#6C757D</Color>
-  <Color x:Key="gray-700">#495057</Color>
-  <Color x:Key="gray-800">#343A40</Color>
-  <Color x:Key="gray-900">#212529</Color>
-  <Color x:Key="gray">#6C757D</Color>
-  <Color x:Key="gray-dark">#343A40</Color>
-
-  <Color x:Key="blue">#0D6EFD</Color>
-  <Color x:Key="blue-100">#CFE2FF</Color>
-  <Color x:Key="blue-200">#9EC5FE</Color>
-  <Color x:Key="blue-300">#6EA8FE</Color>
-  <Color x:Key="blue-400">#3D8BFD</Color>
-  <Color x:Key="blue-500">#0D6EFD</Color>
-  <Color x:Key="blue-600">#0A58CA</Color>
-  <Color x:Key="blue-700">#084298</Color>
-  <Color x:Key="blue-800">#052C65</Color>
-  <Color x:Key="blue-900">#031633</Color>
-
-  <Color x:Key="indigo">#6610F2</Color>
-  <Color x:Key="indigo-100">#E0CFFC</Color>
-  <Color x:Key="indigo-200">#C29FFA</Color>
-  <Color x:Key="indigo-300">#A370F7</Color>
-  <Color x:Key="indigo-400">#8540F5</Color>
-  <Color x:Key="indigo-500">#6610F2</Color>
-  <Color x:Key="indigo-600">#520DC2</Color>
-  <Color x:Key="indigo-700">#3D0A91</Color>
-  <Color x:Key="indigo-800">#290661</Color>
-  <Color x:Key="indigo-900">#140330</Color>
-
-  <Color x:Key="purple">#6F42C1</Color>
-  <Color x:Key="purple-100">#E2D9F3</Color>
-  <Color x:Key="purple-200">#C5B3E6</Color>
-  <Color x:Key="purple-300">#A98EDA</Color>
-  <Color x:Key="purple-400">#8C68CD</Color>
-  <Color x:Key="purple-500">#6F42C1</Color>
-  <Color x:Key="purple-600">#59359A</Color>
-  <Color x:Key="purple-700">#432874</Color>
-  <Color x:Key="purple-800">#2C1A4D</Color>
-  <Color x:Key="purple-900">#160D27</Color>
-
-  <Color x:Key="pink">#D63384</Color>
-  <Color x:Key="pink-100">#F7D6E6</Color>
-  <Color x:Key="pink-200">#EFADCE</Color>
-  <Color x:Key="pink-300">#E685B5</Color>
-  <Color x:Key="pink-400">#DE5C9D</Color>
-  <Color x:Key="pink-500">#D63384</Color>
-  <Color x:Key="pink-600">#AB296A</Color>
-  <Color x:Key="pink-700">#801F4F</Color>
-  <Color x:Key="pink-800">#561435</Color>
-  <Color x:Key="pink-900">#2B0A1A</Color>
-
-  <Color x:Key="red">#DC3545</Color>
-  <Color x:Key="red-100">#F8D7DA</Color>
-  <Color x:Key="red-200">#F1AEB5</Color>
-  <Color x:Key="red-300">#EA868F</Color>
-  <Color x:Key="red-400">#E35D6A</Color>
-  <Color x:Key="red-500">#DC3545</Color>
-  <Color x:Key="red-600">#B02A37</Color>
-  <Color x:Key="red-700">#842029</Color>
-  <Color x:Key="red-800">#58151C</Color>
-  <Color x:Key="red-900">#2C0B0E</Color>
-
-  <Color x:Key="orange">#FD7E14</Color>
-  <Color x:Key="orange-100">#FFE5D0</Color>
-  <Color x:Key="orange-200">#FECBA1</Color>
-  <Color x:Key="orange-300">#FEB272</Color>
-  <Color x:Key="orange-400">#FD9843</Color>
-  <Color x:Key="orange-500">#FD7E14</Color>
-  <Color x:Key="orange-600">#CA6510</Color>
-  <Color x:Key="orange-700">#984C0C</Color>
-  <Color x:Key="orange-800">#653208</Color>
-  <Color x:Key="orange-900">#331904</Color>
-
-  <Color x:Key="yellow">#FFC107</Color>
-  <Color x:Key="yellow-100">#FFF3CD</Color>
-  <Color x:Key="yellow-200">#FFE69C</Color>
-  <Color x:Key="yellow-300">#FFDA6A</Color>
-  <Color x:Key="yellow-400">#FFCD39</Color>
-  <Color x:Key="yellow-500">#FFC107</Color>
-  <Color x:Key="yellow-600">#CC9A06</Color>
-  <Color x:Key="yellow-700">#997404</Color>
-  <Color x:Key="yellow-800">#664D03</Color>
-  <Color x:Key="yellow-900">#332701</Color>
-
-  <Color x:Key="green">#198754</Color>
-  <Color x:Key="green-100">#D1E7DD</Color>
-  <Color x:Key="green-200">#A3CFBB</Color>
-  <Color x:Key="green-300">#75B798</Color>
-  <Color x:Key="green-400">#479F76</Color>
-  <Color x:Key="green-500">#198754</Color>
-  <Color x:Key="green-600">#146C43</Color>
-  <Color x:Key="green-700">#0F5132</Color>
-  <Color x:Key="green-800">#0A3622</Color>
-  <Color x:Key="green-900">#051B11</Color>
-
-  <Color x:Key="teal">#20C997</Color>
-  <Color x:Key="teal-100">#D2F4EA</Color>
-  <Color x:Key="teal-200">#A6E9D5</Color>
-  <Color x:Key="teal-300">#79DFC1</Color>
-  <Color x:Key="teal-400">#4DD4AC</Color>
-  <Color x:Key="teal-500">#20C997</Color>
-  <Color x:Key="teal-600">#1AA179</Color>
-  <Color x:Key="teal-700">#13795B</Color>
-  <Color x:Key="teal-800">#0D503C</Color>
-  <Color x:Key="teal-900">#06281E</Color>
-
-  <Color x:Key="cyan">#0DCAF0</Color>
-  <Color x:Key="cyan-100">#CFF4FC</Color>
-  <Color x:Key="cyan-200">#9EEAF9</Color>
-  <Color x:Key="cyan-300">#6EDFF6</Color>
-  <Color x:Key="cyan-400">#3DD5F3</Color>
-  <Color x:Key="cyan-500">#0DCAF0</Color>
-  <Color x:Key="cyan-600">#0AA2C0</Color>
-  <Color x:Key="cyan-700">#087990</Color>
-  <Color x:Key="cyan-800">#055160</Color>
-  <Color x:Key="cyan-900">#032830</Color>
-
-  <Color x:Key="primary">#0D6EFD</Color>
-  <Color x:Key="secondary">#6C757D</Color>
-  <Color x:Key="success">#198754</Color>
-  <Color x:Key="info">#0DCAF0</Color>
-  <Color x:Key="warning">#FFC107</Color>
-  <Color x:Key="danger">#DC3545</Color>
-  <Color x:Key="light">#F8F9FA</Color>
-  <Color x:Key="dark">#212529</Color>
-
-  <!-- Brush shorthands for direct UI use. -->
-  <SolidColorBrush x:Key="Brush.white" Color="{StaticResource white}" />
-  <SolidColorBrush x:Key="Brush.black" Color="{StaticResource black}" />
-  <SolidColorBrush x:Key="Brush.blue-100" Color="{StaticResource blue-100}" />
-  <SolidColorBrush x:Key="Brush.blue-500" Color="{StaticResource blue-500}" />
-  <SolidColorBrush x:Key="Brush.blue-600" Color="{StaticResource blue-600}" />
-  <SolidColorBrush x:Key="Brush.red-500" Color="{StaticResource red-500}" />
-  <SolidColorBrush x:Key="Brush.red-600" Color="{StaticResource red-600}" />
-  <SolidColorBrush x:Key="Brush.red-700" Color="{StaticResource red-700}" />
-  <SolidColorBrush x:Key="Brush.yellow-500" Color="{StaticResource yellow-500}" />
-  <SolidColorBrush x:Key="Brush.gray-100" Color="{StaticResource gray-100}" />
-  <SolidColorBrush x:Key="Brush.gray-200" Color="{StaticResource gray-200}" />
-  <SolidColorBrush x:Key="Brush.gray-300" Color="{StaticResource gray-300}" />
-  <SolidColorBrush x:Key="Brush.gray-500" Color="{StaticResource gray-500}" />
-  <SolidColorBrush x:Key="Brush.gray-600" Color="{StaticResource gray-600}" />
-  <SolidColorBrush x:Key="Brush.gray-700" Color="{StaticResource gray-700}" />
-  <SolidColorBrush x:Key="Brush.gray-800" Color="{StaticResource gray-800}" />
-  <SolidColorBrush x:Key="Brush.gray-900" Color="{StaticResource gray-900}" />
-  <SolidColorBrush x:Key="Brush.primary" Color="{StaticResource primary}" />
-  <SolidColorBrush x:Key="Brush.secondary" Color="{StaticResource secondary}" />
-  <SolidColorBrush x:Key="Brush.success" Color="{StaticResource success}" />
-  <SolidColorBrush x:Key="Brush.info" Color="{StaticResource info}" />
-  <SolidColorBrush x:Key="Brush.warning" Color="{StaticResource warning}" />
-  <SolidColorBrush x:Key="Brush.danger" Color="{StaticResource danger}" />
-  <SolidColorBrush x:Key="Brush.light" Color="{StaticResource light}" />
-  <SolidColorBrush x:Key="Brush.dark" Color="{StaticResource dark}" />
+  <!-- red -->
+  <Color x:Key="red-50">#FEF2F2</Color>
+  <Color x:Key="red-100">#FFE2E2</Color>
+  <Color x:Key="red-200">#FFC9C9</Color>
+  <Color x:Key="red-300">#FFA2A2</Color>
+  <Color x:Key="red-400">#FF6467</Color>
+  <Color x:Key="red-500">#FB2C36</Color>
+  <Color x:Key="red-600">#E7000B</Color>
+  <Color x:Key="red-700">#C10007</Color>
+  <Color x:Key="red-800">#9F0712</Color>
+  <Color x:Key="red-900">#82181A</Color>
+  <Color x:Key="red-950">#460809</Color>
+  <!-- orange -->
+  <Color x:Key="orange-50">#FFF7ED</Color>
+  <Color x:Key="orange-100">#FFEDD4</Color>
+  <Color x:Key="orange-200">#FFD6A7</Color>
+  <Color x:Key="orange-300">#FFB86A</Color>
+  <Color x:Key="orange-400">#FF8904</Color>
+  <Color x:Key="orange-500">#FF6900</Color>
+  <Color x:Key="orange-600">#F54900</Color>
+  <Color x:Key="orange-700">#CA3500</Color>
+  <Color x:Key="orange-800">#9F2D00</Color>
+  <Color x:Key="orange-900">#7E2A0C</Color>
+  <Color x:Key="orange-950">#441306</Color>
+  <!-- amber -->
+  <Color x:Key="amber-50">#FFFBEB</Color>
+  <Color x:Key="amber-100">#FEF3C6</Color>
+  <Color x:Key="amber-200">#FEE685</Color>
+  <Color x:Key="amber-300">#FFD230</Color>
+  <Color x:Key="amber-400">#FFB900</Color>
+  <Color x:Key="amber-500">#FE9A00</Color>
+  <Color x:Key="amber-600">#E17100</Color>
+  <Color x:Key="amber-700">#BB4D00</Color>
+  <Color x:Key="amber-800">#973C00</Color>
+  <Color x:Key="amber-900">#7B3306</Color>
+  <Color x:Key="amber-950">#461901</Color>
+  <!-- yellow -->
+  <Color x:Key="yellow-50">#FEFCE8</Color>
+  <Color x:Key="yellow-100">#FEF9C2</Color>
+  <Color x:Key="yellow-200">#FFF085</Color>
+  <Color x:Key="yellow-300">#FFDF20</Color>
+  <Color x:Key="yellow-400">#FDC700</Color>
+  <Color x:Key="yellow-500">#F0B100</Color>
+  <Color x:Key="yellow-600">#D08700</Color>
+  <Color x:Key="yellow-700">#A65F00</Color>
+  <Color x:Key="yellow-800">#894B00</Color>
+  <Color x:Key="yellow-900">#733E0A</Color>
+  <Color x:Key="yellow-950">#432004</Color>
+  <!-- lime -->
+  <Color x:Key="lime-50">#F7FEE7</Color>
+  <Color x:Key="lime-100">#ECFCCA</Color>
+  <Color x:Key="lime-200">#D8F999</Color>
+  <Color x:Key="lime-300">#BBF451</Color>
+  <Color x:Key="lime-400">#9AE600</Color>
+  <Color x:Key="lime-500">#7CCF00</Color>
+  <Color x:Key="lime-600">#5EA500</Color>
+  <Color x:Key="lime-700">#497D00</Color>
+  <Color x:Key="lime-800">#3C6300</Color>
+  <Color x:Key="lime-900">#35530E</Color>
+  <Color x:Key="lime-950">#192E03</Color>
+  <!-- green -->
+  <Color x:Key="green-50">#F0FDF4</Color>
+  <Color x:Key="green-100">#DCFCE7</Color>
+  <Color x:Key="green-200">#B9F8CF</Color>
+  <Color x:Key="green-300">#7BF1A8</Color>
+  <Color x:Key="green-400">#05DF72</Color>
+  <Color x:Key="green-500">#00C950</Color>
+  <Color x:Key="green-600">#00A63E</Color>
+  <Color x:Key="green-700">#008236</Color>
+  <Color x:Key="green-800">#016630</Color>
+  <Color x:Key="green-900">#0D542B</Color>
+  <Color x:Key="green-950">#032E15</Color>
+  <!-- emerald -->
+  <Color x:Key="emerald-50">#ECFDF5</Color>
+  <Color x:Key="emerald-100">#D0FAE5</Color>
+  <Color x:Key="emerald-200">#A4F4CF</Color>
+  <Color x:Key="emerald-300">#5EE9B5</Color>
+  <Color x:Key="emerald-400">#00D492</Color>
+  <Color x:Key="emerald-500">#00BC7D</Color>
+  <Color x:Key="emerald-600">#009966</Color>
+  <Color x:Key="emerald-700">#007A55</Color>
+  <Color x:Key="emerald-800">#006045</Color>
+  <Color x:Key="emerald-900">#004F3B</Color>
+  <Color x:Key="emerald-950">#002C22</Color>
+  <!-- teal -->
+  <Color x:Key="teal-50">#F0FDFA</Color>
+  <Color x:Key="teal-100">#CBFBF1</Color>
+  <Color x:Key="teal-200">#96F7E4</Color>
+  <Color x:Key="teal-300">#46ECD5</Color>
+  <Color x:Key="teal-400">#00D5BE</Color>
+  <Color x:Key="teal-500">#00BBA7</Color>
+  <Color x:Key="teal-600">#009689</Color>
+  <Color x:Key="teal-700">#00786F</Color>
+  <Color x:Key="teal-800">#005F5A</Color>
+  <Color x:Key="teal-900">#0B4F4A</Color>
+  <Color x:Key="teal-950">#022F2E</Color>
+  <!-- cyan -->
+  <Color x:Key="cyan-50">#ECFEFF</Color>
+  <Color x:Key="cyan-100">#CEFAFE</Color>
+  <Color x:Key="cyan-200">#A2F4FD</Color>
+  <Color x:Key="cyan-300">#53EAFD</Color>
+  <Color x:Key="cyan-400">#00D3F2</Color>
+  <Color x:Key="cyan-500">#00B8DB</Color>
+  <Color x:Key="cyan-600">#0092B8</Color>
+  <Color x:Key="cyan-700">#007595</Color>
+  <Color x:Key="cyan-800">#005F78</Color>
+  <Color x:Key="cyan-900">#104E64</Color>
+  <Color x:Key="cyan-950">#053345</Color>
+  <!-- sky -->
+  <Color x:Key="sky-50">#F0F9FF</Color>
+  <Color x:Key="sky-100">#DFF2FE</Color>
+  <Color x:Key="sky-200">#B8E6FE</Color>
+  <Color x:Key="sky-300">#74D4FF</Color>
+  <Color x:Key="sky-400">#00BCFF</Color>
+  <Color x:Key="sky-500">#00A6F4</Color>
+  <Color x:Key="sky-600">#0084D1</Color>
+  <Color x:Key="sky-700">#0069A8</Color>
+  <Color x:Key="sky-800">#00598A</Color>
+  <Color x:Key="sky-900">#024A70</Color>
+  <Color x:Key="sky-950">#052F4A</Color>
+  <!-- blue -->
+  <Color x:Key="blue-50">#EFF6FF</Color>
+  <Color x:Key="blue-100">#DBEAFE</Color>
+  <Color x:Key="blue-200">#BEDBFF</Color>
+  <Color x:Key="blue-300">#8EC5FF</Color>
+  <Color x:Key="blue-400">#51A2FF</Color>
+  <Color x:Key="blue-500">#2B7FFF</Color>
+  <Color x:Key="blue-600">#155DFC</Color>
+  <Color x:Key="blue-700">#1447E6</Color>
+  <Color x:Key="blue-800">#193CB8</Color>
+  <Color x:Key="blue-900">#1C398E</Color>
+  <Color x:Key="blue-950">#162456</Color>
+  <!-- indigo -->
+  <Color x:Key="indigo-50">#EEF2FF</Color>
+  <Color x:Key="indigo-100">#E0E7FF</Color>
+  <Color x:Key="indigo-200">#C6D2FF</Color>
+  <Color x:Key="indigo-300">#A3B3FF</Color>
+  <Color x:Key="indigo-400">#7C86FF</Color>
+  <Color x:Key="indigo-500">#615FFF</Color>
+  <Color x:Key="indigo-600">#4F39F6</Color>
+  <Color x:Key="indigo-700">#432DD7</Color>
+  <Color x:Key="indigo-800">#372AAC</Color>
+  <Color x:Key="indigo-900">#312C85</Color>
+  <Color x:Key="indigo-950">#1E1A4D</Color>
+  <!-- violet -->
+  <Color x:Key="violet-50">#F5F3FF</Color>
+  <Color x:Key="violet-100">#EDE9FE</Color>
+  <Color x:Key="violet-200">#DDD6FF</Color>
+  <Color x:Key="violet-300">#C4B4FF</Color>
+  <Color x:Key="violet-400">#A684FF</Color>
+  <Color x:Key="violet-500">#8E51FF</Color>
+  <Color x:Key="violet-600">#7F22FE</Color>
+  <Color x:Key="violet-700">#7008E7</Color>
+  <Color x:Key="violet-800">#5D0EC0</Color>
+  <Color x:Key="violet-900">#4D179A</Color>
+  <Color x:Key="violet-950">#2F0D68</Color>
+  <!-- purple -->
+  <Color x:Key="purple-50">#FAF5FF</Color>
+  <Color x:Key="purple-100">#F3E8FF</Color>
+  <Color x:Key="purple-200">#E9D4FF</Color>
+  <Color x:Key="purple-300">#DAB2FF</Color>
+  <Color x:Key="purple-400">#C27AFF</Color>
+  <Color x:Key="purple-500">#AD46FF</Color>
+  <Color x:Key="purple-600">#9810FA</Color>
+  <Color x:Key="purple-700">#8200DB</Color>
+  <Color x:Key="purple-800">#6E11B0</Color>
+  <Color x:Key="purple-900">#59168B</Color>
+  <Color x:Key="purple-950">#3C0366</Color>
+  <!-- fuchsia -->
+  <Color x:Key="fuchsia-50">#FDF4FF</Color>
+  <Color x:Key="fuchsia-100">#FAE8FF</Color>
+  <Color x:Key="fuchsia-200">#F6CFFF</Color>
+  <Color x:Key="fuchsia-300">#F4A8FF</Color>
+  <Color x:Key="fuchsia-400">#ED6AFF</Color>
+  <Color x:Key="fuchsia-500">#E12AFB</Color>
+  <Color x:Key="fuchsia-600">#C800DE</Color>
+  <Color x:Key="fuchsia-700">#A800B7</Color>
+  <Color x:Key="fuchsia-800">#8A0194</Color>
+  <Color x:Key="fuchsia-900">#721378</Color>
+  <Color x:Key="fuchsia-950">#4B004F</Color>
+  <!-- pink -->
+  <Color x:Key="pink-50">#FDF2F8</Color>
+  <Color x:Key="pink-100">#FCE7F3</Color>
+  <Color x:Key="pink-200">#FCCEE8</Color>
+  <Color x:Key="pink-300">#FDA5D5</Color>
+  <Color x:Key="pink-400">#FB64B6</Color>
+  <Color x:Key="pink-500">#F6339A</Color>
+  <Color x:Key="pink-600">#E60076</Color>
+  <Color x:Key="pink-700">#C6005C</Color>
+  <Color x:Key="pink-800">#A3004C</Color>
+  <Color x:Key="pink-900">#861043</Color>
+  <Color x:Key="pink-950">#510424</Color>
+  <!-- rose -->
+  <Color x:Key="rose-50">#FFF1F2</Color>
+  <Color x:Key="rose-100">#FFE4E6</Color>
+  <Color x:Key="rose-200">#FFCCD3</Color>
+  <Color x:Key="rose-300">#FFA1AD</Color>
+  <Color x:Key="rose-400">#FF637E</Color>
+  <Color x:Key="rose-500">#FF2056</Color>
+  <Color x:Key="rose-600">#EC003F</Color>
+  <Color x:Key="rose-700">#C70036</Color>
+  <Color x:Key="rose-800">#A50036</Color>
+  <Color x:Key="rose-900">#8B0836</Color>
+  <Color x:Key="rose-950">#4D0218</Color>
+  <!-- slate -->
+  <Color x:Key="slate-50">#F8FAFC</Color>
+  <Color x:Key="slate-100">#F1F5F9</Color>
+  <Color x:Key="slate-200">#E2E8F0</Color>
+  <Color x:Key="slate-300">#CAD5E2</Color>
+  <Color x:Key="slate-400">#90A1B9</Color>
+  <Color x:Key="slate-500">#62748E</Color>
+  <Color x:Key="slate-600">#45556C</Color>
+  <Color x:Key="slate-700">#314158</Color>
+  <Color x:Key="slate-800">#1D293D</Color>
+  <Color x:Key="slate-900">#0F172B</Color>
+  <Color x:Key="slate-950">#020618</Color>
+  <!-- gray -->
+  <Color x:Key="gray-50">#F9FAFB</Color>
+  <Color x:Key="gray-100">#F3F4F6</Color>
+  <Color x:Key="gray-200">#E5E7EB</Color>
+  <Color x:Key="gray-300">#D1D5DC</Color>
+  <Color x:Key="gray-400">#99A1AF</Color>
+  <Color x:Key="gray-500">#6A7282</Color>
+  <Color x:Key="gray-600">#4A5565</Color>
+  <Color x:Key="gray-700">#364153</Color>
+  <Color x:Key="gray-800">#1E2939</Color>
+  <Color x:Key="gray-900">#101828</Color>
+  <Color x:Key="gray-950">#030712</Color>
+  <!-- zinc -->
+  <Color x:Key="zinc-50">#FAFAFA</Color>
+  <Color x:Key="zinc-100">#F4F4F5</Color>
+  <Color x:Key="zinc-200">#E4E4E7</Color>
+  <Color x:Key="zinc-300">#D4D4D8</Color>
+  <Color x:Key="zinc-400">#9F9FA9</Color>
+  <Color x:Key="zinc-500">#71717B</Color>
+  <Color x:Key="zinc-600">#52525C</Color>
+  <Color x:Key="zinc-700">#3F3F46</Color>
+  <Color x:Key="zinc-800">#27272A</Color>
+  <Color x:Key="zinc-900">#18181B</Color>
+  <Color x:Key="zinc-950">#09090B</Color>
+  <!-- neutral -->
+  <Color x:Key="neutral-50">#FAFAFA</Color>
+  <Color x:Key="neutral-100">#F5F5F5</Color>
+  <Color x:Key="neutral-200">#E5E5E5</Color>
+  <Color x:Key="neutral-300">#D4D4D4</Color>
+  <Color x:Key="neutral-400">#A1A1A1</Color>
+  <Color x:Key="neutral-500">#737373</Color>
+  <Color x:Key="neutral-600">#525252</Color>
+  <Color x:Key="neutral-700">#404040</Color>
+  <Color x:Key="neutral-800">#262626</Color>
+  <Color x:Key="neutral-900">#171717</Color>
+  <Color x:Key="neutral-950">#0A0A0A</Color>
+  <!-- stone -->
+  <Color x:Key="stone-50">#FAFAF9</Color>
+  <Color x:Key="stone-100">#F5F5F4</Color>
+  <Color x:Key="stone-200">#E7E5E4</Color>
+  <Color x:Key="stone-300">#D6D3D1</Color>
+  <Color x:Key="stone-400">#A6A09B</Color>
+  <Color x:Key="stone-500">#79716B</Color>
+  <Color x:Key="stone-600">#57534D</Color>
+  <Color x:Key="stone-700">#44403B</Color>
+  <Color x:Key="stone-800">#292524</Color>
+  <Color x:Key="stone-900">#1C1917</Color>
+  <Color x:Key="stone-950">#0C0A09</Color>
 
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Light">
-      <Color x:Key="EditorColor.Primary">#0D6EFD</Color>
-      <Color x:Key="EditorColor.PrimaryLow">#CFE2FF</Color>
-      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>
-      <Color x:Key="EditorColor.Danger">#DC3545</Color>
-      <Color x:Key="EditorColor.DangerHover">#B02A37</Color>
-      <Color x:Key="EditorColor.DangerPressed">#842029</Color>
-      <Color x:Key="EditorColor.DangerText">#DC3545</Color>
-      <Color x:Key="EditorColor.Warning">#997404</Color>
-      <Color x:Key="EditorColor.SurfacePanel">#F8F9FA</Color>
-      <Color x:Key="EditorColor.SurfaceDivider">#DEE2E6</Color>
-      <Color x:Key="EditorColor.SurfaceCard">#FFFFFF</Color>
-      <Color x:Key="EditorColor.SurfaceCardHover">#E9ECEF</Color>
-      <Color x:Key="EditorColor.SurfaceCardPressed">#DEE2E6</Color>
-      <Color x:Key="EditorColor.SurfacePreview">#E9ECEF</Color>
-      <Color x:Key="EditorColor.TextSubtle">#6C757D</Color>
-      <Color x:Key="EditorColor.TextDisabled">#8A9199</Color>
+      <Color x:Key="EditorColor.Primary">#155DFC</Color>  <!-- blue-600 -->
+      <Color x:Key="EditorColor.PrimaryLow">#DBEAFE</Color>  <!-- blue-100 -->
+      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>  <!-- white -->
+      <Color x:Key="EditorColor.Danger">#E7000B</Color>  <!-- red-600 -->
+      <Color x:Key="EditorColor.DangerHover">#C10007</Color>  <!-- red-700 -->
+      <Color x:Key="EditorColor.DangerPressed">#9F0712</Color>  <!-- red-800 -->
+      <Color x:Key="EditorColor.DangerText">#E7000B</Color>  <!-- red-600 -->
+      <Color x:Key="EditorColor.Warning">#BB4D00</Color>  <!-- amber-700 -->
+      <Color x:Key="EditorColor.SurfacePanel">#F8FAFC</Color>  <!-- slate-50 -->
+      <Color x:Key="EditorColor.SurfaceDivider">#E2E8F0</Color>  <!-- slate-200 -->
+      <Color x:Key="EditorColor.SurfaceCard">#FFFFFF</Color>  <!-- white -->
+      <Color x:Key="EditorColor.SurfaceCardHover">#F1F5F9</Color>  <!-- slate-100 -->
+      <Color x:Key="EditorColor.SurfaceCardPressed">#E2E8F0</Color>  <!-- slate-200 -->
+      <Color x:Key="EditorColor.SurfacePreview">#F1F5F9</Color>  <!-- slate-100 -->
+      <Color x:Key="EditorColor.TextSubtle">#62748E</Color>  <!-- slate-500 -->
+      <Color x:Key="EditorColor.TextDisabled">#90A1B9</Color>  <!-- slate-400 -->
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
-      <Color x:Key="EditorColor.Primary">#0D6EFD</Color>
-      <Color x:Key="EditorColor.PrimaryLow">#031633</Color>
-      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>
-      <Color x:Key="EditorColor.Danger">#DC3545</Color>
-      <Color x:Key="EditorColor.DangerHover">#E35D6A</Color>
-      <Color x:Key="EditorColor.DangerPressed">#B02A37</Color>
-      <Color x:Key="EditorColor.DangerText">#E35D6A</Color>
-      <Color x:Key="EditorColor.Warning">#FFC107</Color>
-      <Color x:Key="EditorColor.SurfacePanel">#212529</Color>
-      <Color x:Key="EditorColor.SurfaceDivider">#495057</Color>
-      <Color x:Key="EditorColor.SurfaceCard">#343A40</Color>
-      <Color x:Key="EditorColor.SurfaceCardHover">#495057</Color>
-      <Color x:Key="EditorColor.SurfaceCardPressed">#6C757D</Color>
-      <Color x:Key="EditorColor.SurfacePreview">#343A40</Color>
-      <Color x:Key="EditorColor.TextSubtle">#ADB5BD</Color>
-      <Color x:Key="EditorColor.TextDisabled">#6C757D</Color>
+      <Color x:Key="EditorColor.Primary">#2B7FFF</Color>  <!-- blue-500 -->
+      <Color x:Key="EditorColor.PrimaryLow">#162456</Color>  <!-- blue-950 -->
+      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>  <!-- white -->
+      <Color x:Key="EditorColor.Danger">#E7000B</Color>  <!-- red-600 -->
+      <Color x:Key="EditorColor.DangerHover">#FB2C36</Color>  <!-- red-500 -->
+      <Color x:Key="EditorColor.DangerPressed">#C10007</Color>  <!-- red-700 -->
+      <Color x:Key="EditorColor.DangerText">#FF6467</Color>  <!-- red-400 -->
+      <Color x:Key="EditorColor.Warning">#FFB900</Color>  <!-- amber-400 -->
+      <Color x:Key="EditorColor.SurfacePanel">#0F172B</Color>  <!-- slate-900 -->
+      <Color x:Key="EditorColor.SurfaceDivider">#314158</Color>  <!-- slate-700 -->
+      <Color x:Key="EditorColor.SurfaceCard">#1D293D</Color>  <!-- slate-800 -->
+      <Color x:Key="EditorColor.SurfaceCardHover">#314158</Color>  <!-- slate-700 -->
+      <Color x:Key="EditorColor.SurfaceCardPressed">#45556C</Color>  <!-- slate-600 -->
+      <Color x:Key="EditorColor.SurfacePreview">#1D293D</Color>  <!-- slate-800 -->
+      <Color x:Key="EditorColor.TextSubtle">#90A1B9</Color>  <!-- slate-400 -->
+      <Color x:Key="EditorColor.TextDisabled">#62748E</Color>  <!-- slate-500 -->
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
+  <!-- Semantic brushes: the public theming API used across the app. -->
   <SolidColorBrush x:Key="EditorBrush.Primary" Color="{DynamicResource EditorColor.Primary}" />
   <SolidColorBrush x:Key="EditorBrush.PrimaryLow" Color="{DynamicResource EditorColor.PrimaryLow}" />
   <SolidColorBrush x:Key="EditorBrush.OnPrimary" Color="{DynamicResource EditorColor.OnPrimary}" />
@@ -220,10 +332,9 @@
   <SolidColorBrush x:Key="EditorBrush.Text.Disabled" Color="{DynamicResource EditorColor.TextDisabled}" />
 
   <!--
-    Override FluentTheme's own CheckBox disabled-foreground keys so disabled
-    checkbox text uses our themed disabled color. These sit in Application.Resources
-    and therefore take precedence over the FluentTheme defaults regardless of the
-    per-state selector specificity Fluent applies internally.
+    Override FluentTheme's CheckBox disabled-foreground keys so disabled checkbox
+    text uses our themed disabled color. In Application.Resources these take
+    precedence over the FluentTheme defaults regardless of selector specificity.
   -->
   <SolidColorBrush x:Key="CheckBoxForegroundUncheckedDisabled" Color="{DynamicResource EditorColor.TextDisabled}" />
   <SolidColorBrush x:Key="CheckBoxForegroundCheckedDisabled" Color="{DynamicResource EditorColor.TextDisabled}" />

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -292,6 +292,10 @@
       <Color x:Key="EditorColor.TextSubtle">#62748E</Color>  <!-- slate-500 -->
       <Color x:Key="EditorColor.TextDisabled">#90A1B9</Color>  <!-- slate-400 -->
 
+      <!-- Editor canvas chrome: level-rect border + dashed grid lines over the backdrop. -->
+      <Color x:Key="EditorColor.CanvasBorder">#90A1B9</Color>  <!-- slate-400 -->
+      <Color x:Key="EditorColor.CanvasGrid">#28314158</Color>  <!-- slate-700 @ ~16% -->
+
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->
       <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="#BEDBFF" />     <!-- blue-200, selected -->
@@ -317,6 +321,10 @@
       <Color x:Key="EditorColor.SurfacePreview">#1D293D</Color>  <!-- slate-800 -->
       <Color x:Key="EditorColor.TextSubtle">#90A1B9</Color>  <!-- slate-400 -->
       <Color x:Key="EditorColor.TextDisabled">#62748E</Color>  <!-- slate-500 -->
+
+      <!-- Editor canvas chrome: level-rect border + dashed grid lines over the backdrop. -->
+      <Color x:Key="EditorColor.CanvasBorder">#45556C</Color>  <!-- slate-600 -->
+      <Color x:Key="EditorColor.CanvasGrid">#28CAD5E2</Color>  <!-- slate-300 @ ~16% -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Deep blues so the light row text stays readable. -->

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -291,6 +291,13 @@
       <Color x:Key="EditorColor.SurfacePreview">#F1F5F9</Color>  <!-- slate-100 -->
       <Color x:Key="EditorColor.TextSubtle">#62748E</Color>  <!-- slate-500 -->
       <Color x:Key="EditorColor.TextDisabled">#90A1B9</Color>  <!-- slate-400 -->
+
+      <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
+           Light tints so the dark row text stays readable. -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="#BEDBFF" />     <!-- blue-200, selected -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="#8EC5FF" />  <!-- blue-300, selected+hover -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="#51A2FF" />    <!-- blue-400, selected+pressed -->
+      <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="#155DFC" />            <!-- blue-600, selection indicator -->
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -310,6 +317,13 @@
       <Color x:Key="EditorColor.SurfacePreview">#1D293D</Color>  <!-- slate-800 -->
       <Color x:Key="EditorColor.TextSubtle">#90A1B9</Color>  <!-- slate-400 -->
       <Color x:Key="EditorColor.TextDisabled">#62748E</Color>  <!-- slate-500 -->
+
+      <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
+           Deep blues so the light row text stays readable. -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="#193CB8" />     <!-- blue-800, selected -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumBrush" Color="#1447E6" />  <!-- blue-700, selected+hover -->
+      <SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="#155DFC" />    <!-- blue-600, selected+pressed -->
+      <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="#2B7FFF" />            <!-- blue-500, selection indicator -->
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -337,7 +337,7 @@
 
       <!-- Editor overlay indicators (dashed). AAA (>=7:1) vs the slate-900 canvas backdrop. -->
       <Color x:Key="EditorColor.OverlayGrabRadius">#FF8904</Color>     <!-- orange-400, 7.50 -->
-      <Color x:Key="EditorColor.OverlayBulbRadius">#FE9A00</Color>     <!-- amber-500, 8.35 -->
+      <Color x:Key="EditorColor.OverlayBulbRadius">#FDC700</Color>     <!-- yellow-400, 12.98 -->
       <Color x:Key="EditorColor.OverlayHitboxDesktop">#7CCF00</Color>  <!-- lime-500, 9.15 -->
       <Color x:Key="EditorColor.OverlayHitboxPhone">#F4A8FF</Color>    <!-- fuchsia-300, 10.10 -->
       <Color x:Key="EditorColor.OverlayObjectLocked">#FFA2A2</Color>   <!-- red-300, 9.29 -->

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -296,6 +296,15 @@
       <Color x:Key="EditorColor.CanvasBorder">#90A1B9</Color>  <!-- slate-400 -->
       <Color x:Key="EditorColor.CanvasGrid">#28314158</Color>  <!-- slate-700 @ ~16% -->
 
+      <!-- Editor overlay indicators (dashed). AA (~5-6:1) vs the slate-50 canvas backdrop;
+           700 shades kept over stricter AAA so the hues stay tellable apart. -->
+      <Color x:Key="EditorColor.OverlayGrabRadius">#CA3500</Color>     <!-- orange-700, 4.99 -->
+      <Color x:Key="EditorColor.OverlayBulbRadius">#BB4D00</Color>     <!-- amber-700, 4.81 -->
+      <Color x:Key="EditorColor.OverlayHitboxDesktop">#497D00</Color>  <!-- lime-700, 4.76 -->
+      <Color x:Key="EditorColor.OverlayHitboxPhone">#A800B7</Color>    <!-- fuchsia-700, 5.99 -->
+      <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700, 6.14 -->
+      <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700, 5.60 -->
+
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->
       <SolidColorBrush x:Key="SystemControlHighlightListAccentLowBrush" Color="#BEDBFF" />     <!-- blue-200, selected -->
@@ -325,6 +334,14 @@
       <!-- Editor canvas chrome: level-rect border + dashed grid lines over the backdrop. -->
       <Color x:Key="EditorColor.CanvasBorder">#45556C</Color>  <!-- slate-600 -->
       <Color x:Key="EditorColor.CanvasGrid">#28CAD5E2</Color>  <!-- slate-300 @ ~16% -->
+
+      <!-- Editor overlay indicators (dashed). AAA (>=7:1) vs the slate-900 canvas backdrop. -->
+      <Color x:Key="EditorColor.OverlayGrabRadius">#FF8904</Color>     <!-- orange-400, 7.50 -->
+      <Color x:Key="EditorColor.OverlayBulbRadius">#FE9A00</Color>     <!-- amber-500, 8.35 -->
+      <Color x:Key="EditorColor.OverlayHitboxDesktop">#7CCF00</Color>  <!-- lime-500, 9.15 -->
+      <Color x:Key="EditorColor.OverlayHitboxPhone">#F4A8FF</Color>    <!-- fuchsia-300, 10.10 -->
+      <Color x:Key="EditorColor.OverlayObjectLocked">#FFA2A2</Color>   <!-- red-300, 9.29 -->
+      <Color x:Key="EditorColor.OverlayObjectSelected">#00BCFF</Color> <!-- sky-400, 8.18 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Deep blues so the light row text stays readable. -->

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -170,7 +170,8 @@
       <Color x:Key="EditorColor.Danger">#DC3545</Color>
       <Color x:Key="EditorColor.DangerHover">#B02A37</Color>
       <Color x:Key="EditorColor.DangerPressed">#842029</Color>
-      <Color x:Key="EditorColor.Warning">#FFC107</Color>
+      <Color x:Key="EditorColor.DangerText">#DC3545</Color>
+      <Color x:Key="EditorColor.Warning">#997404</Color>
       <Color x:Key="EditorColor.SurfacePanel">#F8F9FA</Color>
       <Color x:Key="EditorColor.SurfaceDivider">#DEE2E6</Color>
       <Color x:Key="EditorColor.SurfaceCard">#FFFFFF</Color>
@@ -178,7 +179,7 @@
       <Color x:Key="EditorColor.SurfaceCardPressed">#DEE2E6</Color>
       <Color x:Key="EditorColor.SurfacePreview">#E9ECEF</Color>
       <Color x:Key="EditorColor.TextSubtle">#6C757D</Color>
-      <Color x:Key="EditorColor.TextDisabled">#ADB5BD</Color>
+      <Color x:Key="EditorColor.TextDisabled">#8A9199</Color>
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -188,6 +189,7 @@
       <Color x:Key="EditorColor.Danger">#DC3545</Color>
       <Color x:Key="EditorColor.DangerHover">#E35D6A</Color>
       <Color x:Key="EditorColor.DangerPressed">#B02A37</Color>
+      <Color x:Key="EditorColor.DangerText">#E35D6A</Color>
       <Color x:Key="EditorColor.Warning">#FFC107</Color>
       <Color x:Key="EditorColor.SurfacePanel">#212529</Color>
       <Color x:Key="EditorColor.SurfaceDivider">#495057</Color>
@@ -204,6 +206,7 @@
   <SolidColorBrush x:Key="EditorBrush.PrimaryLow" Color="{DynamicResource EditorColor.PrimaryLow}" />
   <SolidColorBrush x:Key="EditorBrush.OnPrimary" Color="{DynamicResource EditorColor.OnPrimary}" />
   <SolidColorBrush x:Key="EditorBrush.Danger" Color="{DynamicResource EditorColor.Danger}" />
+  <SolidColorBrush x:Key="EditorBrush.DangerText" Color="{DynamicResource EditorColor.DangerText}" />
   <SolidColorBrush x:Key="EditorBrush.DangerHover" Color="{DynamicResource EditorColor.DangerHover}" />
   <SolidColorBrush x:Key="EditorBrush.DangerPressed" Color="{DynamicResource EditorColor.DangerPressed}" />
   <SolidColorBrush x:Key="EditorBrush.Warning" Color="{DynamicResource EditorColor.Warning}" />

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -178,6 +178,7 @@
       <Color x:Key="EditorColor.SurfaceCardPressed">#DEE2E6</Color>
       <Color x:Key="EditorColor.SurfacePreview">#E9ECEF</Color>
       <Color x:Key="EditorColor.TextSubtle">#6C757D</Color>
+      <Color x:Key="EditorColor.TextDisabled">#ADB5BD</Color>
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -195,6 +196,7 @@
       <Color x:Key="EditorColor.SurfaceCardPressed">#6C757D</Color>
       <Color x:Key="EditorColor.SurfacePreview">#343A40</Color>
       <Color x:Key="EditorColor.TextSubtle">#ADB5BD</Color>
+      <Color x:Key="EditorColor.TextDisabled">#6C757D</Color>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
@@ -212,4 +214,15 @@
   <SolidColorBrush x:Key="EditorBrush.Surface.CardPressed" Color="{DynamicResource EditorColor.SurfaceCardPressed}" />
   <SolidColorBrush x:Key="EditorBrush.Surface.Preview" Color="{DynamicResource EditorColor.SurfacePreview}" />
   <SolidColorBrush x:Key="EditorBrush.Text.Subtle" Color="{DynamicResource EditorColor.TextSubtle}" />
+  <SolidColorBrush x:Key="EditorBrush.Text.Disabled" Color="{DynamicResource EditorColor.TextDisabled}" />
+
+  <!--
+    Override FluentTheme's own CheckBox disabled-foreground keys so disabled
+    checkbox text uses our themed disabled color. These sit in Application.Resources
+    and therefore take precedence over the FluentTheme defaults regardless of the
+    per-state selector specificity Fluent applies internally.
+  -->
+  <SolidColorBrush x:Key="CheckBoxForegroundUncheckedDisabled" Color="{DynamicResource EditorColor.TextDisabled}" />
+  <SolidColorBrush x:Key="CheckBoxForegroundCheckedDisabled" Color="{DynamicResource EditorColor.TextDisabled}" />
+  <SolidColorBrush x:Key="CheckBoxForegroundIndeterminateDisabled" Color="{DynamicResource EditorColor.TextDisabled}" />
 </ResourceDictionary>

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -1,0 +1,215 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!-- Bootstrap 5.3 color tokens -->
+  <Color x:Key="white">#FFFFFF</Color>
+  <Color x:Key="black">#000000</Color>
+
+  <Color x:Key="gray-100">#F8F9FA</Color>
+  <Color x:Key="gray-200">#E9ECEF</Color>
+  <Color x:Key="gray-300">#DEE2E6</Color>
+  <Color x:Key="gray-400">#CED4DA</Color>
+  <Color x:Key="gray-500">#ADB5BD</Color>
+  <Color x:Key="gray-600">#6C757D</Color>
+  <Color x:Key="gray-700">#495057</Color>
+  <Color x:Key="gray-800">#343A40</Color>
+  <Color x:Key="gray-900">#212529</Color>
+  <Color x:Key="gray">#6C757D</Color>
+  <Color x:Key="gray-dark">#343A40</Color>
+
+  <Color x:Key="blue">#0D6EFD</Color>
+  <Color x:Key="blue-100">#CFE2FF</Color>
+  <Color x:Key="blue-200">#9EC5FE</Color>
+  <Color x:Key="blue-300">#6EA8FE</Color>
+  <Color x:Key="blue-400">#3D8BFD</Color>
+  <Color x:Key="blue-500">#0D6EFD</Color>
+  <Color x:Key="blue-600">#0A58CA</Color>
+  <Color x:Key="blue-700">#084298</Color>
+  <Color x:Key="blue-800">#052C65</Color>
+  <Color x:Key="blue-900">#031633</Color>
+
+  <Color x:Key="indigo">#6610F2</Color>
+  <Color x:Key="indigo-100">#E0CFFC</Color>
+  <Color x:Key="indigo-200">#C29FFA</Color>
+  <Color x:Key="indigo-300">#A370F7</Color>
+  <Color x:Key="indigo-400">#8540F5</Color>
+  <Color x:Key="indigo-500">#6610F2</Color>
+  <Color x:Key="indigo-600">#520DC2</Color>
+  <Color x:Key="indigo-700">#3D0A91</Color>
+  <Color x:Key="indigo-800">#290661</Color>
+  <Color x:Key="indigo-900">#140330</Color>
+
+  <Color x:Key="purple">#6F42C1</Color>
+  <Color x:Key="purple-100">#E2D9F3</Color>
+  <Color x:Key="purple-200">#C5B3E6</Color>
+  <Color x:Key="purple-300">#A98EDA</Color>
+  <Color x:Key="purple-400">#8C68CD</Color>
+  <Color x:Key="purple-500">#6F42C1</Color>
+  <Color x:Key="purple-600">#59359A</Color>
+  <Color x:Key="purple-700">#432874</Color>
+  <Color x:Key="purple-800">#2C1A4D</Color>
+  <Color x:Key="purple-900">#160D27</Color>
+
+  <Color x:Key="pink">#D63384</Color>
+  <Color x:Key="pink-100">#F7D6E6</Color>
+  <Color x:Key="pink-200">#EFADCE</Color>
+  <Color x:Key="pink-300">#E685B5</Color>
+  <Color x:Key="pink-400">#DE5C9D</Color>
+  <Color x:Key="pink-500">#D63384</Color>
+  <Color x:Key="pink-600">#AB296A</Color>
+  <Color x:Key="pink-700">#801F4F</Color>
+  <Color x:Key="pink-800">#561435</Color>
+  <Color x:Key="pink-900">#2B0A1A</Color>
+
+  <Color x:Key="red">#DC3545</Color>
+  <Color x:Key="red-100">#F8D7DA</Color>
+  <Color x:Key="red-200">#F1AEB5</Color>
+  <Color x:Key="red-300">#EA868F</Color>
+  <Color x:Key="red-400">#E35D6A</Color>
+  <Color x:Key="red-500">#DC3545</Color>
+  <Color x:Key="red-600">#B02A37</Color>
+  <Color x:Key="red-700">#842029</Color>
+  <Color x:Key="red-800">#58151C</Color>
+  <Color x:Key="red-900">#2C0B0E</Color>
+
+  <Color x:Key="orange">#FD7E14</Color>
+  <Color x:Key="orange-100">#FFE5D0</Color>
+  <Color x:Key="orange-200">#FECBA1</Color>
+  <Color x:Key="orange-300">#FEB272</Color>
+  <Color x:Key="orange-400">#FD9843</Color>
+  <Color x:Key="orange-500">#FD7E14</Color>
+  <Color x:Key="orange-600">#CA6510</Color>
+  <Color x:Key="orange-700">#984C0C</Color>
+  <Color x:Key="orange-800">#653208</Color>
+  <Color x:Key="orange-900">#331904</Color>
+
+  <Color x:Key="yellow">#FFC107</Color>
+  <Color x:Key="yellow-100">#FFF3CD</Color>
+  <Color x:Key="yellow-200">#FFE69C</Color>
+  <Color x:Key="yellow-300">#FFDA6A</Color>
+  <Color x:Key="yellow-400">#FFCD39</Color>
+  <Color x:Key="yellow-500">#FFC107</Color>
+  <Color x:Key="yellow-600">#CC9A06</Color>
+  <Color x:Key="yellow-700">#997404</Color>
+  <Color x:Key="yellow-800">#664D03</Color>
+  <Color x:Key="yellow-900">#332701</Color>
+
+  <Color x:Key="green">#198754</Color>
+  <Color x:Key="green-100">#D1E7DD</Color>
+  <Color x:Key="green-200">#A3CFBB</Color>
+  <Color x:Key="green-300">#75B798</Color>
+  <Color x:Key="green-400">#479F76</Color>
+  <Color x:Key="green-500">#198754</Color>
+  <Color x:Key="green-600">#146C43</Color>
+  <Color x:Key="green-700">#0F5132</Color>
+  <Color x:Key="green-800">#0A3622</Color>
+  <Color x:Key="green-900">#051B11</Color>
+
+  <Color x:Key="teal">#20C997</Color>
+  <Color x:Key="teal-100">#D2F4EA</Color>
+  <Color x:Key="teal-200">#A6E9D5</Color>
+  <Color x:Key="teal-300">#79DFC1</Color>
+  <Color x:Key="teal-400">#4DD4AC</Color>
+  <Color x:Key="teal-500">#20C997</Color>
+  <Color x:Key="teal-600">#1AA179</Color>
+  <Color x:Key="teal-700">#13795B</Color>
+  <Color x:Key="teal-800">#0D503C</Color>
+  <Color x:Key="teal-900">#06281E</Color>
+
+  <Color x:Key="cyan">#0DCAF0</Color>
+  <Color x:Key="cyan-100">#CFF4FC</Color>
+  <Color x:Key="cyan-200">#9EEAF9</Color>
+  <Color x:Key="cyan-300">#6EDFF6</Color>
+  <Color x:Key="cyan-400">#3DD5F3</Color>
+  <Color x:Key="cyan-500">#0DCAF0</Color>
+  <Color x:Key="cyan-600">#0AA2C0</Color>
+  <Color x:Key="cyan-700">#087990</Color>
+  <Color x:Key="cyan-800">#055160</Color>
+  <Color x:Key="cyan-900">#032830</Color>
+
+  <Color x:Key="primary">#0D6EFD</Color>
+  <Color x:Key="secondary">#6C757D</Color>
+  <Color x:Key="success">#198754</Color>
+  <Color x:Key="info">#0DCAF0</Color>
+  <Color x:Key="warning">#FFC107</Color>
+  <Color x:Key="danger">#DC3545</Color>
+  <Color x:Key="light">#F8F9FA</Color>
+  <Color x:Key="dark">#212529</Color>
+
+  <!-- Brush shorthands for direct UI use. -->
+  <SolidColorBrush x:Key="Brush.white" Color="{StaticResource white}" />
+  <SolidColorBrush x:Key="Brush.black" Color="{StaticResource black}" />
+  <SolidColorBrush x:Key="Brush.blue-100" Color="{StaticResource blue-100}" />
+  <SolidColorBrush x:Key="Brush.blue-500" Color="{StaticResource blue-500}" />
+  <SolidColorBrush x:Key="Brush.blue-600" Color="{StaticResource blue-600}" />
+  <SolidColorBrush x:Key="Brush.red-500" Color="{StaticResource red-500}" />
+  <SolidColorBrush x:Key="Brush.red-600" Color="{StaticResource red-600}" />
+  <SolidColorBrush x:Key="Brush.red-700" Color="{StaticResource red-700}" />
+  <SolidColorBrush x:Key="Brush.yellow-500" Color="{StaticResource yellow-500}" />
+  <SolidColorBrush x:Key="Brush.gray-100" Color="{StaticResource gray-100}" />
+  <SolidColorBrush x:Key="Brush.gray-200" Color="{StaticResource gray-200}" />
+  <SolidColorBrush x:Key="Brush.gray-300" Color="{StaticResource gray-300}" />
+  <SolidColorBrush x:Key="Brush.gray-500" Color="{StaticResource gray-500}" />
+  <SolidColorBrush x:Key="Brush.gray-600" Color="{StaticResource gray-600}" />
+  <SolidColorBrush x:Key="Brush.gray-700" Color="{StaticResource gray-700}" />
+  <SolidColorBrush x:Key="Brush.gray-800" Color="{StaticResource gray-800}" />
+  <SolidColorBrush x:Key="Brush.gray-900" Color="{StaticResource gray-900}" />
+  <SolidColorBrush x:Key="Brush.primary" Color="{StaticResource primary}" />
+  <SolidColorBrush x:Key="Brush.secondary" Color="{StaticResource secondary}" />
+  <SolidColorBrush x:Key="Brush.success" Color="{StaticResource success}" />
+  <SolidColorBrush x:Key="Brush.info" Color="{StaticResource info}" />
+  <SolidColorBrush x:Key="Brush.warning" Color="{StaticResource warning}" />
+  <SolidColorBrush x:Key="Brush.danger" Color="{StaticResource danger}" />
+  <SolidColorBrush x:Key="Brush.light" Color="{StaticResource light}" />
+  <SolidColorBrush x:Key="Brush.dark" Color="{StaticResource dark}" />
+
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Light">
+      <Color x:Key="EditorColor.Primary">#0D6EFD</Color>
+      <Color x:Key="EditorColor.PrimaryLow">#CFE2FF</Color>
+      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>
+      <Color x:Key="EditorColor.Danger">#DC3545</Color>
+      <Color x:Key="EditorColor.DangerHover">#B02A37</Color>
+      <Color x:Key="EditorColor.DangerPressed">#842029</Color>
+      <Color x:Key="EditorColor.Warning">#FFC107</Color>
+      <Color x:Key="EditorColor.SurfacePanel">#F8F9FA</Color>
+      <Color x:Key="EditorColor.SurfaceDivider">#DEE2E6</Color>
+      <Color x:Key="EditorColor.SurfaceCard">#FFFFFF</Color>
+      <Color x:Key="EditorColor.SurfaceCardHover">#E9ECEF</Color>
+      <Color x:Key="EditorColor.SurfaceCardPressed">#DEE2E6</Color>
+      <Color x:Key="EditorColor.SurfacePreview">#E9ECEF</Color>
+      <Color x:Key="EditorColor.TextSubtle">#6C757D</Color>
+    </ResourceDictionary>
+
+    <ResourceDictionary x:Key="Dark">
+      <Color x:Key="EditorColor.Primary">#0D6EFD</Color>
+      <Color x:Key="EditorColor.PrimaryLow">#031633</Color>
+      <Color x:Key="EditorColor.OnPrimary">#FFFFFF</Color>
+      <Color x:Key="EditorColor.Danger">#DC3545</Color>
+      <Color x:Key="EditorColor.DangerHover">#E35D6A</Color>
+      <Color x:Key="EditorColor.DangerPressed">#B02A37</Color>
+      <Color x:Key="EditorColor.Warning">#FFC107</Color>
+      <Color x:Key="EditorColor.SurfacePanel">#212529</Color>
+      <Color x:Key="EditorColor.SurfaceDivider">#495057</Color>
+      <Color x:Key="EditorColor.SurfaceCard">#343A40</Color>
+      <Color x:Key="EditorColor.SurfaceCardHover">#495057</Color>
+      <Color x:Key="EditorColor.SurfaceCardPressed">#6C757D</Color>
+      <Color x:Key="EditorColor.SurfacePreview">#343A40</Color>
+      <Color x:Key="EditorColor.TextSubtle">#ADB5BD</Color>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
+
+  <SolidColorBrush x:Key="EditorBrush.Primary" Color="{DynamicResource EditorColor.Primary}" />
+  <SolidColorBrush x:Key="EditorBrush.PrimaryLow" Color="{DynamicResource EditorColor.PrimaryLow}" />
+  <SolidColorBrush x:Key="EditorBrush.OnPrimary" Color="{DynamicResource EditorColor.OnPrimary}" />
+  <SolidColorBrush x:Key="EditorBrush.Danger" Color="{DynamicResource EditorColor.Danger}" />
+  <SolidColorBrush x:Key="EditorBrush.DangerHover" Color="{DynamicResource EditorColor.DangerHover}" />
+  <SolidColorBrush x:Key="EditorBrush.DangerPressed" Color="{DynamicResource EditorColor.DangerPressed}" />
+  <SolidColorBrush x:Key="EditorBrush.Warning" Color="{DynamicResource EditorColor.Warning}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.Panel" Color="{DynamicResource EditorColor.SurfacePanel}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.Divider" Color="{DynamicResource EditorColor.SurfaceDivider}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.Card" Color="{DynamicResource EditorColor.SurfaceCard}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.CardHover" Color="{DynamicResource EditorColor.SurfaceCardHover}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.CardPressed" Color="{DynamicResource EditorColor.SurfaceCardPressed}" />
+  <SolidColorBrush x:Key="EditorBrush.Surface.Preview" Color="{DynamicResource EditorColor.SurfacePreview}" />
+  <SolidColorBrush x:Key="EditorBrush.Text.Subtle" Color="{DynamicResource EditorColor.TextSubtle}" />
+</ResourceDictionary>

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -296,14 +296,13 @@
       <Color x:Key="EditorColor.CanvasBorder">#90A1B9</Color>  <!-- slate-400 -->
       <Color x:Key="EditorColor.CanvasGrid">#28314158</Color>  <!-- slate-700 @ ~16% -->
 
-      <!-- Editor overlay indicators (dashed). AA (~5-6:1) vs the slate-50 canvas backdrop;
-           700 shades kept over stricter AAA so the hues stay tellable apart. -->
-      <Color x:Key="EditorColor.OverlayGrabRadius">#CA3500</Color>     <!-- orange-700, 4.99 -->
-      <Color x:Key="EditorColor.OverlayBulbRadius">#BB4D00</Color>     <!-- amber-700, 4.81 -->
-      <Color x:Key="EditorColor.OverlayHitboxDesktop">#497D00</Color>  <!-- lime-700, 4.76 -->
-      <Color x:Key="EditorColor.OverlayHitboxPhone">#A800B7</Color>    <!-- fuchsia-700, 5.99 -->
-      <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700, 6.14 -->
-      <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700, 5.60 -->
+      <!-- Editor overlay indicators (dashed) -->
+      <Color x:Key="EditorColor.OverlayGrabRadius">#CA3500</Color>     <!-- orange-700 -->
+      <Color x:Key="EditorColor.OverlayBulbRadius">#BB4D00</Color>     <!-- amber-700 -->
+      <Color x:Key="EditorColor.OverlayHitboxDesktop">#497D00</Color>  <!-- lime-700 -->
+      <Color x:Key="EditorColor.OverlayHitboxPhone">#A800B7</Color>    <!-- fuchsia-700 -->
+      <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700 -->
+      <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->

--- a/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/ConfirmDialog.axaml
@@ -4,23 +4,6 @@
              x:Class="CtrDxEditor.Views.ConfirmDialog"
              x:CompileBindings="True"
              x:DataType="views:ConfirmDialog">
-  <UserControl.Styles>
-    <Style Selector="Button.danger">
-      <Setter Property="Background" Value="#C42B1C" />
-      <Setter Property="BorderBrush" Value="#C42B1C" />
-      <Setter Property="Foreground" Value="White" />
-    </Style>
-    <Style Selector="Button.danger:pointerover">
-      <Setter Property="Background" Value="#D83B2D" />
-      <Setter Property="BorderBrush" Value="#D83B2D" />
-      <Setter Property="Foreground" Value="White" />
-    </Style>
-    <Style Selector="Button.danger:pressed">
-      <Setter Property="Background" Value="#A4261D" />
-      <Setter Property="BorderBrush" Value="#A4261D" />
-      <Setter Property="Foreground" Value="White" />
-    </Style>
-  </UserControl.Styles>
   <StackPanel Margin="24" Spacing="16" Width="380">
     <TextBlock FontSize="18" FontWeight="SemiBold" Text="{Binding Header}" />
     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />

--- a/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
@@ -27,26 +27,26 @@
 
     <!-- Base card surface. -->
     <Style Selector="RadioButton.PickerCard Border.card-surface">
-      <Setter Property="Background" Value="#14FFFFFF" />
-      <Setter Property="BorderBrush" Value="#22FFFFFF" />
+      <Setter Property="Background" Value="{DynamicResource EditorBrush.Surface.Card}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.Surface.Divider}" />
       <Setter Property="BorderThickness" Value="1" />
     </Style>
 
     <!-- Hover state. -->
     <Style Selector="RadioButton.PickerCard:pointerover Border.card-surface">
-      <Setter Property="Background" Value="#20FFFFFF" />
-      <Setter Property="BorderBrush" Value="#55FFFFFF" />
+      <Setter Property="Background" Value="{DynamicResource EditorBrush.Surface.CardHover}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.Primary}" />
     </Style>
 
     <!-- Pressed state. -->
     <Style Selector="RadioButton.PickerCard:pressed Border.card-surface">
-      <Setter Property="Background" Value="#28FFFFFF" />
+      <Setter Property="Background" Value="{DynamicResource EditorBrush.Surface.CardPressed}" />
     </Style>
 
     <!-- Selected state. -->
     <Style Selector="RadioButton.PickerCard:checked Border.card-surface">
-      <Setter Property="Background" Value="#220078D7" />
-      <Setter Property="BorderBrush" Value="#FF0078D7" />
+      <Setter Property="Background" Value="{DynamicResource EditorBrush.PrimaryLow}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource EditorBrush.Primary}" />
       <Setter Property="BorderThickness" Value="2" />
     </Style>
 
@@ -121,7 +121,7 @@
             <TextBlock Grid.Row="1"
                        Grid.Column="0"
                        Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="#E06C75"
+                       Foreground="{DynamicResource EditorBrush.Danger}"
                        FontSize="12"
                        Margin="0,2,0,0"
                        IsVisible="{Binding CustomWidth, Converter={x:Static ObjectConverters.IsNull}}" />
@@ -129,7 +129,7 @@
             <TextBlock Grid.Row="1"
                        Grid.Column="2"
                        Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="#E06C75"
+                       Foreground="{DynamicResource EditorBrush.Danger}"
                        FontSize="12"
                        Margin="0,2,0,0"
                        IsVisible="{Binding CustomHeight, Converter={x:Static ObjectConverters.IsNull}}" />
@@ -147,7 +147,7 @@
                          Value="{Binding RopePhysicsSpeed, Mode=TwoWay}" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                     Foreground="#E06C75"
+                     Foreground="{DynamicResource EditorBrush.Danger}"
                      FontSize="12"
                      IsVisible="{Binding RopePhysicsSpeed, Converter={x:Static ObjectConverters.IsNull}}" />
         </StackPanel>
@@ -177,7 +177,7 @@
                            Value="{Binding CustomSpecial, Mode=TwoWay}" />
 
             <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="#E06C75"
+                       Foreground="{DynamicResource EditorBrush.Danger}"
                        FontSize="12"
                        IsVisible="{Binding CustomSpecial, Converter={x:Static ObjectConverters.IsNull}}" />
           </StackPanel>
@@ -222,7 +222,7 @@
         <StackPanel Spacing="8">
 
           <Border Height="1"
-                  Background="#22FFFFFF"
+                  Background="{DynamicResource EditorBrush.Surface.Divider}"
                   Margin="0,8,0,4" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.CustomizationOptions}"
@@ -258,7 +258,7 @@
                             <Border Classes="preview-frame"
                                     Height="36"
                                     CornerRadius="7"
-                                    Background="#252525"
+                                    Background="{DynamicResource EditorBrush.Surface.Preview}"
                                     ClipToBounds="True">
                               <Panel>
                                 <ctrl:RopeSwatch Width="76"
@@ -270,7 +270,7 @@
                                 <icons:MaterialIcon Kind="DiceMultiple"
                                                     Width="24"
                                                     Height="24"
-                                                    Foreground="#B0B0B0"
+                                                    Foreground="{DynamicResource EditorBrush.Text.Subtle}"
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     IsVisible="{Binding IsRandom}" />
@@ -293,12 +293,12 @@
                                 Width="20"
                                 Height="20"
                                 CornerRadius="10"
-                                Background="#FF0078D7"
+                                Background="{DynamicResource EditorBrush.Primary}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Top"
                                 Margin="0,-4,-4,0">
                           <TextBlock Text="✓"
-                                     Foreground="White"
+                                     Foreground="{DynamicResource EditorBrush.OnPrimary}"
                                      FontSize="12"
                                      FontWeight="Bold"
                                      HorizontalAlignment="Center"
@@ -338,7 +338,7 @@
 
                             <Border Classes="preview-frame"
                                     Height="72"
-                                    Background="#222"
+                                    Background="{DynamicResource EditorBrush.Surface.Preview}"
                                     ClipToBounds="True"
                                     CornerRadius="7"
                                     HorizontalAlignment="Stretch">
@@ -349,7 +349,7 @@
                                 <icons:MaterialIcon Kind="DiceMultiple"
                                                     Width="32"
                                                     Height="32"
-                                                    Foreground="#B0B0B0"
+                                                    Foreground="{DynamicResource EditorBrush.Text.Subtle}"
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     IsVisible="{Binding IsRandom}" />
@@ -372,12 +372,12 @@
                                 Width="20"
                                 Height="20"
                                 CornerRadius="10"
-                                Background="#FF0078D7"
+                                Background="{DynamicResource EditorBrush.Primary}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Top"
                                 Margin="0,-4,-4,0">
                           <TextBlock Text="✓"
-                                     Foreground="White"
+                                     Foreground="{DynamicResource EditorBrush.OnPrimary}"
                                      FontSize="12"
                                      FontWeight="Bold"
                                      HorizontalAlignment="Center"
@@ -418,7 +418,7 @@
                             <Border Classes="preview-frame"
                                     Height="60"
                                     CornerRadius="7"
-                                    Background="#252525"
+                                    Background="{DynamicResource EditorBrush.Surface.Preview}"
                                     ClipToBounds="True">
                               <Panel>
                                 <Image Source="{Binding Thumbnail}"
@@ -428,7 +428,7 @@
                                 <icons:MaterialIcon Kind="DiceMultiple"
                                                     Width="28"
                                                     Height="28"
-                                                    Foreground="#B0B0B0"
+                                                    Foreground="{DynamicResource EditorBrush.Text.Subtle}"
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     IsVisible="{Binding IsRandom}" />
@@ -451,12 +451,12 @@
                                 Width="20"
                                 Height="20"
                                 CornerRadius="10"
-                                Background="#FF0078D7"
+                                Background="{DynamicResource EditorBrush.Primary}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Top"
                                 Margin="0,-4,-4,0">
                           <TextBlock Text="✓"
-                                     Foreground="White"
+                                     Foreground="{DynamicResource EditorBrush.OnPrimary}"
                                      FontSize="12"
                                      FontWeight="Bold"
                                      HorizontalAlignment="Center"
@@ -497,7 +497,7 @@
                             <Border Classes="preview-frame"
                                     Height="60"
                                     CornerRadius="7"
-                                    Background="#252525"
+                                    Background="{DynamicResource EditorBrush.Surface.Preview}"
                                     ClipToBounds="True">
                               <Panel>
                                 <Image Source="{Binding Thumbnail}"
@@ -507,7 +507,7 @@
                                 <icons:MaterialIcon Kind="DiceMultiple"
                                                     Width="28"
                                                     Height="28"
-                                                    Foreground="#B0B0B0"
+                                                    Foreground="{DynamicResource EditorBrush.Text.Subtle}"
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center"
                                                     IsVisible="{Binding IsRandom}" />
@@ -530,12 +530,12 @@
                                 Width="20"
                                 Height="20"
                                 CornerRadius="10"
-                                Background="#FF0078D7"
+                                Background="{DynamicResource EditorBrush.Primary}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Top"
                                 Margin="0,-4,-4,0">
                           <TextBlock Text="✓"
-                                     Foreground="White"
+                                     Foreground="{DynamicResource EditorBrush.OnPrimary}"
                                      FontSize="12"
                                      FontWeight="Bold"
                                      HorizontalAlignment="Center"

--- a/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
@@ -121,7 +121,7 @@
             <TextBlock Grid.Row="1"
                        Grid.Column="0"
                        Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="{DynamicResource EditorBrush.Danger}"
+                       Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
                        Margin="0,2,0,0"
                        IsVisible="{Binding CustomWidth, Converter={x:Static ObjectConverters.IsNull}}" />
@@ -129,7 +129,7 @@
             <TextBlock Grid.Row="1"
                        Grid.Column="2"
                        Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="{DynamicResource EditorBrush.Danger}"
+                       Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
                        Margin="0,2,0,0"
                        IsVisible="{Binding CustomHeight, Converter={x:Static ObjectConverters.IsNull}}" />
@@ -147,7 +147,7 @@
                          Value="{Binding RopePhysicsSpeed, Mode=TwoWay}" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                     Foreground="{DynamicResource EditorBrush.Danger}"
+                     Foreground="{DynamicResource EditorBrush.DangerText}"
                      FontSize="12"
                      IsVisible="{Binding RopePhysicsSpeed, Converter={x:Static ObjectConverters.IsNull}}" />
         </StackPanel>
@@ -177,7 +177,7 @@
                            Value="{Binding CustomSpecial, Mode=TwoWay}" />
 
             <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
-                       Foreground="{DynamicResource EditorBrush.Danger}"
+                       Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
                        IsVisible="{Binding CustomSpecial, Converter={x:Static ObjectConverters.IsNull}}" />
           </StackPanel>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -130,7 +130,7 @@
       </MenuItem>
     </Menu>
     <Grid ColumnDefinitions="160,*,280">
-      <Border Grid.Column="0" Background="#202329">
+      <Border Grid.Column="0" Background="{DynamicResource EditorBrush.Surface.Panel}">
         <ItemsControl x:Name="PaletteList" ItemsSource="{Binding Palette}" Margin="6,6,6,10">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
@@ -178,9 +178,9 @@
                    ViewportSize="{Binding #Canvas.HorizontalScrollViewport}"
                    SmallChange="48"
                    LargeChange="{Binding #Canvas.HorizontalScrollViewport}" />
-        <Border Grid.Row="1" Grid.Column="1" Background="#202329" />
+        <Border Grid.Row="1" Grid.Column="1" Background="{DynamicResource EditorBrush.Surface.Panel}" />
       </Grid>
-      <Grid Grid.Column="2" Background="#202329" RowDefinitions="Auto,2*,Auto,3*">
+      <Grid Grid.Column="2" Background="{DynamicResource EditorBrush.Surface.Panel}" RowDefinitions="Auto,2*,Auto,3*">
         <TextBlock Grid.Row="0" Text="{loc:Tr Panel.Objects}" FontWeight="Bold" Margin="8,8,8,4" />
         <ListBox Grid.Row="1" Margin="4,0,4,4" x:Name="ObjectsListBox"
                  ItemsSource="{Binding ObjectList}"
@@ -205,7 +205,7 @@
                 <TextBlock Grid.Column="0" VerticalAlignment="Center"
                            Text="{Binding Type, Converter={x:Static loc:ObjectNameConverter.Instance}}" />
                 <icons:MaterialIcon Grid.Column="1" Kind="Lock" Width="14" Height="14"
-                                    Margin="6,0,0,0" Foreground="Goldenrod">
+                                    Margin="6,0,0,0" Foreground="{DynamicResource EditorBrush.Warning}">
                   <icons:MaterialIcon.IsVisible>
                     <MultiBinding Converter="{x:Static conv:ObjectEqualsConverter.Instance}">
                       <Binding Path="." />
@@ -217,7 +217,7 @@
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
-        <Border Grid.Row="2" Height="1" Background="#3A3F47" Margin="4,0" />
+        <Border Grid.Row="2" Height="1" Background="{DynamicResource EditorBrush.Surface.Divider}" Margin="4,0" />
         <views:PropertyPanel Grid.Row="3" />
       </Grid>
     </Grid>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -129,7 +129,7 @@
         </MenuItem>
       </MenuItem>
     </Menu>
-    <Grid ColumnDefinitions="160,*,280">
+    <Grid ColumnDefinitions="160,1,*,1,280">
       <Border Grid.Column="0" Background="{DynamicResource EditorBrush.Surface.Panel}">
         <ItemsControl x:Name="PaletteList" ItemsSource="{Binding Palette}" Margin="6,6,6,10">
           <ItemsControl.ItemTemplate>
@@ -147,7 +147,8 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
       </Border>
-      <Grid Grid.Column="1" RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">
+      <Border Grid.Column="1" Background="{DynamicResource EditorBrush.Surface.Divider}" />
+      <Grid Grid.Column="2" RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">
         <render:LevelCanvas Grid.Row="0" Grid.Column="0" x:Name="Canvas" Focusable="True"
                             ClipToBounds="True"
                             Document="{Binding Document}"
@@ -180,7 +181,8 @@
                    LargeChange="{Binding #Canvas.HorizontalScrollViewport}" />
         <Border Grid.Row="1" Grid.Column="1" Background="{DynamicResource EditorBrush.Surface.Panel}" />
       </Grid>
-      <Grid Grid.Column="2" Background="{DynamicResource EditorBrush.Surface.Panel}" RowDefinitions="Auto,2*,Auto,3*">
+      <Border Grid.Column="3" Background="{DynamicResource EditorBrush.Surface.Divider}" />
+      <Grid Grid.Column="4" Background="{DynamicResource EditorBrush.Surface.Panel}" RowDefinitions="Auto,2*,Auto,3*">
         <TextBlock Grid.Row="0" Text="{loc:Tr Panel.Objects}" FontWeight="Bold" Margin="8,8,8,4" />
         <ListBox Grid.Row="1" Margin="4,0,4,4" x:Name="ObjectsListBox"
                  Background="Transparent"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -183,6 +183,7 @@
       <Grid Grid.Column="2" Background="{DynamicResource EditorBrush.Surface.Panel}" RowDefinitions="Auto,2*,Auto,3*">
         <TextBlock Grid.Row="0" Text="{loc:Tr Panel.Objects}" FontWeight="Bold" Margin="8,8,8,4" />
         <ListBox Grid.Row="1" Margin="4,0,4,4" x:Name="ObjectsListBox"
+                 Background="Transparent"
                  ItemsSource="{Binding ObjectList}"
                  SelectedItem="{Binding SelectedObject, Mode=TwoWay}"
                  DoubleTapped="ObjectList_DoubleTapped">

--- a/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
@@ -6,7 +6,7 @@
              x:CompileBindings="True"
              x:DataType="views:MessageDialog">
   <StackPanel Margin="24" Spacing="16" Width="460">
-    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="#E06C75" Text="{Binding Header}" />
+    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource EditorBrush.Danger}" Text="{Binding Header}" />
     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
     <Button Content="{loc:Tr Dialog.Common.Ok}" Click="Ok_Click" HorizontalAlignment="Right" />
   </StackPanel>

--- a/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
@@ -6,7 +6,7 @@
              x:CompileBindings="True"
              x:DataType="views:MessageDialog">
   <StackPanel Margin="24" Spacing="16" Width="460">
-    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource EditorBrush.Danger}" Text="{Binding Header}" />
+    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource EditorBrush.DangerText}" Text="{Binding Header}" />
     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
     <Button Content="{loc:Tr Dialog.Common.Ok}" Click="Ok_Click" HorizontalAlignment="Right" />
   </StackPanel>

--- a/src/CtrDxEditor.Shared/Views/PropertyPanel.axaml
+++ b/src/CtrDxEditor.Shared/Views/PropertyPanel.axaml
@@ -6,6 +6,12 @@
              xmlns:loc="using:CtrDxEditor.Localization"
              x:Class="CtrDxEditor.Views.PropertyPanel"
              x:DataType="vm:EditorViewModel">
+  <UserControl.Styles>
+    <!-- Dim a property field's label when the field itself is disabled. -->
+    <Style Selector="TextBlock.field-label:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource EditorBrush.Text.Disabled}" />
+    </Style>
+  </UserControl.Styles>
   <DockPanel>
     <TextBlock DockPanel.Dock="Top" Text="{loc:Tr Panel.Properties}" FontWeight="Bold" Margin="8,8,8,4" />
     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
@@ -18,7 +24,9 @@
                 <ColumnDefinition Width="Auto" MinWidth="100" SharedSizeGroup="LabelColumn" />
                 <ColumnDefinition Width="100" />
               </Grid.ColumnDefinitions>
-              <TextBlock Grid.Column="0" Text="{Binding Label}" VerticalAlignment="Center" Margin="0,0,8,0" />
+              <TextBlock Grid.Column="0" Classes="field-label" Text="{Binding Label}"
+                         IsEnabled="{Binding IsEnabled}"
+                         VerticalAlignment="Center" Margin="0,0,8,0" />
               <ComboBox Grid.Column="1" IsVisible="{Binding EnumOptions, Converter={x:Static ObjectConverters.IsNotNull}}"
                         IsEnabled="{Binding IsEnabled}"
                         Cursor="{Binding IsEnabled, Converter={x:Static conv:PropertyFieldStateConverters.Cursor}}"


### PR DESCRIPTION
## Description

- Add shared editor theme resources based on the Tailwind color palette
- Move canvas brushes/pens into `CanvasPalette` so canvas chrome responds to theme changes
- Improve contrast and disabled-field styling across editor controls
- Theme canvas grid, borders, dashed lines, radius rings, and list selection colors
- Add dividers between the object palette, canvas, and object/properties panel