### PR TITLE
fix: browser (WASM) background rendering, candy/Om Nom freezes, and screenshot saving

### DIFF
--- a/src/CtrDxEditor.Browser/Content/IndexedDbContentStore.cs
+++ b/src/CtrDxEditor.Browser/Content/IndexedDbContentStore.cs
@@ -58,6 +58,34 @@ namespace CtrDxEditor.Browser.Content
         }
 
         /// <inheritdoc />
+        public byte[] ReadBytes(string relPath)
+        {
+            using Stream s = Entry(LoadedArchive(), relPath).Open();
+            using MemoryStream ms = new();
+            s.CopyTo(ms);
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc />
+        public string ReadText(string relPath)
+        {
+            using Stream s = Entry(LoadedArchive(), relPath).Open();
+            using StreamReader r = new(s, Encoding.UTF8);
+            return r.ReadToEnd();
+        }
+
+        /// <summary>
+        /// The zip archive, which the async reads load into memory once during preload. Synchronous reads
+        /// cannot themselves await the IndexedDB fetch, so they require it to already be resident; on the
+        /// single-threaded browser it always is by the time on-demand sprites are requested.
+        /// </summary>
+        private ZipArchive LoadedArchive()
+        {
+            return _archive
+                ?? throw new InvalidOperationException("Content archive not loaded; an async read must run first.");
+        }
+
+        /// <inheritdoc />
         public async Task<bool> IsPopulatedAsync()
         {
             ZipArchive? zip = await ArchiveAsync();

--- a/src/CtrDxEditor.Shared/Content/FolderContentStore.cs
+++ b/src/CtrDxEditor.Shared/Content/FolderContentStore.cs
@@ -31,6 +31,18 @@ namespace CtrDxEditor.Content
         }
 
         /// <inheritdoc />
+        public byte[] ReadBytes(string relPath)
+        {
+            return File.ReadAllBytes(Full(relPath));
+        }
+
+        /// <inheritdoc />
+        public string ReadText(string relPath)
+        {
+            return File.ReadAllText(Full(relPath));
+        }
+
+        /// <inheritdoc />
         public async Task<bool> IsPopulatedAsync()
         {
             string manifestPath = Full(ContentManifest.FileName);

--- a/src/CtrDxEditor.Shared/Content/IContentStore.cs
+++ b/src/CtrDxEditor.Shared/Content/IContentStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace CtrDxEditor.Content
@@ -16,5 +17,22 @@ namespace CtrDxEditor.Content
 
         /// <summary>True when the manifest is present and every file it lists resolves.</summary>
         Task<bool> IsPopulatedAsync();
+
+        /// <summary>
+        /// Reads the asset's raw bytes synchronously, from data the store already holds in memory (or on
+        /// local disk). Throws if it is absent. Unlike <see cref="ReadBytesAsync"/> this never awaits, so
+        /// it is safe to call from the UI thread on single-threaded WebAssembly, where blocking on an
+        /// async read deadlocks the sole thread. Stores that cannot serve reads synchronously throw.
+        /// </summary>
+        byte[] ReadBytes(string relPath)
+        {
+            throw new NotSupportedException("This content store does not support synchronous reads.");
+        }
+
+        /// <summary>Reads the asset as UTF-8 text synchronously. See <see cref="ReadBytes"/>.</summary>
+        string ReadText(string relPath)
+        {
+            throw new NotSupportedException("This content store does not support synchronous reads.");
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -219,7 +219,7 @@ namespace CtrDxEditor.Content
             Bitmap? bmp = null;
             try
             {
-                string rel = $"images/backgrounds/bgr_{id:D2}{suffix}.png";
+                string rel = $"images/backgrounds/bgr_{id:D2}{suffix}{imageExtension}";
                 byte[] bytes = store.ReadBytes(rel);
                 using MemoryStream ms = new(bytes);
                 bmp = Bitmap.DecodeToWidth(ms, decodeWidth);

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -201,10 +201,9 @@ namespace CtrDxEditor.Content
         }
 
         /// <remarks>
-        /// The <see cref="IContentStore"/> read is dispatched through <c>Task.Run</c> so the awaited
-        /// continuation never marshals back to a UI SynchronizationContext. Calling this synchronously
-        /// from the UI thread therefore blocks only on the file read/decode rather than deadlocking
-        /// against its own continuation.
+        /// Reads the image through the store's synchronous API. On single-threaded WebAssembly there is no
+        /// worker thread, so a sync-over-async read (blocking on <c>ReadBytesAsync</c>) deadlocks the sole
+        /// UI thread; the store instead serves the bytes from the archive it already loaded during preload.
         /// </remarks>
         private Bitmap? LoadBackground(int id, int decodeWidth, ConcurrentDictionary<int, Bitmap?> cache, string suffix = "_p1")
         {
@@ -221,7 +220,7 @@ namespace CtrDxEditor.Content
             try
             {
                 string rel = $"images/backgrounds/bgr_{id:D2}{suffix}.png";
-                byte[] bytes = Task.Run(() => store.ReadBytesAsync(rel)).GetAwaiter().GetResult();
+                byte[] bytes = store.ReadBytes(rel);
                 using MemoryStream ms = new(bytes);
                 bmp = Bitmap.DecodeToWidth(ms, decodeWidth);
             }
@@ -395,8 +394,7 @@ namespace CtrDxEditor.Content
         {
             try
             {
-                byte[] bytes = Task.Run(() => store.ReadBytesAsync(CandySkins.ResourceBase(skin) + imageExtension))
-                    .GetAwaiter().GetResult();
+                byte[] bytes = store.ReadBytes(CandySkins.ResourceBase(skin) + imageExtension);
                 using MemoryStream ms = new(bytes);
                 return new Bitmap(ms);
             }
@@ -410,7 +408,7 @@ namespace CtrDxEditor.Content
         {
             try
             {
-                string json = Task.Run(() => store.ReadTextAsync(CandySkins.JsonPath(skin))).GetAwaiter().GetResult();
+                string json = store.ReadText(CandySkins.JsonPath(skin));
                 return new Atlas(AtlasJsonLoader.ParseFrames(json));
             }
             catch (Exception ex) when (ex is IOException or FileNotFoundException or InvalidOperationException)

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -556,11 +556,16 @@ namespace CtrDxEditor.Views
                     ?? throw new InvalidOperationException("The level could not be rendered.");
 
                 // PNG encoding of a full-resolution level can take a noticeable amount of time. The bitmap
-                // is finished rendering and is not touched elsewhere, so encode + write it on a background
-                // thread to keep the editor responsive. (On the single-threaded browser runtime this still
-                // runs inline, but harmlessly.) The await resumes on the UI thread for the toast below.
+                // is finished rendering and is not touched elsewhere, so encode it on a background thread to
+                // keep the editor responsive. (On the single-threaded browser runtime this still runs inline,
+                // but harmlessly.) Bitmap.Save writes synchronously, which the browser's destination stream
+                // rejects - it supports only async writes - so encode into memory first, then copy to the
+                // destination with async writes. The await resumes on the UI thread for the toast below.
+                using MemoryStream buffer = new();
+                await Task.Run(() => bitmap.Save(buffer));
+                buffer.Position = 0;
                 await using Stream stream = await file.OpenWriteAsync();
-                await Task.Run(() => bitmap.Save(stream));
+                await buffer.CopyToAsync(stream);
             }
             catch (Exception ex)
             {

--- a/src/CtrDxEditor.Tests/SpriteCacheBackgroundTests.cs
+++ b/src/CtrDxEditor.Tests/SpriteCacheBackgroundTests.cs
@@ -36,6 +36,94 @@ namespace CtrDxEditor.Tests
             {
                 return Task.FromResult(true);
             }
+
+            public byte[] ReadBytes(string relPath)
+            {
+                return [];
+            }
+
+            public string ReadText(string relPath)
+            {
+                return "";
+            }
+        }
+
+        // Records which read API the cache used. Its async reads never complete synchronously (they
+        // model the WebAssembly single thread, where blocking on an async read deadlocks); only the
+        // synchronous reads return, so a passing assertion proves the cache took the safe sync path.
+        private sealed class RecordingStore : IContentStore
+        {
+            public bool AsyncBytesCalled;
+            public bool SyncBytesCalled;
+            public bool SyncTextCalled;
+
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(true);
+            }
+
+            public async Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                AsyncBytesCalled = true;
+                await Task.Yield();
+                return [];
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult("");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(true);
+            }
+
+            public byte[] ReadBytes(string relPath)
+            {
+                SyncBytesCalled = true;
+                return [];
+            }
+
+            public string ReadText(string relPath)
+            {
+                SyncTextCalled = true;
+                return "[]";
+            }
+        }
+
+        /// <summary>
+        /// Regression: on-demand background loads must use the store's synchronous read, not sync-over-async.
+        /// On single-threaded WebAssembly there is no worker thread, so <c>Task.Run(...).GetResult()</c>
+        /// deadlocks the sole UI thread (froze the app when a New Level background/thumbnail was resolved).
+        /// </summary>
+        [Fact]
+        public void GetBackgroundUsesSynchronousStoreRead()
+        {
+            RecordingStore store = new();
+            SpriteCache cache = new(store);
+
+            _ = cache.GetBackground(1);
+
+            Assert.True(store.SyncBytesCalled, "GetBackground must read background bytes synchronously.");
+            Assert.False(store.AsyncBytesCalled, "GetBackground must not block on an async read (deadlocks on WASM).");
+        }
+
+        /// <summary>
+        /// Regression: on-demand candy-skin loads must use the store's synchronous reads, not sync-over-async,
+        /// for the same WebAssembly single-thread reason as <see cref="GetBackgroundUsesSynchronousStoreRead"/>.
+        /// </summary>
+        [Fact]
+        public void GetCandySpriteUsesSynchronousStoreReads()
+        {
+            RecordingStore store = new();
+            SpriteCache cache = new(store);
+
+            _ = cache.GetSprite("candy", candySkin: 1);
+
+            Assert.True(store.SyncBytesCalled, "Loading a candy skin's atlas image must read bytes synchronously.");
+            Assert.True(store.SyncTextCalled, "Loading a candy skin's atlas table must read text synchronously.");
+            Assert.False(store.AsyncBytesCalled, "Candy-skin loads must not block on an async read (deadlocks on WASM).");
         }
 
         // A single-threaded context whose posted continuations are never pumped: reproduces the

--- a/src/CtrDxEditor.Tests/SpriteCacheBackgroundTests.cs
+++ b/src/CtrDxEditor.Tests/SpriteCacheBackgroundTests.cs
@@ -56,6 +56,7 @@ namespace CtrDxEditor.Tests
             public bool AsyncBytesCalled;
             public bool SyncBytesCalled;
             public bool SyncTextCalled;
+            public string? LastSyncBytesPath;
 
             public Task<bool> ExistsAsync(string relPath)
             {
@@ -82,6 +83,7 @@ namespace CtrDxEditor.Tests
             public byte[] ReadBytes(string relPath)
             {
                 SyncBytesCalled = true;
+                LastSyncBytesPath = relPath;
                 return [];
             }
 
@@ -107,6 +109,21 @@ namespace CtrDxEditor.Tests
 
             Assert.True(store.SyncBytesCalled, "GetBackground must read background bytes synchronously.");
             Assert.False(store.AsyncBytesCalled, "GetBackground must not block on an async read (deadlocks on WASM).");
+        }
+
+        /// <summary>
+        /// Regression: the background path must honour the configured image extension. The browser bundle
+        /// ships WebP, not PNG, so a hardcoded ".png" resolves to no entry and the background renders blank.
+        /// </summary>
+        [Fact]
+        public void GetBackgroundHonoursConfiguredImageExtension()
+        {
+            RecordingStore store = new();
+            SpriteCache cache = new(store, ".webp");
+
+            _ = cache.GetBackground(1);
+
+            Assert.Equal("images/backgrounds/bgr_01_p1.webp", store.LastSyncBytesPath);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Fixes three bugs that only surfaced in the WebAssembly browser build.

1. Freeze when picking a background / candy / Om Nom platform

On-demand sprite loaders (`LoadBackground`, `LoadCandyBitmap`, `LoadCandyAtlas`) resolved bytes with `Task.Run(() => store.ReadBytesAsync(...)).GetAwaiter().GetResult()`. That sync-over-async pattern was added to dodge the *desktop* UI-thread deadlock, but the browser build has no worker threads (`WasmEnableThreads` is off), so `Task.Run` can only run on the single UI thread — blocking it with `.GetResult()` means the queued read never runs and the app deadlocks.

Added a synchronous `ReadBytes`/`ReadText` to `IContentStore`. `IndexedDbContentStore` serves them straight from the zip archive it already holds in memory after preload; `FolderContentStore` reads from disk. The loaders now call these directly — no `Task.Run`, no blocking. Laziness is preserved (no extra preload memory).

2. Backgrounds render blank

With the deadlock gone, a latent bug surfaced: the background path was hardcoded to `.png`, while every other loader honours the configured `imageExtension`. The browser bundle ships WebP, so `bgr_01_p1.png` resolved to nothing. Now uses `imageExtension` (`.webp` on browser, `.png` on desktop).

3. Saving a screenshot fails

`bitmap.Save(stream)` writes synchronously, but the browser's `OpenWriteAsync` stream supports only async writes. Now encodes the PNG into a `MemoryStream` first, then `CopyToAsync` to the destination.