### PR TITLE
feat: Add undo/redo and delete menu actions

### DIFF
--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -9,6 +9,8 @@
     "Menu.File.Close": "_Close",
 
     "Menu.Edit": "_Edit",
+    "Menu.Edit.Undo": "_Undo",
+    "Menu.Edit.Redo": "_Redo",
     "Menu.Edit.LevelSettings": "Level _Settings...",
 
     "Menu.View": "_View",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -11,6 +11,7 @@
     "Menu.Edit": "_Edit",
     "Menu.Edit.Undo": "_Undo",
     "Menu.Edit.Redo": "_Redo",
+    "Menu.Edit.Delete": "_Delete",
     "Menu.Edit.LevelSettings": "Level _Settings...",
 
     "Menu.View": "_View",

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -177,8 +177,13 @@ namespace CtrDxEditor.Rendering
 
         // Hovering / dragging the auto-catch radius ring, or a horizontal rail end/hook, uses a horizontal-
         // resize cursor (col-resize); a vertical rail end/hook uses the vertical one.
-        private static Cursor ResizeCursor => new(StandardCursorType.SizeWestEast);
-        private static Cursor VResizeCursor => new(StandardCursorType.SizeNorthSouth);
+        // Cached, but created lazily rather than in the static constructor: eager creation would touch
+        // Avalonia's cursor factory at type load, which throws in the headless test host. Lazy .Value
+        // still allocates each cursor only once, so pointer-move hit-testing doesn't churn instances.
+        private static readonly Lazy<Cursor> LazyResizeCursor = new(() => new Cursor(StandardCursorType.SizeWestEast));
+        private static readonly Lazy<Cursor> LazyVResizeCursor = new(() => new Cursor(StandardCursorType.SizeNorthSouth));
+        private static Cursor ResizeCursor => LazyResizeCursor.Value;
+        private static Cursor VResizeCursor => LazyVResizeCursor.Value;
 
         private bool _dragging;
         private bool _resizingRadius;

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -169,6 +169,12 @@ namespace CtrDxEditor.Rendering
         /// <summary>Callback raised when a canvas drag moves the selected object, so bound views can refresh.</summary>
         public Action? SelectedObjectMoved { get; set; }
 
+        /// <summary>Callback raised before a direct canvas edit begins, so the view model can capture undo state.</summary>
+        public Action? BeginDocumentEdit { get; set; }
+
+        /// <summary>Callback raised after a direct canvas edit ends, so the view model can commit undo state.</summary>
+        public Action? CompleteDocumentEdit { get; set; }
+
         // Hovering / dragging the auto-catch radius ring, or a horizontal rail end/hook, uses a horizontal-
         // resize cursor (col-resize); a vertical rail end/hook uses the vertical one.
         private static readonly Cursor ResizeCursor = new(StandardCursorType.SizeWestEast);
@@ -927,6 +933,7 @@ namespace CtrDxEditor.Rendering
             // (the ring can sit over other objects) but not over a middle-button pan.
             if (OnRadiusEdge(levelPt))
             {
+                BeginDocumentEdit?.Invoke();
                 _resizingRadius = true;
                 e.Pointer.Capture(this);
                 return;
@@ -940,10 +947,12 @@ namespace CtrDxEditor.Rendering
                 case GrabRail.Handle.ResizeStart:
                 case GrabRail.Handle.ResizeEnd:
                 case GrabRail.Handle.SlideHook:
+                    BeginDocumentEdit?.Invoke();
                     _railDrag = handle;
                     e.Pointer.Capture(this);
                     return;
                 case GrabRail.Handle.MoveBar:
+                    BeginDocumentEdit?.Invoke();
                     _dragOffset = levelPt - new Vec2(SelectedObject!.X, SelectedObject.Y);
                     _dragging = true;
                     e.Pointer.Capture(this);
@@ -977,6 +986,7 @@ namespace CtrDxEditor.Rendering
                 if (li >= 0 && bounds[li].Contains(levelPt))
                 {
                     SelectedObject = locked;
+                    BeginDocumentEdit?.Invoke();
                     _dragOffset = levelPt - new Vec2(locked.X, locked.Y);
                     _dragging = true;
                     e.Pointer.Capture(this);
@@ -1000,6 +1010,7 @@ namespace CtrDxEditor.Rendering
 
             LevelObject obj = doc.Objects[hit];
             SelectedObject = obj;
+            BeginDocumentEdit?.Invoke();
             _dragOffset = levelPt - new Vec2(obj.X, obj.Y);
             _dragging = true;
             e.Pointer.Capture(this);
@@ -1057,10 +1068,15 @@ namespace CtrDxEditor.Rendering
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
+            bool editedDocument = _dragging || _resizingRadius || _railDrag != GrabRail.Handle.None;
             _dragging = false;
             _panning = false;
             _resizingRadius = false;
             _railDrag = GrabRail.Handle.None;
+            if (editedDocument)
+            {
+                CompleteDocumentEdit?.Invoke();
+            }
             // Letting go ends the "grabbed" look; a fresh hover re-lights it if the cursor is on the hook.
             SetHookHovered(false);
             e.Pointer.Capture(null);

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -1073,6 +1073,28 @@ namespace CtrDxEditor.Rendering
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
             base.OnPointerReleased(e);
+            EndPointerGesture();
+            e.Pointer.Capture(null);
+        }
+
+        /// <inheritdoc />
+        protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            base.OnPointerCaptureLost(e);
+            EndPointerGesture();
+        }
+
+        private void EndPointerGesture()
+        {
+            // Capture loss (including the release path's own Capture(null)) can fire with nothing in
+            // progress; skip the resets and completion callback unless a gesture is actually active.
+            bool gestureActive = _dragging || _panning || _resizingRadius
+                || _railDrag != GrabRail.Handle.None || _hookHovered;
+            if (!gestureActive)
+            {
+                return;
+            }
+
             bool editedDocument = _dragging || _resizingRadius || _railDrag != GrabRail.Handle.None;
             _dragging = false;
             _panning = false;
@@ -1084,7 +1106,6 @@ namespace CtrDxEditor.Rendering
             }
             // Letting go ends the "grabbed" look; a fresh hover re-lights it if the cursor is on the hook.
             SetHookHovered(false);
-            e.Pointer.Capture(null);
         }
 
         /// <inheritdoc />

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -243,14 +243,24 @@ namespace CtrDxEditor.Rendering
             base.OnPropertyChanged(change);
             if (change.Property == DocumentProperty)
             {
-                _pendingFit = true;
-                TryFit(); // fits immediately if already laid out (later loads); else waits for Bounds.
+                // Auto-fit only when the level's dimensions change (a fresh load, a new level, or a
+                // resolution change). An undo/redo restore swaps in a re-parsed same-sized document,
+                // and refitting it would throw away the user's current zoom and pan.
+                LevelDocument? oldDoc = change.GetOldValue<LevelDocument?>();
+                LevelDocument? newDoc = change.GetNewValue<LevelDocument?>();
+                if (newDoc is not null
+                    && (oldDoc is null || oldDoc.Width != newDoc.Width || oldDoc.Height != newDoc.Height))
+                {
+                    _pendingFit = true;
+                    TryFit(); // fits immediately if already laid out (later loads); else waits for Bounds.
+                }
+                UpdateScrollState();
             }
             else if (change.Property == BoundsProperty && _pendingFit)
             {
                 TryFit();
             }
-            else if (change.Property == BoundsProperty || change.Property == ViewProperty || change.Property == DocumentProperty)
+            else if (change.Property == BoundsProperty || change.Property == ViewProperty)
             {
                 UpdateScrollState();
             }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -177,8 +177,8 @@ namespace CtrDxEditor.Rendering
 
         // Hovering / dragging the auto-catch radius ring, or a horizontal rail end/hook, uses a horizontal-
         // resize cursor (col-resize); a vertical rail end/hook uses the vertical one.
-        private static readonly Cursor ResizeCursor = new(StandardCursorType.SizeWestEast);
-        private static readonly Cursor VResizeCursor = new(StandardCursorType.SizeNorthSouth);
+        private static Cursor ResizeCursor => new(StandardCursorType.SizeWestEast);
+        private static Cursor VResizeCursor => new(StandardCursorType.SizeNorthSouth);
 
         private bool _dragging;
         private bool _resizingRadius;
@@ -1157,11 +1157,11 @@ namespace CtrDxEditor.Rendering
         }
 
         /// <summary>Adds an object at the level's center (for single-click placement from the palette).</summary>
-        public void AddAtCenter(string element)
+        public bool AddAtCenter(string element)
         {
             if (Document is not { } doc)
             {
-                return;
+                return false;
             }
 
             LevelObject? placed = PlaceAt?.Invoke(element, doc.Width / 2, doc.Height / 2);
@@ -1170,10 +1170,11 @@ namespace CtrDxEditor.Rendering
                 SelectedObject = placed;
             }
             InvalidateVisual();
+            return placed is not null;
         }
 
         /// <summary>Drops an object at a screen-space point, snapping according to the current settings.</summary>
-        public void DropElement(string element, Point screenPoint)
+        public bool DropElement(string element, Point screenPoint)
         {
             Vec2 levelPt = View.ScreenToLevel(new Vec2(screenPoint.X, screenPoint.Y));
             (int gx, int gy) = Snap(levelPt);
@@ -1183,6 +1184,7 @@ namespace CtrDxEditor.Rendering
                 SelectedObject = placed;
             }
             InvalidateVisual();
+            return placed is not null;
         }
 
         private (int X, int Y) Snap(Vec2 levelPt)

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -17,10 +17,17 @@ namespace CtrDxEditor.ViewModels
     {
         private readonly Func<string?> _get;
         private readonly Action<string?> _set;
+        private readonly Action _onChanging;
         private readonly Action _onChanged;
 
         /// <summary>Attribute-backed field (text, number, bool, or fixed enum).</summary>
-        public AttributeFieldViewModel(LevelObject target, string name, AttrType type, string[]? enumValues, Action onChanged)
+        public AttributeFieldViewModel(
+            LevelObject target,
+            string name,
+            AttrType type,
+            string[]? enumValues,
+            Action onChanged,
+            Action? onChanging = null)
         {
             Name = name;
             Label = Localizer.AttributeName(name);
@@ -30,11 +37,18 @@ namespace CtrDxEditor.ViewModels
             EnumOptions = enumValues?.Select(v => new AttributeOptionViewModel(v, LabelForOption(name, v))).ToArray();
             _get = () => target.GetAttr(name);
             _set = v => target.SetAttr(name, v ?? string.Empty);
+            _onChanging = onChanging ?? (() => { });
             _onChanged = onChanged;
         }
 
         /// <summary>Delegate-backed choice field with dynamic options (e.g. grab "Attach to").</summary>
-        public AttributeFieldViewModel(string name, AttributeOptionViewModel[] options, Func<string?> get, Action<string?> set, Action onChanged)
+        public AttributeFieldViewModel(
+            string name,
+            AttributeOptionViewModel[] options,
+            Func<string?> get,
+            Action<string?> set,
+            Action onChanged,
+            Action? onChanging = null)
         {
             Name = name;
             Label = Localizer.AttributeName(name);
@@ -42,11 +56,18 @@ namespace CtrDxEditor.ViewModels
             EnumOptions = options;
             _get = get;
             _set = set;
+            _onChanging = onChanging ?? (() => { });
             _onChanged = onChanged;
         }
 
         /// <summary>Delegate-backed simple field (bool/text/number) with no fixed option list.</summary>
-        public AttributeFieldViewModel(string name, AttrType type, Func<string?> get, Action<string?> set, Action onChanged)
+        public AttributeFieldViewModel(
+            string name,
+            AttrType type,
+            Func<string?> get,
+            Action<string?> set,
+            Action onChanged,
+            Action? onChanging = null)
         {
             Name = name;
             Label = Localizer.AttributeName(name);
@@ -54,6 +75,7 @@ namespace CtrDxEditor.ViewModels
             IsNumeric = type is AttrType.Whole or AttrType.Number;
             _get = get;
             _set = set;
+            _onChanging = onChanging ?? (() => { });
             _onChanged = onChanged;
         }
 
@@ -112,6 +134,11 @@ namespace CtrDxEditor.ViewModels
             get => _get();
             set
             {
+                if (_get() == value)
+                {
+                    return;
+                }
+                _onChanging();
                 _set(value);
                 _onChanged();
                 OnPropertyChanged();

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -20,6 +20,7 @@ namespace CtrDxEditor.ViewModels
     /// <param name="initial">The editor settings snapshot loaded at startup (decoration defaults, content path).</param>
     public sealed partial class EditorViewModel(SpriteCache sprites, ISettingsStore? settings = null, EditorSettings? initial = null) : ViewModelBase
     {
+        private const int UndoHistoryLimit = 100;
         private readonly DescriptorTable _descriptors = DescriptorTable.Default;
         private readonly List<HistoryState> _undoStack = [];
         private readonly List<HistoryState> _redoStack = [];
@@ -405,6 +406,11 @@ namespace CtrDxEditor.ViewModels
             }
 
             _undoStack.Add(state);
+            if (_undoStack.Count > UndoHistoryLimit)
+            {
+                _undoStack.RemoveAt(0);
+            }
+
             _redoStack.Clear();
             NotifyHistoryChanged();
         }

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -211,7 +211,7 @@ namespace CtrDxEditor.ViewModels
                 {
                     continue;
                 }
-                bool enabled = Document is not null && !Cardinality.IsAtCapacity(d, objs);
+                bool enabled = Document is not null && LockedObject is null && !Cardinality.IsAtCapacity(d, objs);
                 Palette.Add(new PaletteItemViewModel(
                     d.ElementName, Localizer.ObjectName(d.ElementName), enabled,
                     Sprites.GetThumbnail(d.ElementName, ActiveCandySkin, ActiveOmNomSupport)));
@@ -234,7 +234,7 @@ namespace CtrDxEditor.ViewModels
         public LevelObject? PlaceObject(string element, int levelX, int levelY)
         {
             ObjectDescriptor? d = _descriptors.For(element);
-            if (d is null || Document is null || Cardinality.IsAtCapacity(d, Document.Objects))
+            if (d is null || Document is null || LockedObject is not null || Cardinality.IsAtCapacity(d, Document.Objects))
             {
                 return null;
             }
@@ -326,6 +326,11 @@ namespace CtrDxEditor.ViewModels
         partial void OnDocumentChanged(LevelDocument? value)
         {
             OnPropertyChanged(nameof(HasDocument));
+        }
+
+        partial void OnLockedObjectChanged(LevelObject? value)
+        {
+            RefreshPalette();
         }
 
         // The candy skin changes the candy sprites, so the palette thumbnails must be rebuilt. (The

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -423,7 +423,8 @@ namespace CtrDxEditor.ViewModels
             RefreshObjectList();
             SelectedObject = ObjectAt(state.SelectedIndex);
             LockedObject = ObjectAt(state.LockedIndex);
-            LevelLoaded?.Invoke();
+            // A restore repaints in place; it must not refit/refocus the canvas the way opening a
+            // level does (LevelLoaded), or every undo/redo would throw away the user's zoom and pan.
             ObjectMutated?.Invoke();
         }
 

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -21,6 +21,9 @@ namespace CtrDxEditor.ViewModels
     public sealed partial class EditorViewModel(SpriteCache sprites, ISettingsStore? settings = null, EditorSettings? initial = null) : ViewModelBase
     {
         private readonly DescriptorTable _descriptors = DescriptorTable.Default;
+        private readonly List<HistoryState> _undoStack = [];
+        private readonly List<HistoryState> _redoStack = [];
+        private HistoryState? _pendingUndoTransaction;
 
         /// <summary>Persisted editor settings store, for reading/writing decoration defaults; null when unavailable.</summary>
         public ISettingsStore? Settings { get; } = settings;
@@ -64,12 +67,19 @@ namespace CtrDxEditor.ViewModels
         /// <summary>True when a level is open and editor-only commands can run.</summary>
         public bool HasDocument => Document is not null;
 
+        /// <summary>True when an undo snapshot is available.</summary>
+        public bool CanUndo => _undoStack.Count > 0;
+
+        /// <summary>True when a redo snapshot is available.</summary>
+        public bool CanRedo => _redoStack.Count > 0;
+
         /// <summary>Loads a level from its XML text into the editor.</summary>
         public void LoadLevelXml(string xml)
         {
             Document = LevelDocument.Parse(xml);
             SelectedObject = null;
             LockedObject = null;
+            ClearHistory();
             // The canvas fits the level to the viewport once it is laid out (LevelCanvas.FitToView).
             RefreshPalette();
             RefreshObjectList();
@@ -82,6 +92,7 @@ namespace CtrDxEditor.ViewModels
             Document = null;
             SelectedObject = null;
             LockedObject = null;
+            ClearHistory();
             Palette.Clear();
             ObjectList.Clear();
             Fields.Clear();
@@ -109,6 +120,7 @@ namespace CtrDxEditor.ViewModels
             ActiveOmNomSupport = omNomSupport;
             SelectedObject = null;
             LockedObject = null;
+            ClearHistory();
             RefreshPalette();
             RefreshObjectList();
             LevelLoaded?.Invoke();
@@ -121,6 +133,7 @@ namespace CtrDxEditor.ViewModels
             {
                 return;
             }
+            CaptureUndoSnapshot();
             Document.UpdateSettings(settings);
             RefreshPalette();
             RefreshObjectList();
@@ -146,6 +159,7 @@ namespace CtrDxEditor.ViewModels
             }
 
             LevelObject removed = SelectedObject;
+            CaptureUndoSnapshot();
             LevelDocument.Remove(removed);
             if (Equals(LockedObject, removed))
             {
@@ -225,6 +239,7 @@ namespace CtrDxEditor.ViewModels
                 return null;
             }
 
+            CaptureUndoSnapshot();
             LevelObject obj = Placement.CreateObject(d, levelX, levelY);
             LevelObjectPolicy.ApplyDefaults(obj, Document);
             Document.Add(obj);
@@ -238,6 +253,60 @@ namespace CtrDxEditor.ViewModels
         public string? ToXml()
         {
             return Document?.Save();
+        }
+
+        /// <summary>Begins a coalesced undo transaction for direct document mutations such as canvas drags.</summary>
+        public void BeginUndoTransaction()
+        {
+            _pendingUndoTransaction ??= CreateHistoryState();
+        }
+
+        /// <summary>Completes a coalesced undo transaction if the document changed.</summary>
+        public void CompleteUndoTransaction()
+        {
+            if (_pendingUndoTransaction is not { } before || Document is null)
+            {
+                _pendingUndoTransaction = null;
+                return;
+            }
+
+            _pendingUndoTransaction = null;
+            if (before.Xml == Document.Save())
+            {
+                return;
+            }
+
+            PushUndoState(before);
+        }
+
+        /// <summary>Restores the previous document snapshot, if available.</summary>
+        public void Undo()
+        {
+            if (Document is null || _undoStack.Count == 0)
+            {
+                return;
+            }
+
+            HistoryState current = CreateHistoryState()!;
+            HistoryState previous = PopLast(_undoStack);
+            _redoStack.Add(current);
+            RestoreHistoryState(previous);
+            NotifyHistoryChanged();
+        }
+
+        /// <summary>Restores the next document snapshot after an undo, if available.</summary>
+        public void Redo()
+        {
+            if (Document is null || _redoStack.Count == 0)
+            {
+                return;
+            }
+
+            HistoryState current = CreateHistoryState()!;
+            HistoryState next = PopLast(_redoStack);
+            _undoStack.Add(current);
+            RestoreHistoryState(next);
+            NotifyHistoryChanged();
         }
 
         /// <summary>Re-reads every property field from the selected object, for canvas-driven mutations like dragging.</summary>
@@ -287,12 +356,17 @@ namespace CtrDxEditor.ViewModels
                 ObjectMutated?.Invoke();
             }
 
-            Fields.Add(new AttributeFieldViewModel(value, "x", AttrType.Whole, null, Changed));
-            Fields.Add(new AttributeFieldViewModel(value, "y", AttrType.Whole, null, Changed));
+            void Changing()
+            {
+                CaptureUndoSnapshot();
+            }
+
+            Fields.Add(new AttributeFieldViewModel(value, "x", AttrType.Whole, null, Changed, Changing));
+            Fields.Add(new AttributeFieldViewModel(value, "y", AttrType.Whole, null, Changed, Changing));
 
             if (value.Type == "grab" && Document is not null)
             {
-                GrabFieldBuilder.Build(Fields, value, Document, Changed, () => PopulateFields(value));
+                GrabFieldBuilder.Build(Fields, value, Document, Changed, Changing, () => PopulateFields(value));
                 return;
             }
 
@@ -305,9 +379,95 @@ namespace CtrDxEditor.ViewModels
                     {
                         continue;
                     }
-                    Fields.Add(new AttributeFieldViewModel(value, spec.Name, spec.Type, spec.EnumValues, Changed));
+                    Fields.Add(new AttributeFieldViewModel(value, spec.Name, spec.Type, spec.EnumValues, Changed, Changing));
                 }
             }
         }
+
+        private void CaptureUndoSnapshot()
+        {
+            if (CreateHistoryState() is { } state)
+            {
+                PushUndoState(state);
+            }
+        }
+
+        private void PushUndoState(HistoryState state)
+        {
+            if (_undoStack.Count > 0 && _undoStack[^1].Xml == state.Xml)
+            {
+                return;
+            }
+
+            _undoStack.Add(state);
+            _redoStack.Clear();
+            NotifyHistoryChanged();
+        }
+
+        private HistoryState? CreateHistoryState()
+        {
+            return Document is null
+                ? null
+                : new HistoryState(Document.Save(), IndexOf(Document.Objects, SelectedObject), IndexOf(Document.Objects, LockedObject));
+        }
+
+        private void RestoreHistoryState(HistoryState state)
+        {
+            Document = LevelDocument.Parse(state.Xml);
+            RefreshPalette();
+            RefreshObjectList();
+            SelectedObject = ObjectAt(state.SelectedIndex);
+            LockedObject = ObjectAt(state.LockedIndex);
+            LevelLoaded?.Invoke();
+            ObjectMutated?.Invoke();
+        }
+
+        private LevelObject? ObjectAt(int index)
+        {
+            return Document is { } doc && index >= 0 && index < doc.Objects.Count
+                ? doc.Objects[index]
+                : null;
+        }
+
+        private static int IndexOf(IReadOnlyList<LevelObject> objects, LevelObject? target)
+        {
+            if (target is null)
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < objects.Count; i++)
+            {
+                if (Equals(objects[i], target))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static HistoryState PopLast(List<HistoryState> states)
+        {
+            int index = states.Count - 1;
+            HistoryState state = states[index];
+            states.RemoveAt(index);
+            return state;
+        }
+
+        private void ClearHistory()
+        {
+            _undoStack.Clear();
+            _redoStack.Clear();
+            _pendingUndoTransaction = null;
+            NotifyHistoryChanged();
+        }
+
+        private void NotifyHistoryChanged()
+        {
+            OnPropertyChanged(nameof(CanUndo));
+            OnPropertyChanged(nameof(CanRedo));
+        }
+
+        private sealed record HistoryState(string Xml, int SelectedIndex, int LockedIndex);
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/GrabFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/GrabFieldBuilder.cs
@@ -22,6 +22,7 @@ namespace CtrDxEditor.ViewModels
             LevelObject grab,
             LevelDocument document,
             Action onChanged,
+            Action onChanging,
             Action rebuild)
         {
             bool gun = Bool(grab, "gun");
@@ -51,7 +52,8 @@ namespace CtrDxEditor.ViewModels
                     vmOptions,
                     () => GrabBinding.CurrentToken(grab, document.Objects, document.TwoParts),
                     token => GrabBinding.Apply(grab, token ?? "primary"),
-                    onChanged)
+                    onChanged,
+                    onChanging)
                 { IsEnabled = !gun && !autoCatch });
             }
 
@@ -66,59 +68,62 @@ namespace CtrDxEditor.ViewModels
                 () => autoCatch,
                 on => grab.SetAttr("radius", on ? "100" : "-1"),
                 Structural,
+                onChanging,
                 geomEnabled));
             fields.Add(autoCatch
-                ? Attr(grab, "radius", AttrType.Whole, onChanged, geomEnabled)
-                : Attr(grab, "length", AttrType.Whole, onChanged, geomEnabled));
+                ? Attr(grab, "radius", AttrType.Whole, onChanged, onChanging, geomEnabled)
+                : Attr(grab, "length", AttrType.Whole, onChanged, onChanging, geomEnabled));
 
             fields.Add(Synthetic(
                 "movable",
                 () => movable,
                 on => grab.SetAttr("moveLength", on ? "100" : "-1"),
                 Structural,
+                onChanging,
                 railEnabled));
             if (movable)
             {
-                fields.Add(Attr(grab, "moveVertical", AttrType.Bool, onChanged, railEnabled));
-                fields.Add(Attr(grab, "moveLength", AttrType.Whole, onChanged, railEnabled));
-                fields.Add(Attr(grab, "moveOffset", AttrType.Whole, onChanged, railEnabled));
+                fields.Add(Attr(grab, "moveVertical", AttrType.Bool, onChanged, onChanging, railEnabled));
+                fields.Add(Attr(grab, "moveLength", AttrType.Whole, onChanged, onChanging, railEnabled));
+                fields.Add(Attr(grab, "moveOffset", AttrType.Whole, onChanged, onChanging, railEnabled));
             }
 
-            fields.Add(BoolAttr(grab, "wheel", Structural, !(gun || movable), ClearMoveRail));
-            fields.Add(BoolAttr(grab, "gun", Structural, !(wheel || spider || kickable || movable), ClearMoveRail));
+            fields.Add(BoolAttr(grab, "wheel", Structural, onChanging, !(gun || movable), ClearMoveRail));
+            fields.Add(BoolAttr(grab, "gun", Structural, onChanging, !(wheel || spider || kickable || movable), ClearMoveRail));
 
-            fields.Add(Attr(grab, "spider", AttrType.Bool, Structural, !gun));
-            fields.Add(BoolAttr(grab, "kickable", Structural, !(gun || movable), ClearMoveRail));
+            fields.Add(Attr(grab, "spider", AttrType.Bool, Structural, onChanging, !gun));
+            fields.Add(BoolAttr(grab, "kickable", Structural, onChanging, !(gun || movable), ClearMoveRail));
             if (kickable)
             {
-                fields.Add(Attr(grab, "kicked", AttrType.Bool, onChanged, !gun));
+                fields.Add(Attr(grab, "kicked", AttrType.Bool, onChanged, onChanging, !gun));
             }
 
             // The game hides an invisible grab (and its rope) entirely; the editor keeps it visible but
             // pale so it stays selectable. Works for every grab type, so it is never gated.
-            fields.Add(Attr(grab, "invisible", AttrType.Bool, onChanged, true));
+            fields.Add(Attr(grab, "invisible", AttrType.Bool, onChanged, onChanging, true));
         }
 
         private static AttributeFieldViewModel Attr(
-            LevelObject grab, string name, AttrType type, Action onChanged, bool enabled)
+            LevelObject grab, string name, AttrType type, Action onChanged, Action onChanging, bool enabled)
         {
-            return new AttributeFieldViewModel(grab, name, type, null, onChanged) { IsEnabled = enabled };
+            return new AttributeFieldViewModel(grab, name, type, null, onChanged, onChanging) { IsEnabled = enabled };
         }
 
         private static AttributeFieldViewModel Synthetic(
-            string name, Func<bool> get, Action<bool> set, Action onChanged, bool enabled)
+            string name, Func<bool> get, Action<bool> set, Action onChanged, Action onChanging, bool enabled)
         {
             return new AttributeFieldViewModel(
                 name,
                 AttrType.Bool,
                 () => get() ? "true" : "false",
                 v => set(v == "true"),
-                onChanged)
+                onChanged,
+                onChanging)
             { IsEnabled = enabled };
         }
 
         private static AttributeFieldViewModel BoolAttr(
-            LevelObject grab, string name, Action onChanged, bool enabled, Action<LevelObject> whenEnabled)
+            LevelObject grab, string name, Action onChanged, Action onChanging, bool enabled, Action<LevelObject> whenEnabled)
         {
             return new AttributeFieldViewModel(
                 name,
@@ -133,7 +138,8 @@ namespace CtrDxEditor.ViewModels
                         whenEnabled(grab);
                     }
                 },
-                onChanged)
+                onChanged,
+                onChanging)
             { IsEnabled = enabled };
         }
 

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -67,6 +67,18 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
+        <MenuItem Click="Delete_Click"
+                  IsEnabled="{Binding SelectedObject, Converter={x:Static ObjectConverters.IsNotNull}}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="DeleteOutline" />
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <AccessText Grid.Column="0" Text="{loc:Tr Menu.Edit.Delete}" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="{x:Static views:ShortcutHint.Delete}" Opacity="0.6" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
         <Separator />
         <MenuItem Header="{loc:Tr Menu.Edit.LevelSettings}" Click="LevelSettings_Click"
                   IsEnabled="{Binding Document, Converter={x:Static ObjectConverters.IsNotNull}}">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -45,6 +45,29 @@
         </MenuItem>
       </MenuItem>
       <MenuItem Header="{loc:Tr Menu.Edit}">
+        <MenuItem Click="Undo_Click" IsEnabled="{Binding CanUndo}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="Undo" />
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <AccessText Grid.Column="0" Text="{loc:Tr Menu.Edit.Undo}" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="{x:Static views:ShortcutHint.Undo}" Opacity="0.6" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
+        <MenuItem Click="Redo_Click" IsEnabled="{Binding CanRedo}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="Redo" />
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <AccessText Grid.Column="0" Text="{loc:Tr Menu.Edit.Redo}" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="{x:Static views:ShortcutHint.Redo}" Opacity="0.6" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
+        <Separator />
         <MenuItem Header="{loc:Tr Menu.Edit.LevelSettings}" Click="LevelSettings_Click"
                   IsEnabled="{Binding Document, Converter={x:Static ObjectConverters.IsNotNull}}">
           <MenuItem.Icon>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -237,14 +237,20 @@ namespace CtrDxEditor.Views
                 canvas.HideGhost();
                 if (!_paletteDragging)
                 {
-                    canvas.AddAtCenter(element); // a click: drop at the level center
+                    if (canvas.AddAtCenter(element)) // a click: drop at the level center
+                    {
+                        _ = canvas.Focus();
+                    }
                 }
                 else
                 {
                     Point onCanvas = e.GetPosition(canvas);
                     if (new Rect(canvas.Bounds.Size).Contains(onCanvas))
                     {
-                        canvas.DropElement(element, onCanvas); // dragged onto the canvas
+                        if (canvas.DropElement(element, onCanvas)) // dragged onto the canvas
+                        {
+                            _ = canvas.Focus();
+                        }
                     }
                     // dragged but released off-canvas: cancel
                 }

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -44,6 +44,8 @@ namespace CtrDxEditor.Views
                 DataContext is EditorViewModel vm ? vm.PlaceObject(element, x, y) : null;
             canvas.ToggleLock = obj => (DataContext as EditorViewModel)?.ToggleLock(obj);
             canvas.SelectedObjectMoved = () => (DataContext as EditorViewModel)?.RefreshFieldValues();
+            canvas.BeginDocumentEdit = () => (DataContext as EditorViewModel)?.BeginUndoTransaction();
+            canvas.CompleteDocumentEdit = () => (DataContext as EditorViewModel)?.CompleteUndoTransaction();
 
             // Palette placement is an internal pointer-capture drag (no OS drag-drop, so no OS drag image):
             // a click drops at center, a drag drops where it lands on the canvas, a drag off-canvas cancels.
@@ -62,9 +64,22 @@ namespace CtrDxEditor.Views
             KeyDown += (_, e) =>
             {
                 bool ctrl = e.KeyModifiers.HasFlag(cmdModifier);
+                bool shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
 #pragma warning disable IDE0010
                 switch (e.Key)
                 {
+                    case Key.Z when ctrl && !shift && DataContext is EditorViewModel { CanUndo: true } undoVm:
+                        undoVm.Undo();
+                        e.Handled = true;
+                        break;
+                    case Key.Z when ctrl && shift && DataContext is EditorViewModel { CanRedo: true } redoVm:
+                        redoVm.Redo();
+                        e.Handled = true;
+                        break;
+                    case Key.Y when ctrl && !OperatingSystem.IsMacOS() && DataContext is EditorViewModel { CanRedo: true } redoVm:
+                        redoVm.Redo();
+                        e.Handled = true;
+                        break;
                     case Key.Delete when DataContext is EditorViewModel vm:
                         vm.DeleteSelected();
                         canvas.InvalidateVisual();
@@ -94,6 +109,22 @@ namespace CtrDxEditor.Views
                 }
 #pragma warning restore IDE0010
             };
+        }
+
+        private void Undo_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.Undo();
+            }
+        }
+
+        private void Redo_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.Redo();
+            }
         }
 
         private void SnapToggle_Click(object? sender, RoutedEventArgs e)

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -127,6 +127,15 @@ namespace CtrDxEditor.Views
             }
         }
 
+        private void Delete_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.DeleteSelected();
+                this.FindControl<LevelCanvas>("Canvas")!.InvalidateVisual();
+            }
+        }
+
         private void SnapToggle_Click(object? sender, RoutedEventArgs e)
         {
             if (DataContext is EditorViewModel vm)

--- a/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
+++ b/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
@@ -24,5 +24,8 @@ namespace CtrDxEditor.Views
 
         /// <summary>Localized platform shortcut text for redo.</summary>
         public static string Redo { get; } = OperatingSystem.IsMacOS() ? $"{Mod} Shift Z" : $"{Mod} Y";
+
+        /// <summary>Localized platform shortcut text for deleting the selected object.</summary>
+        public static string Delete { get; } = "Delete";
     }
 }

--- a/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
+++ b/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
@@ -18,5 +18,11 @@ namespace CtrDxEditor.Views
 
         /// <summary>Localized platform shortcut text for fitting the level to the viewport.</summary>
         public static string ZoomFit { get; } = $"{Mod} 0";
+
+        /// <summary>Localized platform shortcut text for undo.</summary>
+        public static string Undo { get; } = $"{Mod} Z";
+
+        /// <summary>Localized platform shortcut text for redo.</summary>
+        public static string Redo { get; } = OperatingSystem.IsMacOS() ? $"{Mod} Shift Z" : $"{Mod} Y";
     }
 }

--- a/src/CtrDxEditor.Tests/EditorPaletteGatingTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteGatingTests.cs
@@ -139,5 +139,25 @@ namespace CtrDxEditor.Tests
             Assert.False(PaletteItem(vm, "candyL").Enabled);
             Assert.False(PaletteItem(vm, "candyR").Enabled);
         }
+
+        /// <summary>Locking an object disables palette placement until the lock is cleared.</summary>
+        [Fact]
+        public void LockedObjectDisablesPalettePlacement()
+        {
+            EditorViewModel vm = Vm();
+            vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: false));
+            LevelObject locked = vm.PlaceObject("target", 320, 240)!;
+
+            vm.ToggleLock(locked);
+
+            Assert.All(vm.Palette, item => Assert.False(item.Enabled));
+            Assert.Null(vm.PlaceObject("star", 100, 120));
+            Assert.DoesNotContain(vm.Document!.Objects, o => o.Type == "star");
+
+            vm.ToggleLock(locked);
+
+            Assert.True(PaletteItem(vm, "star").Enabled);
+            Assert.NotNull(vm.PlaceObject("star", 100, 120));
+        }
     }
 }

--- a/src/CtrDxEditor.Tests/EditorUndoRedoTests.cs
+++ b/src/CtrDxEditor.Tests/EditorUndoRedoTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests undo and redo behavior in the editor view model.</summary>
+    public class EditorUndoRedoTests
+    {
+        private sealed class EmptyStore : IContentStore
+        {
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                return Task.FromResult(Array.Empty<byte>());
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult("");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        private const string Level = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <map>
+            <layer name="settings">
+                <map gridSize="32" width="640" height="480" />
+            </layer>
+            <layer name="Objects">
+                <candy x="100" y="100" />
+            </layer>
+        </map>
+        """;
+
+        /// <summary>Verifies that undoing and redoing placement removes and restores the object.</summary>
+        [Fact]
+        public void UndoAndRedoRestorePlacedObject()
+        {
+            EditorViewModel vm = CreateLoadedViewModel();
+
+            _ = vm.PlaceObject("star", 50, 60);
+
+            Assert.True(vm.CanUndo);
+            Assert.False(vm.CanRedo);
+            Assert.Equal(2, vm.Document!.Objects.Count);
+
+            vm.Undo();
+
+            _ = Assert.Single(vm.Document.Objects);
+            Assert.False(vm.CanUndo);
+            Assert.True(vm.CanRedo);
+
+            vm.Redo();
+
+            Assert.Equal(2, vm.Document.Objects.Count);
+            Assert.Equal("star", vm.Document.Objects[1].Type);
+            Assert.True(vm.CanUndo);
+            Assert.False(vm.CanRedo);
+        }
+
+        /// <summary>Verifies that making a new edit after undo replaces the redo chain.</summary>
+        [Fact]
+        public void NewEditAfterUndoClearsRedo()
+        {
+            EditorViewModel vm = CreateLoadedViewModel();
+            _ = vm.PlaceObject("star", 50, 60);
+            vm.Undo();
+
+            _ = vm.PlaceObject("target", 300, 200);
+
+            Assert.True(vm.CanUndo);
+            Assert.False(vm.CanRedo);
+            Assert.Equal(["candy", "target"], vm.Document!.Objects.Select(o => o.Type));
+        }
+
+        /// <summary>Verifies that undoing deletion restores the object and selection.</summary>
+        [Fact]
+        public void UndoRestoresDeletedSelection()
+        {
+            EditorViewModel vm = CreateLoadedViewModel();
+            LevelObject candy = vm.Document!.Objects[0];
+            vm.SelectedObject = candy;
+
+            vm.DeleteSelected();
+
+            Assert.Empty(vm.Document.Objects);
+
+            vm.Undo();
+
+            LevelObject restored = Assert.Single(vm.Document.Objects);
+            Assert.Equal("candy", restored.Type);
+            Assert.Same(restored.Element, vm.SelectedObject!.Element);
+        }
+
+        /// <summary>Verifies that property-panel edits are undoable.</summary>
+        [Fact]
+        public void UndoRestoresPropertyFieldEdit()
+        {
+            EditorViewModel vm = CreateLoadedViewModel();
+            vm.SelectedObject = vm.Document!.Objects[0];
+            AttributeFieldViewModel xField = vm.Fields.Single(f => f.Name == "x");
+
+            xField.Value = "250";
+
+            Assert.Equal(250, vm.Document.Objects[0].X);
+
+            vm.Undo();
+
+            Assert.Equal(100, vm.Document.Objects[0].X);
+            Assert.Equal("100", vm.Fields.Single(f => f.Name == "x").Value);
+        }
+
+        /// <summary>Verifies that direct document edits can be grouped into one undo entry.</summary>
+        [Fact]
+        public void UndoTransactionCoalescesDirectMutations()
+        {
+            EditorViewModel vm = CreateLoadedViewModel();
+            LevelObject candy = vm.Document!.Objects[0];
+            vm.SelectedObject = candy;
+
+            vm.BeginUndoTransaction();
+            candy.X = 120;
+            candy.Y = 140;
+            vm.CompleteUndoTransaction();
+
+            vm.Undo();
+
+            Assert.Equal(100, vm.Document.Objects[0].X);
+            Assert.Equal(100, vm.Document.Objects[0].Y);
+        }
+
+        private static EditorViewModel CreateLoadedViewModel()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            return vm;
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/EditorUndoRedoTests.cs
+++ b/src/CtrDxEditor.Tests/EditorUndoRedoTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -143,6 +144,30 @@ namespace CtrDxEditor.Tests
 
             Assert.Equal(100, vm.Document.Objects[0].X);
             Assert.Equal(100, vm.Document.Objects[0].Y);
+        }
+
+        /// <summary>Verifies the undo stack keeps only the most recent snapshots.</summary>
+        [Fact]
+        public void UndoHistoryIsCapped()
+        {
+            const int historyLimit = 100;
+            EditorViewModel vm = CreateLoadedViewModel();
+            vm.SelectedObject = vm.Document!.Objects[0];
+            AttributeFieldViewModel xField = vm.Fields.Single(f => f.Name == "x");
+
+            for (int i = 0; i < historyLimit + 5; i++)
+            {
+                xField.Value = (200 + i).ToString(CultureInfo.InvariantCulture);
+            }
+
+            int undoCount = 0;
+            while (vm.CanUndo)
+            {
+                vm.Undo();
+                undoCount++;
+            }
+
+            Assert.Equal(historyLimit, undoCount);
         }
 
         private static EditorViewModel CreateLoadedViewModel()

--- a/src/CtrDxEditor.Tests/LevelCanvasPlacementTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasPlacementTests.cs
@@ -1,0 +1,47 @@
+using Avalonia;
+
+using CtrDxEditor.Core.Descriptors;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+using CtrDxEditor.Rendering;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests palette placement behavior on the editor canvas.</summary>
+    public class LevelCanvasPlacementTests
+    {
+        /// <summary>Verifies click placement reports success so the host can return keyboard focus to the canvas.</summary>
+        [Fact]
+        public void AddAtCenterReturnsTrueWhenObjectIsPlaced()
+        {
+            LevelCanvas canvas = new()
+            {
+                Document = LevelDocument.CreateNew(new LevelSettings(640, 480, 1.0f, 0, false, false)),
+                PlaceAt = (_, x, y) => Placement.CreateObject(DescriptorTable.Default.For("star")!, x, y),
+            };
+
+            bool placed = canvas.AddAtCenter("star");
+
+            Assert.True(placed);
+        }
+
+        /// <summary>Verifies drag placement reports success so the host can return keyboard focus to the canvas.</summary>
+        [Fact]
+        public void DropElementReturnsTrueWhenObjectIsPlaced()
+        {
+            LevelCanvas canvas = new()
+            {
+                Document = LevelDocument.CreateNew(new LevelSettings(640, 480, 1.0f, 0, false, false)),
+                View = ViewTransform.Identity,
+                PlaceAt = (_, x, y) => Placement.CreateObject(DescriptorTable.Default.For("star")!, x, y),
+            };
+
+            bool placed = canvas.DropElement("star", new Point(10, 20));
+
+            Assert.True(placed);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests canvas transaction wiring that is difficult to exercise through headless pointer capture.</summary>
+    public class LevelCanvasTransactionTests
+    {
+        /// <summary>Verifies lost pointer capture ends the same document-edit gesture as pointer release.</summary>
+        [Fact]
+        public void PointerCaptureLostCompletesDocumentEditGesture()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Rendering", "LevelCanvas.cs"));
+
+            Assert.Contains("protected override void OnPointerCaptureLost", source, StringComparison.Ordinal);
+            Assert.Contains("EndPointerGesture();", source, StringComparison.Ordinal);
+            Assert.Contains("CompleteDocumentEdit?.Invoke();", source, StringComparison.Ordinal);
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string path = AppContext.BaseDirectory;
+            while (Path.GetFileName(path) != "src")
+            {
+                path = Directory.GetParent(path)?.FullName
+                       ?? throw new InvalidOperationException("Could not locate src directory.");
+            }
+
+            return Path.Combine([path, .. parts]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add undo/redo support for editor document mutations, including placement, deletion, level settings changes, property edits, and canvas drag edits.
- Add Edit menu entries and shortcut hints for Undo, Redo and Delete.
- Return keyboard focus to the level canvas after successful palette placement so shortcuts work immediately.
- Disable palette placement while an object is locked, with `PlaceObject` guarding against placement as a backstop.