### PR TITLE
feat: Add level screenshot option (reopened)

### DIFF
--- a/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
+++ b/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
@@ -72,10 +72,10 @@ namespace CtrDxEditor.Core.Tests
             BackgroundLayout layout = BackgroundPlacement.Compute(
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9);
 
-            Assert.Null(layout.EarthCenter);
+            Assert.Empty(layout.EarthCenters);
         }
 
-        /// <summary>The earth is center-anchored at earthBgPosition ÷ MapScale, offset by the column.</summary>
+        /// <summary>A single-screen cosmic box draws one earth at earthBgPosition ÷ MapScale, column-offset.</summary>
         [Fact]
         public void EarthCenteredAtScaledPosition()
         {
@@ -83,9 +83,52 @@ namespace CtrDxEditor.Core.Tests
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9,
                 earthPosition: new Vec2(1284, 724));
 
-            Vec2 earth = Assert.NotNull(layout.EarthCenter);
+            Vec2 earth = Assert.Single(layout.EarthCenters);
             Assert.Equal(layout.Left + (1284.0 / 3.0), earth.X, precision: 9);
             Assert.Equal(724.0 / 3.0, earth.Y, precision: 9);
+        }
+
+        /// <summary>Maps wider than one screen (mapWidth &gt; 2560) get a second earth one column right.</summary>
+        [Fact]
+        public void WideMapDuplicatesEarthHorizontally()
+        {
+            // levelWidth 1000 -> mapWidth 3000 > 2560, so a horizontal copy is added; height stays 1 screen.
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 1000, levelHeight: 480, p1Aspect: P1Aspect16By9,
+                earthPosition: new Vec2(1284, 724));
+
+            Assert.Equal(2, layout.EarthCenters.Count);
+            Vec2 baseEarth = layout.EarthCenters[0];
+            Vec2 copy = layout.EarthCenters[1];
+            Assert.Equal(baseEarth.X + layout.Width, copy.X, precision: 9);
+            Assert.Equal(baseEarth.Y, copy.Y, precision: 9);
+        }
+
+        /// <summary>Maps taller than one screen (mapHeight &gt; 1440) get a second earth one tile down.</summary>
+        [Fact]
+        public void TallMapDuplicatesEarthVertically()
+        {
+            // levelHeight 960 -> mapHeight 2880 > 1440, so a vertical copy is added; width stays 1 screen.
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 960, p1Aspect: P1Aspect16By9,
+                earthPosition: new Vec2(1284, 724));
+
+            Assert.Equal(2, layout.EarthCenters.Count);
+            Vec2 baseEarth = layout.EarthCenters[0];
+            Vec2 copy = layout.EarthCenters[1];
+            Assert.Equal(baseEarth.X, copy.X, precision: 9);
+            Assert.Equal(baseEarth.Y + layout.TileHeight, copy.Y, precision: 9);
+        }
+
+        /// <summary>A map larger than one screen in both axes gets all three earths (base + two copies).</summary>
+        [Fact]
+        public void LargeMapDrawsThreeEarths()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 1000, levelHeight: 960, p1Aspect: P1Aspect16By9,
+                earthPosition: new Vec2(1284, 724));
+
+            Assert.Equal(3, layout.EarthCenters.Count);
         }
 
         /// <summary>A missing p2 (no p2Y) yields no p2 even for tall maps.</summary>

--- a/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
+++ b/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using CtrDxEditor.Core.Geometry;
 
 namespace CtrDxEditor.Core.Editing
@@ -10,9 +12,13 @@ namespace CtrDxEditor.Core.Editing
     /// <param name="Width">Level-space width of the p1 column (the internal screen width).</param>
     /// <param name="TileHeight">Level-space height of one p1 tile; repeat this down from y=0.</param>
     /// <param name="P2">The secondary background's bounds, or null when the map is short or has no p2.</param>
-    /// <param name="EarthCenter">Level-space center of the earth decoration (cosmic box only), or null.</param>
+    /// <param name="EarthCenters">
+    /// Level-space centers of the earth decoration (cosmic box only), empty when there is no earth. The
+    /// game draws a base earth plus a horizontal copy for maps wider than one screen and a vertical copy
+    /// for maps taller than one screen (up to three), so this holds 0..3 positions.
+    /// </param>
     public readonly record struct BackgroundLayout(
-        double Left, double Width, double TileHeight, LevelBounds? P2, Vec2? EarthCenter);
+        double Left, double Width, double TileHeight, LevelBounds? P2, IReadOnlyList<Vec2> EarthCenters);
 
     /// <summary>
     /// Pure background placement math. The game (GameScene.Draw / GameScene.Init) draws the box
@@ -66,11 +72,25 @@ namespace CtrDxEditor.Core.Editing
 
             // The earth is center-anchored at earthBgPosition within the p1 column's space (GameScene
             // CreateEarthImageWithOffsetXY), so it maps to level space by ÷MapScale, offset by the column.
-            Vec2? earth = earthPosition is { } e
-                ? new Vec2(left + (e.X / SpritePlacement.MapScale), e.Y / SpritePlacement.MapScale)
-                : null;
+            // The game wraps it with the tiled background when the map exceeds one screen: an extra copy
+            // one column to the right for wide maps (mapWidth > SCREEN_WIDTH) and one tile down for tall
+            // maps (mapHeight > SCREEN_HEIGHT). Both offsets scale to the p1 column width / tile height.
+            List<Vec2> earthCenters = [];
+            if (earthPosition is { } e)
+            {
+                Vec2 baseEarth = new(left + (e.X / SpritePlacement.MapScale), e.Y / SpritePlacement.MapScale);
+                earthCenters.Add(baseEarth);
+                if (levelWidth > width)
+                {
+                    earthCenters.Add(new Vec2(baseEarth.X + width, baseEarth.Y));
+                }
+                if (tall)
+                {
+                    earthCenters.Add(new Vec2(baseEarth.X, baseEarth.Y + tileHeight));
+                }
+            }
 
-            return new BackgroundLayout(left, width, tileHeight, p2, earth);
+            return new BackgroundLayout(left, width, tileHeight, p2, earthCenters);
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -31,7 +31,9 @@
     "Dialog.FileType.LevelXml": "Level XML",
     "Dialog.Screenshot.Title": "Save level screenshot",
     "Dialog.FileType.Png": "PNG image",
+    "Notification.Screenshot.Saving": "Saving screenshot…",
     "Notification.Screenshot.Title": "Screenshot saved",
+    "Notification.Screenshot.Failed": "Screenshot failed to save",
 
     "Dialog.Common.Cancel": "Cancel",
     "Dialog.Common.Ok": "OK",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -6,6 +6,7 @@
     "Menu.File.Open": "_Open...",
     "Menu.File.Save": "_Save",
     "Menu.File.SaveAs": "Save _As...",
+    "Menu.File.Screenshot": "Take Level Screenshot...",
     "Menu.File.Close": "_Close",
 
     "Menu.Edit": "_Edit",
@@ -28,6 +29,8 @@
     "Dialog.Open.Title": "Open level XML",
     "Dialog.Save.Title": "Save level XML",
     "Dialog.FileType.LevelXml": "Level XML",
+    "Dialog.Screenshot.Title": "Save level screenshot",
+    "Dialog.FileType.Png": "PNG image",
 
     "Dialog.Common.Cancel": "Cancel",
     "Dialog.Common.Ok": "OK",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -31,6 +31,7 @@
     "Dialog.FileType.LevelXml": "Level XML",
     "Dialog.Screenshot.Title": "Save level screenshot",
     "Dialog.FileType.Png": "PNG image",
+    "Notification.Screenshot.Title": "Screenshot saved",
 
     "Dialog.Common.Cancel": "Cancel",
     "Dialog.Common.Ok": "OK",

--- a/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/GrabRenderer.cs
@@ -144,6 +144,25 @@ namespace CtrDxEditor.Rendering
         }
 
         /// <summary>
+        /// Draws only grab auto-catch rings (not the light bulb's lit radius) with <paramref name="pen"/>.
+        /// Used for the game-accurate dashed blue ring baked into a level screenshot, where the bulb's
+        /// reach is already conveyed by its additive glow rather than a ring.
+        /// </summary>
+        public static void DrawGrabRadiusRings(DrawingContext ctx, ViewTransform v, IReadOnlyList<LevelObject> objects, Pen pen)
+        {
+            foreach (LevelObject obj in objects)
+            {
+                if (obj.Type != "grab" || RadiusRing.Of(obj) is not { } ring)
+                {
+                    continue;
+                }
+                Vec2 c = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+                double screenR = ring.Radius * v.Zoom;
+                ctx.DrawEllipse(null, pen, new Point(c.X, c.Y), screenR, screenR);
+            }
+        }
+
+        /// <summary>
         /// Draws a movable grab's rail (left cap + tiled center + right cap), the back half of the mover
         /// assembly - the rope is drawn over it and under the movable hook, matching the game's
         /// <c>moveBackground</c> (DrawBack) then rope then <c>grabMover</c> (Draw) layering. Laid out in a

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -514,15 +514,19 @@ namespace CtrDxEditor.Rendering
                         context.DrawImage(p2, new Rect(p2.Size), LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
                     }
 
-                    if (layout.EarthCenter is { } ec && sprites.GetEarthArt() is { } earthArt)
+                    if (layout.EarthCenters.Count > 0 && sprites.GetEarthArt() is { } earthArt)
                     {
                         IntRect ef = earthArt.Frame.Frame;
                         double ew = ef.W / SpritePlacement.MapScale;
                         double eh = ef.H / SpritePlacement.MapScale;
-                        context.DrawImage(
-                            earthArt.Bitmap,
-                            new Rect(ef.X, ef.Y, ef.W, ef.H),
-                            LevelRectToScreen(v, ec.X - (ew / 2.0), ec.Y - (eh / 2.0), ew, eh));
+                        Rect earthSrc = new(ef.X, ef.Y, ef.W, ef.H);
+                        foreach (Vec2 ec in layout.EarthCenters)
+                        {
+                            context.DrawImage(
+                                earthArt.Bitmap,
+                                earthSrc,
+                                LevelRectToScreen(v, ec.X - (ew / 2.0), ec.Y - (eh / 2.0), ew, eh));
+                        }
                     }
                 }
             }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -414,123 +414,9 @@ namespace CtrDxEditor.Rendering
             }
 
             ViewTransform v = View;
-            Vec2 tl = v.LevelToScreen(new Vec2(0, 0));
-            Vec2 br = v.LevelToScreen(new Vec2(doc.Width, doc.Height));
-
-            // Editor-decoration background, drawn as the bottom layer so the level border and grid sit
-            // on top of it. The p1 column keeps its game width and aspect (GameScene.Draw scales it to
-            // the internal screen width) and stays centered on the map, so it extends past the level
-            // rect sideways rather than being cropped to it - but it's bounded to the level's own height
-            // (clipped top/bottom) so it doesn't repeat off into empty canvas. Horizontally it's a
-            // single column: the game repeats the background vertically only, never sideways. A p2
-            // overlay is drawn once for maps taller than one screen. BackgroundPlacement mirrors that.
-            Bitmap? bg = sprites.GetBackground(ActiveBackground);
-            if (bg is not null && bg.Size is { Width: > 0, Height: > 0 } bgSize)
-            {
-                Bitmap? p2 = sprites.GetBackgroundP2(ActiveBackground);
-                double p2Aspect = p2 is { Size: { Width: > 0 } p2s } ? p2s.Height / p2s.Width : 0.0;
-                BackgroundLayout layout = BackgroundPlacement.Compute(
-                    doc.Width, doc.Height, bgSize.Height / bgSize.Width,
-                    p2Aspect, SpriteCache.GetBackgroundP2Y(ActiveBackground),
-                    SpriteCache.GetEarthBgPosition(ActiveBackground));
-
-                // Clip vertically to the level's height (full canvas width, so the wide column still
-                // shows past the level sides), keeping the background within the level's own span.
-                using (context.PushClip(new Rect(0, tl.Y, Bounds.Width, br.Y - tl.Y)))
-                {
-                    if (layout.TileHeight > 0.5)
-                    {
-                        Rect bgSrc = new(bgSize);
-                        for (double ty = 0; ty < doc.Height; ty += layout.TileHeight)
-                        {
-                            context.DrawImage(bg, bgSrc, LevelRectToScreen(v, layout.Left, ty, layout.Width, layout.TileHeight));
-                        }
-                    }
-
-                    if (layout.P2 is { } p2b && p2 is not null)
-                    {
-                        context.DrawImage(p2, new Rect(p2.Size), LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
-                    }
-
-                    // Cosmic box only: the earth sprite the game draws over the background (GameScene.Draw
-                    // earthAnims). Static here - the game's gravity-flip spin has no editor equivalent.
-                    // The game centers the trimmed quad directly on earthBgPosition (Image with anchor
-                    // CENTER and restoreCutTransparency off, so DrawQuad applies no trim offset), so place
-                    // the frame itself - not the untrimmed sourceSize box that SpritePlacement would use.
-                    if (layout.EarthCenter is { } ec && sprites.GetEarthArt() is { } earthArt)
-                    {
-                        IntRect ef = earthArt.Frame.Frame;
-                        double ew = ef.W / SpritePlacement.MapScale;
-                        double eh = ef.H / SpritePlacement.MapScale;
-                        context.DrawImage(
-                            earthArt.Bitmap,
-                            new Rect(ef.X, ef.Y, ef.W, ef.H),
-                            LevelRectToScreen(v, ec.X - (ew / 2.0), ec.Y - (eh / 2.0), ew, eh));
-                    }
-                }
-            }
-
-            context.DrawRectangle(null, _palette.LevelBorder,
-                new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
-
-            int grid = doc.GridSize > 0 ? doc.GridSize : 32;
-            for (int gx = 0; gx <= doc.Width; gx += grid)
-            {
-                Vec2 a = v.LevelToScreen(new Vec2(gx, 0));
-                Vec2 b = v.LevelToScreen(new Vec2(gx, doc.Height));
-                context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
-            }
-            for (int gy = 0; gy <= doc.Height; gy += grid)
-            {
-                Vec2 a = v.LevelToScreen(new Vec2(0, gy));
-                Vec2 b = v.LevelToScreen(new Vec2(doc.Width, gy));
-                context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
-            }
+            DrawLevelContent(context, v, Bounds.Size, doc, sprites, drawGrid: true);
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
-
-            // Ropes are interleaved per grab - each grab draws its hook's back art, then its rope, then the
-            // hook's front art - so the rope threads between the two hook layers the way the game does
-            // (Grab.DrawBack + Grab.Draw). Ropes with no target resolve to null and are skipped, keeping the
-            // per-rope seed (for seasonal light frames) in step with the grabs that actually have a rope.
-            Rect opBounds = new(Bounds.Size);
-
-            // Light-bulb lit-glow halos: an additive Skia pass under the bottles, matching the game's
-            // DrawLight-then-bottle order. Drawn once for every bulb with a positive litRadius.
-            List<(Vec2 Center, double Radius)> glowBulbs = [];
-            foreach (LevelObject o in objects)
-            {
-                if (o.Type == "lightBulb" && RadiusRing.Of(o) is { } ring)
-                {
-                    glowBulbs.Add((new Vec2(o.X, o.Y), ring.Radius));
-                }
-            }
-            if (glowBulbs.Count > 0 && sprites.GetSprite("lightBulb_glow") is { Layers.Count: >= 1 } glow)
-            {
-                SpriteLayerDraw glowLayer = glow.Layers[0];
-                context.Custom(new GlowDrawOperation(opBounds, v, glowLayer.Bitmap, glowLayer.Frame.Frame, glowBulbs));
-            }
-
-            // Draw in the game's fixed z-order (GameScene.Draw) rather than level-list order, so a candy
-            // placed before a grab still sits above its rope. OrderBy is a stable sort, so objects sharing
-            // a layer keep their list order - this keeps the per-rope seed deterministic across grabs.
-            int ropeSeed = 0;
-            foreach (LevelObject obj in objects.OrderBy(GameDrawLayer))
-            {
-                if (obj.Type == "grab")
-                {
-                    RopeVisual? rope = RopeRenderer.BuildRope(obj, objects, doc.TwoParts, ActiveRopeSkin);
-                    DrawGrab(context, v, sprites, obj, objects, doc.TwoParts, rope, ropeSeed, opBounds);
-                    if (rope is not null)
-                    {
-                        ropeSeed++;
-                    }
-                }
-                else
-                {
-                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport);
-                }
-            }
 
             GrabRenderer.DrawRadiusRings(context, v, objects, _palette.GrabRadius, _palette.BulbRadius);
 
@@ -573,6 +459,143 @@ namespace CtrDxEditor.Rendering
                     DrawSprite(context, v, ghostSprite, _ghostLevel.X, _ghostLevel.Y);
                 }
             }
+        }
+
+        // Draws the level itself - background decoration, optional border+grid, light-bulb glow, and all
+        // objects/grabs in the game's z-order - into the given surface. Interactive chrome (selection,
+        // radius rings, hitboxes, ghost) is NOT drawn here; Render layers that on top. drawGrid gates the
+        // editor-only border and grid so a clean screenshot can omit them.
+        private void DrawLevelContent(
+            DrawingContext context,
+            ViewTransform v,
+            Size renderSize,
+            LevelDocument doc,
+            SpriteCache sprites,
+            bool drawGrid)
+        {
+            Vec2 tl = v.LevelToScreen(new Vec2(0, 0));
+            Vec2 br = v.LevelToScreen(new Vec2(doc.Width, doc.Height));
+
+            Bitmap? bg = sprites.GetBackground(ActiveBackground);
+            if (bg is not null && bg.Size is { Width: > 0, Height: > 0 } bgSize)
+            {
+                Bitmap? p2 = sprites.GetBackgroundP2(ActiveBackground);
+                double p2Aspect = p2 is { Size: { Width: > 0 } p2s } ? p2s.Height / p2s.Width : 0.0;
+                BackgroundLayout layout = BackgroundPlacement.Compute(
+                    doc.Width, doc.Height, bgSize.Height / bgSize.Width,
+                    p2Aspect, SpriteCache.GetBackgroundP2Y(ActiveBackground),
+                    SpriteCache.GetEarthBgPosition(ActiveBackground));
+
+                using (context.PushClip(new Rect(0, tl.Y, renderSize.Width, br.Y - tl.Y)))
+                {
+                    if (layout.TileHeight > 0.5)
+                    {
+                        Rect bgSrc = new(bgSize);
+                        for (double ty = 0; ty < doc.Height; ty += layout.TileHeight)
+                        {
+                            context.DrawImage(bg, bgSrc, LevelRectToScreen(v, layout.Left, ty, layout.Width, layout.TileHeight));
+                        }
+                    }
+
+                    if (layout.P2 is { } p2b && p2 is not null)
+                    {
+                        context.DrawImage(p2, new Rect(p2.Size), LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
+                    }
+
+                    if (layout.EarthCenter is { } ec && sprites.GetEarthArt() is { } earthArt)
+                    {
+                        IntRect ef = earthArt.Frame.Frame;
+                        double ew = ef.W / SpritePlacement.MapScale;
+                        double eh = ef.H / SpritePlacement.MapScale;
+                        context.DrawImage(
+                            earthArt.Bitmap,
+                            new Rect(ef.X, ef.Y, ef.W, ef.H),
+                            LevelRectToScreen(v, ec.X - (ew / 2.0), ec.Y - (eh / 2.0), ew, eh));
+                    }
+                }
+            }
+
+            if (drawGrid)
+            {
+                context.DrawRectangle(null, _palette.LevelBorder,
+                    new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
+
+                int grid = doc.GridSize > 0 ? doc.GridSize : 32;
+                for (int gx = 0; gx <= doc.Width; gx += grid)
+                {
+                    Vec2 a = v.LevelToScreen(new Vec2(gx, 0));
+                    Vec2 b = v.LevelToScreen(new Vec2(gx, doc.Height));
+                    context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                }
+                for (int gy = 0; gy <= doc.Height; gy += grid)
+                {
+                    Vec2 a = v.LevelToScreen(new Vec2(0, gy));
+                    Vec2 b = v.LevelToScreen(new Vec2(doc.Width, gy));
+                    context.DrawLine(_palette.Grid, new Point(a.X, a.Y), new Point(b.X, b.Y));
+                }
+            }
+
+            IReadOnlyList<LevelObject> objects = doc.Objects;
+            Rect opBounds = new(renderSize);
+
+            // Light-bulb lit-glow halos: an additive Skia pass under the bottles (game's DrawLight order).
+            List<(Vec2 Center, double Radius)> glowBulbs = [];
+            foreach (LevelObject o in objects)
+            {
+                if (o.Type == "lightBulb" && RadiusRing.Of(o) is { } ring)
+                {
+                    glowBulbs.Add((new Vec2(o.X, o.Y), ring.Radius));
+                }
+            }
+            if (glowBulbs.Count > 0 && sprites.GetSprite("lightBulb_glow") is { Layers.Count: >= 1 } glow)
+            {
+                SpriteLayerDraw glowLayer = glow.Layers[0];
+                context.Custom(new GlowDrawOperation(opBounds, v, glowLayer.Bitmap, glowLayer.Frame.Frame, glowBulbs));
+            }
+
+            // Draw in the game's fixed z-order (GameScene.Draw), a stable sort so same-layer objects keep list order.
+            int ropeSeed = 0;
+            foreach (LevelObject obj in objects.OrderBy(GameDrawLayer))
+            {
+                if (obj.Type == "grab")
+                {
+                    RopeVisual? rope = RopeRenderer.BuildRope(obj, objects, doc.TwoParts, ActiveRopeSkin);
+                    DrawGrab(context, v, sprites, obj, objects, doc.TwoParts, rope, ropeSeed, opBounds);
+                    if (rope is not null)
+                    {
+                        ropeSeed++;
+                    }
+                }
+                else
+                {
+                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Renders the whole level clean (no grid, border, selection, hitboxes, or ghost) onto an opaque
+        /// black backdrop at the game's native scale, for saving as a screenshot. Returns null when there is
+        /// no document or sprite cache.
+        /// </summary>
+        public RenderTargetBitmap? RenderLevelToBitmap()
+        {
+            if (Document is not { } doc || Sprites is not { } sprites)
+            {
+                return null;
+            }
+
+            double bgWidth = ActiveBackground > 0 ? BackgroundPlacement.LevelScreenWidth : 0.0;
+            ScreenshotFrame frame = ComputeScreenshotFrame(doc.Width, doc.Height, bgWidth);
+
+            RenderTargetBitmap rtb = new(frame.Size, new Vector(96, 96));
+            Size renderSize = new(frame.Size.Width, frame.Size.Height);
+            using (DrawingContext ctx = rtb.CreateDrawingContext())
+            {
+                ctx.FillRectangle(Brushes.Black, new Rect(renderSize));
+                DrawLevelContent(ctx, frame.View, renderSize, doc, sprites, drawGrid: false);
+            }
+            return rtb;
         }
 
         // Selection marquee: the trimmed (visible) sprite bounds — the union of every layer's drawn

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -185,6 +185,15 @@ namespace CtrDxEditor.Rendering
         private static Cursor ResizeCursor => LazyResizeCursor.Value;
         private static Cursor VResizeCursor => LazyVResizeCursor.Value;
 
+        // Game-accurate grab auto-catch ring for screenshots: a dashed blue circle matching the game's
+        // Grab.DrawGrabCircle (RGBA 0.2/0.5/0.9, drawn as alternating segments). The on-canvas ring keeps
+        // the themed orange editor guide; this fixed color is only baked into the exported image.
+        private static readonly Pen ScreenshotGrabRadiusPen =
+            new(new SolidColorBrush(Color.FromArgb(255, 51, 128, 230)), 3.0)
+            {
+                DashStyle = new DashStyle([4, 3], 0),
+            };
+
         private bool _dragging;
         private bool _resizingRadius;
         // Which movable-rail handle the current drag is manipulating (slide the hook or resize an end);
@@ -414,7 +423,7 @@ namespace CtrDxEditor.Rendering
             }
 
             ViewTransform v = View;
-            DrawLevelContent(context, v, Bounds.Size, doc, sprites, drawGrid: true);
+            DrawLevelContent(context, v, Bounds.Size, doc, sprites, drawGrid: true, grabRadiusPen: null);
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
 
@@ -463,15 +472,18 @@ namespace CtrDxEditor.Rendering
 
         // Draws the level itself - background decoration, optional border+grid, light-bulb glow, and all
         // objects/grabs in the game's z-order - into the given surface. Interactive chrome (selection,
-        // radius rings, hitboxes, ghost) is NOT drawn here; Render layers that on top. drawGrid gates the
-        // editor-only border and grid so a clean screenshot can omit them.
+        // hitboxes, ghost) is NOT drawn here; Render layers that on top. drawGrid gates the editor-only
+        // border and grid so a clean screenshot can omit them. grabRadiusPen, when set, bakes the grab
+        // auto-catch rings into the image with that pen (the screenshot's game-blue ring); Render passes
+        // null and draws its own themed rings in the chrome pass instead.
         private void DrawLevelContent(
             DrawingContext context,
             ViewTransform v,
             Size renderSize,
             LevelDocument doc,
             SpriteCache sprites,
-            bool drawGrid)
+            bool drawGrid,
+            Pen? grabRadiusPen)
         {
             Vec2 tl = v.LevelToScreen(new Vec2(0, 0));
             Vec2 br = v.LevelToScreen(new Vec2(doc.Width, doc.Height));
@@ -571,6 +583,11 @@ namespace CtrDxEditor.Rendering
                     DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport);
                 }
             }
+
+            if (grabRadiusPen is not null)
+            {
+                GrabRenderer.DrawGrabRadiusRings(context, v, objects, grabRadiusPen);
+            }
         }
 
         /// <summary>
@@ -593,7 +610,7 @@ namespace CtrDxEditor.Rendering
             using (DrawingContext ctx = rtb.CreateDrawingContext())
             {
                 ctx.FillRectangle(Brushes.Black, new Rect(renderSize));
-                DrawLevelContent(ctx, frame.View, renderSize, doc, sprites, drawGrid: false);
+                DrawLevelContent(ctx, frame.View, renderSize, doc, sprites, drawGrid: false, grabRadiusPen: ScreenshotGrabRadiusPen);
             }
             return rtb;
         }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -302,6 +302,29 @@ namespace CtrDxEditor.Rendering
             UpdateScrollState();
         }
 
+        /// <summary>The pixel size and view transform for a clean full-level screenshot.</summary>
+        /// <param name="Size">Output bitmap size in pixels (level units x MapScale).</param>
+        /// <param name="View">Transform placing the frame's top-left at pixel (0, 0).</param>
+        public readonly record struct ScreenshotFrame(PixelSize Size, ViewTransform View);
+
+        /// <summary>
+        /// Computes the screenshot frame for a level. The frame width is the wider of the playfield and the
+        /// background column (<paramref name="bgWidth"/>, 0 when no background), centered on the playfield;
+        /// the height is the level height. Everything renders at <see cref="SpritePlacement.MapScale"/> so the
+        /// output matches the game's native art resolution.
+        /// </summary>
+        public static ScreenshotFrame ComputeScreenshotFrame(int levelWidth, int levelHeight, double bgWidth)
+        {
+            double scale = SpritePlacement.MapScale;
+            double frameWidth = Math.Max(levelWidth, bgWidth);
+            double frameLeft = (levelWidth - frameWidth) / 2.0;
+            PixelSize size = new(
+                Math.Max(1, (int)Math.Round(frameWidth * scale)),
+                Math.Max(1, (int)Math.Round(levelHeight * scale)));
+            ViewTransform view = new(scale, -frameLeft * scale, 0.0);
+            return new ScreenshotFrame(size, view);
+        }
+
         /// <summary>Zooms about the viewport center (for menu/keyboard zoom).</summary>
         public void ZoomBy(double factor)
         {

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -37,6 +37,13 @@
           </MenuItem.Icon>
         </MenuItem>
         <Separator />
+        <MenuItem Header="{loc:Tr Menu.File.Screenshot}" Click="Screenshot_Click"
+                  IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <icons:MaterialIcon Kind="Camera" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <Separator />
         <MenuItem Header="{loc:Tr Menu.File.Close}" Click="Close_Click"
                   IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -512,7 +512,9 @@ namespace CtrDxEditor.Views
             }
 
             LevelCanvas canvas = this.FindControl<LevelCanvas>("Canvas")!;
-            RenderTargetBitmap? bitmap = canvas.RenderLevelToBitmap();
+            // The bitmap must be rendered on the UI thread (Avalonia draws RenderTargetBitmap there); the
+            // encode+write below is what we push off-thread. Disposed at method end - it holds a GPU surface.
+            using RenderTargetBitmap? bitmap = canvas.RenderLevelToBitmap();
             if (bitmap is null)
             {
                 return;
@@ -536,9 +538,13 @@ namespace CtrDxEditor.Views
                 return;
             }
 
+            // PNG encoding of a full-resolution level can take a noticeable amount of time. The bitmap is
+            // finished rendering and is not touched elsewhere, so encode + write it on a background thread
+            // to keep the editor responsive. (On the single-threaded browser runtime this still runs inline,
+            // but harmlessly.) The await resumes on the UI thread for the toast below.
             await using (Stream stream = await file.OpenWriteAsync())
             {
-                bitmap.Save(stream);
+                await Task.Run(() => bitmap.Save(stream));
             }
 
             // Confirm the save with a toast showing where it landed (a full local path on desktop, the

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 using AvaloniaDialogs.Views;
@@ -512,18 +513,13 @@ namespace CtrDxEditor.Views
             }
 
             LevelCanvas canvas = this.FindControl<LevelCanvas>("Canvas")!;
-            // The bitmap must be rendered on the UI thread (Avalonia draws RenderTargetBitmap there); the
-            // encode+write below is what we push off-thread. Disposed at method end - it holds a GPU surface.
-            using RenderTargetBitmap? bitmap = canvas.RenderLevelToBitmap();
-            if (bitmap is null)
-            {
-                return;
-            }
 
             string suggested = _currentLevelFile is { Name: { } name }
                 ? Path.ChangeExtension(name, ".png")
                 : "level.png";
 
+            // Pick the destination first, before doing any rendering, so the dialog opens instantly and the
+            // "Saving…" toast can appear the moment the user confirms - covering the render + encode below.
             IStorageFile? file = await TopLevel.GetTopLevel(this)!.StorageProvider.SaveFilePickerAsync(
                 new FilePickerSaveOptions
                 {
@@ -538,19 +534,49 @@ namespace CtrDxEditor.Views
                 return;
             }
 
-            // PNG encoding of a full-resolution level can take a noticeable amount of time. The bitmap is
-            // finished rendering and is not touched elsewhere, so encode + write it on a background thread
-            // to keep the editor responsive. (On the single-threaded browser runtime this still runs inline,
-            // but harmlessly.) The await resumes on the UI thread for the toast below.
-            await using (Stream stream = await file.OpenWriteAsync())
+            WindowNotificationManager? toasts = Notifications();
+
+            // Show a sticky "Saving…" toast up front (Expiration.Zero = stays until replaced). The manager's
+            // MaxItems is 1, so the terminal "Saved"/"Failed" toast below evicts this one in place.
+            toasts?.Show(new Notification(
+                Localizer.Get("Notification.Screenshot.Saving"),
+                string.Empty,
+                NotificationType.Information,
+                expiration: TimeSpan.Zero));
+
+            // Yield below the render priority so the toast actually paints before the UI-thread render and
+            // the encode hog the thread - otherwise a fast save could finish before "Saving…" ever showed.
+            await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+            try
             {
+                // The bitmap must be rendered on the UI thread (Avalonia draws RenderTargetBitmap there);
+                // the encode+write is what we push off-thread. Disposed here - it holds a GPU surface.
+                using RenderTargetBitmap bitmap = canvas.RenderLevelToBitmap()
+                    ?? throw new InvalidOperationException("The level could not be rendered.");
+
+                // PNG encoding of a full-resolution level can take a noticeable amount of time. The bitmap
+                // is finished rendering and is not touched elsewhere, so encode + write it on a background
+                // thread to keep the editor responsive. (On the single-threaded browser runtime this still
+                // runs inline, but harmlessly.) The await resumes on the UI thread for the toast below.
+                await using Stream stream = await file.OpenWriteAsync();
                 await Task.Run(() => bitmap.Save(stream));
+            }
+            catch (Exception ex)
+            {
+                // Backgrounding the save means an encode/IO failure would otherwise go unobserved on this
+                // async void handler; surface it as a toast (which also clears the sticky "Saving…" one).
+                toasts?.Show(new Notification(
+                    Localizer.Get("Notification.Screenshot.Failed"),
+                    ex.Message,
+                    NotificationType.Error));
+                return;
             }
 
             // Confirm the save with a toast showing where it landed (a full local path on desktop, the
             // download name in the browser where paths are not exposed).
             string location = file.TryGetLocalPath() ?? file.Name;
-            Notifications()?.Show(new Notification(
+            toasts?.Show(new Notification(
                 Localizer.Get("Notification.Screenshot.Title"),
                 location,
                 NotificationType.Success));
@@ -565,7 +591,9 @@ namespace CtrDxEditor.Views
                 _notifications = new WindowNotificationManager(top)
                 {
                     Position = NotificationPosition.BottomRight,
-                    MaxItems = 3,
+                    // One at a time: showing the terminal toast evicts the sticky "Saving…" one, so the
+                    // screenshot save reads as a single toast that updates in place.
+                    MaxItems = 1,
                 };
             }
             return _notifications;

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -31,6 +32,7 @@ namespace CtrDxEditor.Views
         private EditorViewModel? _mutatedSubscription;
         private readonly Action _invalidateCanvas;
         private IStorageFile? _currentLevelFile;
+        private WindowNotificationManager? _notifications;
 
         /// <summary>Creates the main editor view and wires input gestures.</summary>
         public MainView()
@@ -529,11 +531,38 @@ namespace CtrDxEditor.Views
                     FileTypeChoices = [new FilePickerFileType(Localizer.Get("Dialog.FileType.Png")) { Patterns = ["*.png"] }],
                 });
 
-            if (file is not null)
+            if (file is null)
             {
-                await using Stream stream = await file.OpenWriteAsync();
+                return;
+            }
+
+            await using (Stream stream = await file.OpenWriteAsync())
+            {
                 bitmap.Save(stream);
             }
+
+            // Confirm the save with a toast showing where it landed (a full local path on desktop, the
+            // download name in the browser where paths are not exposed).
+            string location = file.TryGetLocalPath() ?? file.Name;
+            Notifications()?.Show(new Notification(
+                Localizer.Get("Notification.Screenshot.Title"),
+                location,
+                NotificationType.Success));
+        }
+
+        // The toast host, created lazily against the current TopLevel and reused. Null only before the
+        // view is attached to a window, which cannot happen from a menu click.
+        private WindowNotificationManager? Notifications()
+        {
+            if (_notifications is null && TopLevel.GetTopLevel(this) is { } top)
+            {
+                _notifications = new WindowNotificationManager(top)
+                {
+                    Position = NotificationPosition.BottomRight,
+                    MaxItems = 3,
+                };
+            }
+            return _notifications;
         }
 
         private async Task SaveAsAsync(EditorViewModel vm)

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 
@@ -498,6 +499,40 @@ namespace CtrDxEditor.Views
             if (DataContext is EditorViewModel vm)
             {
                 await SaveAsAsync(vm);
+            }
+        }
+
+        private async void Screenshot_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is not EditorViewModel vm || !vm.HasDocument)
+            {
+                return;
+            }
+
+            LevelCanvas canvas = this.FindControl<LevelCanvas>("Canvas")!;
+            RenderTargetBitmap? bitmap = canvas.RenderLevelToBitmap();
+            if (bitmap is null)
+            {
+                return;
+            }
+
+            string suggested = _currentLevelFile is { Name: { } name }
+                ? Path.ChangeExtension(name, ".png")
+                : "level.png";
+
+            IStorageFile? file = await TopLevel.GetTopLevel(this)!.StorageProvider.SaveFilePickerAsync(
+                new FilePickerSaveOptions
+                {
+                    Title = Localizer.Get("Dialog.Screenshot.Title"),
+                    DefaultExtension = "png",
+                    SuggestedFileName = suggested,
+                    FileTypeChoices = [new FilePickerFileType(Localizer.Get("Dialog.FileType.Png")) { Patterns = ["*.png"] }],
+                });
+
+            if (file is not null)
+            {
+                await using Stream stream = await file.OpenWriteAsync();
+                bitmap.Save(stream);
             }
         }
 

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -1,0 +1,52 @@
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Rendering;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests the pure framing math behind the level-screenshot export.</summary>
+    public class LevelCanvasScreenshotTests
+    {
+        /// <summary>No background: the frame is the playfield, rendered at MapScale, no pan.</summary>
+        [Fact]
+        public void NoBackgroundUsesLevelSizeAtMapScale()
+        {
+            LevelCanvas.ScreenshotFrame frame = LevelCanvas.ComputeScreenshotFrame(640, 480, 0);
+
+            Assert.Equal(1920, frame.Size.Width);
+            Assert.Equal(1440, frame.Size.Height);
+            Assert.Equal(SpritePlacement.MapScale, frame.View.Zoom);
+            Assert.Equal(0, frame.View.PanX, 3);
+            Assert.Equal(0, frame.View.PanY, 3);
+        }
+
+        /// <summary>Background wider than the level: frame widens to the bg column and centers the level.</summary>
+        [Fact]
+        public void WideBackgroundUsesBackgroundWidthCentered()
+        {
+            double bg = BackgroundPlacement.LevelScreenWidth;
+
+            LevelCanvas.ScreenshotFrame frame = LevelCanvas.ComputeScreenshotFrame(640, 480, bg);
+
+            Assert.Equal(2560, frame.Size.Width);
+            Assert.Equal(1440, frame.Size.Height);
+            // Level narrower than the column -> left wing (bg-640)/2 level units, xMapScale in screen px.
+            double expectedPanX = (bg - 640) / 2.0 * SpritePlacement.MapScale;
+            Assert.Equal(expectedPanX, frame.View.PanX, 3);
+        }
+
+        /// <summary>Level wider than the background column: frame follows the level width, no pan.</summary>
+        [Fact]
+        public void WideLevelUsesLevelWidth()
+        {
+            double bg = BackgroundPlacement.LevelScreenWidth;
+
+            LevelCanvas.ScreenshotFrame frame = LevelCanvas.ComputeScreenshotFrame(1200, 500, bg);
+
+            Assert.Equal(3600, frame.Size.Width);
+            Assert.Equal(1500, frame.Size.Height);
+            Assert.Equal(0, frame.View.PanX, 3);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add "Take Level Screenshot..." under File menu.
- Add notification toaster to let users know when the screenshot is being saved and has finished saving to the device.
- Fix cosmic box background does not duplicate earth background for long levels.