### PR TITLE
feat: Add timed star editing and night-level canvas variants

### DIFF
--- a/src/CtrDxEditor.Core.Tests/DescriptorTableTests.cs
+++ b/src/CtrDxEditor.Core.Tests/DescriptorTableTests.cs
@@ -48,12 +48,13 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(int.MaxValue, DescriptorTable.Default.For("star")!.MaxCount);
         }
 
-        /// <summary>Verifies the default timeout value for star descriptors.</summary>
+        /// <summary>Verifies the timeout metadata for star descriptors.</summary>
         [Fact]
-        public void StarDefaultTimeoutIsMinusOne()
+        public void StarTimeoutIsDecimalWithMinusOneDefault()
         {
             AttributeSpec timeout = Assert.Single(DescriptorTable.Default.For("star")!.Attributes);
             Assert.Equal("timeout", timeout.Name);
+            Assert.Equal(AttrType.Number, timeout.Type);
             Assert.Equal("-1", timeout.Default);
         }
 

--- a/src/CtrDxEditor.Core.Tests/RoundTripTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RoundTripTests.cs
@@ -42,6 +42,23 @@ namespace CtrDxEditor.Core.Tests
             Assert.Contains("Ja", localeLayers);
         }
 
+        /// <summary>Star timeout values survive round-trip as authored, including decimals and zero.</summary>
+        [Fact]
+        public void StarTimeoutsSurviveRoundTrip()
+        {
+            const string original =
+                "<level width=\"640\" height=\"480\">" +
+                "<star x=\"100\" y=\"120\" timeout=\"4.5\" />" +
+                "<star x=\"200\" y=\"220\" timeout=\"0\" />" +
+                "</level>";
+
+            LevelDocument doc = LevelDocument.Parse(original);
+            XDocument after = XDocument.Parse(doc.Save());
+
+            string[] timeouts = [.. after.Root!.Elements("star").Select(s => (string?)s.Attribute("timeout") ?? string.Empty)];
+            Assert.Equal(["4.5", "0"], timeouts);
+        }
+
         // Re-serialize with normalized whitespace so DeepEquals compares structure, not formatting.
         private static XDocument Normalize(XDocument d)
         {

--- a/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
+++ b/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
@@ -34,7 +34,7 @@ namespace CtrDxEditor.Core.Descriptors
             new ObjectDescriptor("candyR", "Candy (Right)", [], MaxCount: 1),
             new ObjectDescriptor("star", "Star",
             [
-                new AttributeSpec("timeout", AttrType.Whole, "-1"),
+                new AttributeSpec("timeout", AttrType.Number, "-1"),
             ], MaxCount: int.MaxValue),
             new ObjectDescriptor("grab", "Grab",
             [

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -338,7 +338,6 @@ namespace CtrDxEditor.Content
             // Candy frames are addressed by quad index against the active skin's atlas; everything else
             // resolves against its own preloaded atlas by frame name (or quad, if the layer specifies one).
             bool isCandy = element is "candy" or "candyL" or "candyR";
-            bool isTarget = element == "target";
             (Bitmap? candyBitmap, Atlas? candyAtlas) = isCandy ? LoadCandySkin(candySkin) : (null, null);
 
             List<SpriteLayerDraw> layers = new(v.Layers.Count);
@@ -347,7 +346,7 @@ namespace CtrDxEditor.Content
                 Bitmap? bitmap = isCandy ? candyBitmap : LoadBitmap(layer.AtlasImageBasePath + imageExtension);
                 Atlas? atlas = isCandy ? candyAtlas : LoadAtlas(layer.AtlasJsonRelPath);
                 // The target's platform is whichever char_supports frame the active support selects.
-                AtlasFrame? frame = isTarget && omNomSupport > 0 && layer.AtlasJsonRelPath == SupportsAtlasJson
+                AtlasFrame? frame = omNomSupport > 0 && layer.AtlasJsonRelPath == SupportsAtlasJson
                     ? atlas?.At(omNomSupport)
                     : atlas?.At(layer.Quad);
                 if (bitmap is not null && frame is not null)

--- a/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
+++ b/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
@@ -161,6 +161,14 @@ namespace CtrDxEditor.Content
                 new SpriteLayer("images/obj_star_idle.json", "images/obj_star_idle", 18),
             ]),
 
+            // Timed star ring = empty ring behind full ring. The editor is static, so it draws the full
+            // timer rather than clipping it to a countdown fraction.
+            new("star_timed",
+            [
+                new SpriteLayer("images/obj_star_idle.json", "images/obj_star_idle", 20),
+                new SpriteLayer("images/obj_star_idle.json", "images/obj_star_idle", 19),
+            ]),
+
             // Gravity button.
             new("gravitySwitch",
             [

--- a/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
+++ b/src/CtrDxEditor.Shared/Content/VisualDescriptorMap.cs
@@ -31,6 +31,14 @@ namespace CtrDxEditor.Content
                 new SpriteLayer("images/char_animations.json", "images/char_animations", 0),
             ]),
 
+            // Night Om Nom keeps the selected support cup, but uses DX's classic sleeping spritesheet
+            // (OriginalTargetAnimationBackend), not the Flash/XML blink frames.
+            new("target_sleeping",
+            [
+                new SpriteLayer("images/char_supports.json", "images/char_supports", 0),
+                new SpriteLayer("images/char_animations_sleeping.json", "images/char_animations_sleeping", 6),
+            ]),
+
             // Candy = wrapper bottom + body + wrapper top (all share sourceSize 393x418). Addressed by
             // quad index, not frame name: candy skins share this frame order but not their frame names,
             // and SpriteCache swaps in the active skin's atlas at resolve time. Matches the game's

--- a/src/CtrDxEditor.Shared/Controls/NumericTextBox.cs
+++ b/src/CtrDxEditor.Shared/Controls/NumericTextBox.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -24,6 +25,10 @@ namespace CtrDxEditor.Controls
         public static readonly StyledProperty<int> MaximumProperty =
             AvaloniaProperty.Register<NumericTextBox, int>(nameof(Maximum), 9999);
 
+        /// <summary>Backs <see cref="AcceptDecimal"/>.</summary>
+        public static readonly StyledProperty<bool> AcceptDecimalProperty =
+            AvaloniaProperty.Register<NumericTextBox, bool>(nameof(AcceptDecimal));
+
         /// <inheritdoc/>
         protected override Type StyleKeyOverride => typeof(TextBox);
 
@@ -33,6 +38,9 @@ namespace CtrDxEditor.Controls
         /// <summary>Largest value the box will accept.</summary>
         public int Maximum { get => GetValue(MaximumProperty); set => SetValue(MaximumProperty, value); }
 
+        /// <summary>Whether the box accepts one decimal point in addition to whole-number input.</summary>
+        public bool AcceptDecimal { get => GetValue(AcceptDecimalProperty); set => SetValue(AcceptDecimalProperty, value); }
+
         /// <summary>
         /// Whether <paramref name="text"/> is an acceptable value or a prefix of one: empty, a lone
         /// "-" (when negatives are allowed), or an integer within [<paramref name="min"/>,
@@ -40,6 +48,16 @@ namespace CtrDxEditor.Controls
         /// digit; anything containing a non-digit, or out of range, is rejected.
         /// </summary>
         public static bool IsAcceptable(string text, int min, int max)
+        {
+            return IsAcceptable(text, min, max, acceptDecimal: false);
+        }
+
+        /// <summary>
+        /// Decimal-aware variant of <see cref="IsAcceptable(string,int,int)"/>. When
+        /// <paramref name="acceptDecimal"/> is true, one "." is allowed and the parsed value is checked
+        /// against the same bounds.
+        /// </summary>
+        public static bool IsAcceptable(string text, int min, int max, bool acceptDecimal)
         {
             if (text.Length == 0)
             {
@@ -60,15 +78,30 @@ namespace CtrDxEditor.Controls
                 i = 1;
             }
 
+            bool sawDecimal = false;
             for (; i < text.Length; i++)
             {
-                if (!char.IsDigit(text[i]))
+                char c = text[i];
+                if (acceptDecimal && c == '.')
+                {
+                    if (sawDecimal)
+                    {
+                        return false;
+                    }
+                    sawDecimal = true;
+                    continue;
+                }
+                if (!char.IsDigit(c))
                 {
                     return false;
                 }
             }
 
-            return long.TryParse(text, out long value) && value >= min && value <= max;
+            return acceptDecimal && sawDecimal
+                ? double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double decimalValue)
+                    && decimalValue >= min
+                    && decimalValue <= max
+                : long.TryParse(text, out long value) && value >= min && value <= max;
         }
 
         /// <inheritdoc />
@@ -113,7 +146,7 @@ namespace CtrDxEditor.Controls
         // Whether replacing the current selection with insert yields an acceptable string.
         private bool WouldBeAcceptable(string insert)
         {
-            return IsAcceptable(Prospective(insert), Minimum, Maximum);
+            return IsAcceptable(Prospective(insert), Minimum, Maximum, AcceptDecimal);
         }
 
         private string Prospective(string insert)

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -131,7 +131,8 @@
     "Object.gravitySwitch": "Gravity button",
     "Object.lightBulb": "Light bulb",
 
-    "Attr.timeout": "Timeout",
+    "Attr.timed": "Timed",
+    "Attr.timeout": "Duration (s)",
     "Attr.length": "Length",
     "Attr.part": "Split candy bind",
     "Attr.part.L": "Left",

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Styling;
 
 namespace CtrDxEditor.Rendering
 {
@@ -42,6 +43,11 @@ namespace CtrDxEditor.Rendering
         /// <summary>Selection marquee for an unlocked object.</summary>
         public Pen ObjectSelected { get; private set; } = OverlayPen(Brushes.DeepSkyBlue, 1.5);
 
+        /// <summary>Text brush for a timed-star duration label on the blank (no-background) canvas:
+        /// pure white in the dark theme, pure black in the light theme. When a background is applied
+        /// the canvas draws these labels black regardless.</summary>
+        public IBrush StarDurationText { get; private set; } = Brushes.White;
+
         /// <summary>Re-resolves every brush and pen for <paramref name="host"/>'s active theme variant.</summary>
         public void Refresh(Control host)
         {
@@ -58,6 +64,7 @@ namespace CtrDxEditor.Rendering
             HitboxPhone = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
+            StarDurationText = host.ActualThemeVariant == ThemeVariant.Dark ? Brushes.White : Brushes.Black;
         }
 
         /// <summary>Resolves a themed <see cref="Color"/> resource for the host's active theme variant,

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -680,6 +680,21 @@ namespace CtrDxEditor.Rendering
         private static void DrawObject(
             DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport)
         {
+            if (obj.Type == "star" && StarTimeout(obj) is double timeout && timeout > 0)
+            {
+                if (sprites.GetSprite("star_timed") is { } timed)
+                {
+                    DrawSprite(ctx, v, timed, obj.X, obj.Y);
+                }
+                if (sprites.GetSprite("star", candySkin, omNomSupport) is { } star)
+                {
+                    DrawSprite(ctx, v, star, obj.X, obj.Y);
+                    DrawStarDuration(ctx, v, star, obj, timeout);
+                }
+                DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+                return;
+            }
+
             ObjectSprite? sprite = sprites.GetSprite(GrabRenderer.SpriteKey(obj), candySkin, omNomSupport);
             if (sprite is not null)
             {
@@ -690,6 +705,54 @@ namespace CtrDxEditor.Rendering
                 DrawSprite(ctx, v, sprite, obj.X, obj.Y);
             }
             DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+        }
+
+        private static double StarTimeout(LevelObject obj)
+        {
+            return double.TryParse(obj.GetAttr("timeout"), NumberStyles.Float, CultureInfo.InvariantCulture, out double timeout)
+                ? timeout
+                : 0;
+        }
+
+        private static void DrawStarDuration(DrawingContext ctx, ViewTransform v, ObjectSprite star, LevelObject obj, double timeout)
+        {
+            string text = FormatStarDuration(timeout);
+            FormattedText formatted = new(
+                text,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily.Default, FontStyle.Normal, FontWeight.Bold),
+                Math.Max(10.0, 18.0 * v.Zoom),
+                Brushes.White);
+
+            double top = StarTop(star, obj);
+            Vec2 anchor = v.LevelToScreen(new Vec2(obj.X, top));
+            Point origin = ComputeStarDurationOrigin(
+                new Point(anchor.X, anchor.Y),
+                new Size(formatted.Width, formatted.Height),
+                v.Zoom);
+            ctx.DrawText(formatted, origin);
+        }
+
+        private static string FormatStarDuration(double timeout)
+        {
+            return timeout.ToString("0.###", CultureInfo.InvariantCulture) + "s";
+        }
+
+        private static Point ComputeStarDurationOrigin(Point starTopCenter, Size textSize, double zoom)
+        {
+            return new Point(starTopCenter.X - (textSize.Width / 2.0), starTopCenter.Y + (2.0 * zoom));
+        }
+
+        private static double StarTop(ObjectSprite star, LevelObject obj)
+        {
+            double top = double.MaxValue;
+            foreach (SpriteLayerDraw layer in star.Layers)
+            {
+                LevelBounds bounds = SpritePlacement.Compute(layer.Frame, obj.X, obj.Y, star.Scale).Dest;
+                top = Math.Min(top, bounds.Y);
+            }
+            return top == double.MaxValue ? obj.Y : top;
         }
 
         // A pale grab is one the game hides outright (invisible="true"); the editor keeps it visible at

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -433,7 +433,7 @@ namespace CtrDxEditor.Rendering
             {
                 foreach (LevelObject obj in objects)
                 {
-                    if (sprites.GetSprite(obj.Type) is not { } sprite)
+                    if (sprites.GetSprite(CanvasSpriteKey(obj, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is not { } sprite)
                     {
                         continue;
                     }
@@ -451,7 +451,7 @@ namespace CtrDxEditor.Rendering
             LevelObject? selected = SelectedObject;
             if (selected is not null)
             {
-                LevelBounds sb = SelectionBounds(sprites, selected, ActiveCandySkin, ActiveOmNomSupport);
+                LevelBounds sb = SelectionBounds(sprites, selected, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
                 Vec2 stl = v.LevelToScreen(new Vec2(sb.X, sb.Y));
                 Vec2 sbr = v.LevelToScreen(new Vec2(sb.X + sb.W, sb.Y + sb.H));
                 // Both boxes are dashed; a locked object is red, an unlocked one blue.
@@ -461,7 +461,7 @@ namespace CtrDxEditor.Rendering
 
             // Translucent ghost of the object being dragged from the palette, at its snapped drop spot.
             if (_ghostActive && _ghostElement is { } ghostElement
-                && sprites.GetSprite(ghostElement, ActiveCandySkin, ActiveOmNomSupport) is { } ghostSprite)
+                && sprites.GetSprite(CanvasSpriteKey(ghostElement, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is { } ghostSprite)
             {
                 using (context.PushOpacity(0.7))
                 {
@@ -584,7 +584,7 @@ namespace CtrDxEditor.Rendering
                 }
                 else
                 {
-                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport);
+                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
                 }
             }
 
@@ -622,7 +622,7 @@ namespace CtrDxEditor.Rendering
         // Selection marquee: the trimmed (visible) sprite bounds — the union of every layer's drawn
         // region — grown 25% so the dashed box sits a little outside the art rather than hugging the
         // untrimmed sourceSize box (which is much larger than what the player sees).
-        private static LevelBounds SelectionBounds(SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport)
+        private static LevelBounds SelectionBounds(SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport, bool nightLevel)
         {
             // A movable grab's marquee / click target wraps the whole rail, not just the hook, so it can
             // be selected by clicking anywhere along the bar.
@@ -634,7 +634,7 @@ namespace CtrDxEditor.Rendering
             // Pass the active decoration so the box matches the drawn art (candy skins and Om Nom
             // platforms vary in trimmed size, which would otherwise mis-size the marquee / hit box).
             // RenderSpriteKey (not SpriteKey) so a fixed hook's box matches whichever random quad pair it drew.
-            ObjectSprite? sprite = sprites.GetSprite(GrabRenderer.RenderSpriteKey(obj), candySkin, omNomSupport);
+            ObjectSprite? sprite = sprites.GetSprite(SelectionSpriteKey(GrabRenderer.RenderSpriteKey(obj), nightLevel), candySkin, omNomSupport);
             if (sprite is null || sprite.Layers.Count == 0)
             {
                 return new LevelBounds(obj.X - 8, obj.Y - 8, 16, 16);
@@ -678,7 +678,7 @@ namespace CtrDxEditor.Rendering
         // Draws a non-grab object: its optional decorative back-layer variant, then every sprite layer,
         // then any overlays. Grabs go through DrawGrab instead so their rope can slot between hook layers.
         private static void DrawObject(
-            DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport)
+            DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport, bool nightLevel)
         {
             if (obj.Type == "star" && StarTimeout(obj) is double timeout && timeout > 0)
             {
@@ -686,7 +686,7 @@ namespace CtrDxEditor.Rendering
                 {
                     DrawSprite(ctx, v, timed, obj.X, obj.Y);
                 }
-                if (sprites.GetSprite("star", candySkin, omNomSupport) is { } star)
+                if (sprites.GetSprite(CanvasSpriteKey("star", nightLevel), candySkin, omNomSupport) is { } star)
                 {
                     DrawSprite(ctx, v, star, obj.X, obj.Y);
                     DrawStarDuration(ctx, v, star, obj, timeout);
@@ -695,7 +695,7 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
-            ObjectSprite? sprite = sprites.GetSprite(GrabRenderer.SpriteKey(obj), candySkin, omNomSupport);
+            ObjectSprite? sprite = sprites.GetSprite(CanvasSpriteKey(GrabRenderer.SpriteKey(obj), nightLevel), candySkin, omNomSupport);
             if (sprite is not null)
             {
                 if (sprite.Variants.Count > 0)
@@ -712,6 +712,25 @@ namespace CtrDxEditor.Rendering
             return double.TryParse(obj.GetAttr("timeout"), NumberStyles.Float, CultureInfo.InvariantCulture, out double timeout)
                 ? timeout
                 : 0;
+        }
+
+        private static string CanvasSpriteKey(LevelObject obj, bool nightLevel)
+        {
+            return CanvasSpriteKey(GrabRenderer.SpriteKey(obj), nightLevel);
+        }
+
+        private static string CanvasSpriteKey(string element, bool nightLevel)
+        {
+            return nightLevel ? element switch
+            {
+                "target" => "target_sleeping",
+                _ => element,
+            } : element;
+        }
+
+        private static string SelectionSpriteKey(string element, bool nightLevel)
+        {
+            return element == "star" ? "star" : CanvasSpriteKey(element, nightLevel);
         }
 
         private static void DrawStarDuration(DrawingContext ctx, ViewTransform v, ObjectSprite star, LevelObject obj, double timeout)
@@ -1045,7 +1064,7 @@ namespace CtrDxEditor.Rendering
             {
                 list.Add(Sprites is null
                     ? new LevelBounds(o.X - 8, o.Y - 8, 16, 16)
-                    : SelectionBounds(Sprites, o, ActiveCandySkin, ActiveOmNomSupport));
+                    : SelectionBounds(Sprites, o, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel));
             }
             return list;
         }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -584,7 +584,8 @@ namespace CtrDxEditor.Rendering
                 }
                 else
                 {
-                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
+                    DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel,
+                        ActiveBackground > 0 ? Brushes.Black : _palette.StarDurationText);
                 }
             }
 
@@ -678,7 +679,14 @@ namespace CtrDxEditor.Rendering
         // Draws a non-grab object: its optional decorative back-layer variant, then every sprite layer,
         // then any overlays. Grabs go through DrawGrab instead so their rope can slot between hook layers.
         private static void DrawObject(
-            DrawingContext ctx, ViewTransform v, SpriteCache sprites, LevelObject obj, int candySkin, int omNomSupport, bool nightLevel)
+            DrawingContext ctx,
+            ViewTransform v,
+            SpriteCache sprites,
+            LevelObject obj,
+            int candySkin,
+            int omNomSupport,
+            bool nightLevel,
+            IBrush starDurationText)
         {
             if (obj.Type == "star" && StarTimeout(obj) is double timeout && timeout > 0)
             {
@@ -689,7 +697,7 @@ namespace CtrDxEditor.Rendering
                 if (sprites.GetSprite(CanvasSpriteKey("star", nightLevel), candySkin, omNomSupport) is { } star)
                 {
                     DrawSprite(ctx, v, star, obj.X, obj.Y);
-                    DrawStarDuration(ctx, v, star, obj, timeout);
+                    DrawStarDuration(ctx, v, star, obj, timeout, starDurationText);
                 }
                 DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
                 return;
@@ -733,16 +741,15 @@ namespace CtrDxEditor.Rendering
             return element == "star" ? "star" : CanvasSpriteKey(element, nightLevel);
         }
 
-        private static void DrawStarDuration(DrawingContext ctx, ViewTransform v, ObjectSprite star, LevelObject obj, double timeout)
+        private static void DrawStarDuration(
+            DrawingContext ctx,
+            ViewTransform v,
+            ObjectSprite star,
+            LevelObject obj,
+            double timeout,
+            IBrush foreground)
         {
-            string text = FormatStarDuration(timeout);
-            FormattedText formatted = new(
-                text,
-                CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                new Typeface(FontFamily.Default, FontStyle.Normal, FontWeight.Bold),
-                Math.Max(10.0, 18.0 * v.Zoom),
-                Brushes.White);
+            FormattedText formatted = CreateStarDurationText(FormatStarDuration(timeout), v.Zoom, foreground);
 
             double top = StarTop(star, obj);
             Vec2 anchor = v.LevelToScreen(new Vec2(obj.X, top));
@@ -751,6 +758,17 @@ namespace CtrDxEditor.Rendering
                 new Size(formatted.Width, formatted.Height),
                 v.Zoom);
             ctx.DrawText(formatted, origin);
+        }
+
+        private static FormattedText CreateStarDurationText(string text, double zoom, IBrush foreground)
+        {
+            return new FormattedText(
+                text,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily.DefaultFontFamilyName, FontStyle.Normal, FontWeight.Bold),
+                Math.Max(10.0, 18.0 * zoom),
+                foreground);
         }
 
         private static string FormatStarDuration(double timeout)

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -33,6 +33,7 @@ namespace CtrDxEditor.ViewModels
             Label = Localizer.AttributeName(name);
             IsBool = type == AttrType.Bool;
             IsNumeric = type is AttrType.Whole or AttrType.Number;
+            AllowsDecimal = type == AttrType.Number;
             EnumValues = enumValues;
             EnumOptions = enumValues?.Select(v => new AttributeOptionViewModel(v, LabelForOption(name, v))).ToArray();
             _get = () => target.GetAttr(name);
@@ -73,6 +74,7 @@ namespace CtrDxEditor.ViewModels
             Label = Localizer.AttributeName(name);
             IsBool = type == AttrType.Bool;
             IsNumeric = type is AttrType.Whole or AttrType.Number;
+            AllowsDecimal = type == AttrType.Number;
             _get = get;
             _set = set;
             _onChanging = onChanging ?? (() => { });
@@ -94,8 +96,11 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Whether this field renders as a checkbox.</summary>
         public bool IsBool { get; }
 
-        /// <summary>Whether this field renders as a whole-number-only box (x, y, length, radius, ...).</summary>
+        /// <summary>Whether this field renders as a numeric box.</summary>
         public bool IsNumeric { get; }
+
+        /// <summary>Whether this numeric field accepts decimal values.</summary>
+        public bool AllowsDecimal { get; }
 
         /// <summary>
         /// Smallest value a numeric field accepts. Lengths and radii are magnitudes and cannot go
@@ -104,6 +109,7 @@ namespace CtrDxEditor.ViewModels
         /// </summary>
         public int NumericMinimum => Name switch
         {
+            "timeout" => 1,
             "length" or "radius" or "moveLength" or "moveOffset" or "litRadius" => 0,
             _ => -9999,
         };
@@ -131,7 +137,7 @@ namespace CtrDxEditor.ViewModels
         /// <summary>The current underlying value.</summary>
         public string? Value
         {
-            get => _get();
+            get => DisplayValue(_get());
             set
             {
                 if (_get() == value)
@@ -171,6 +177,13 @@ namespace CtrDxEditor.ViewModels
                     "R" => "right",
                     _ => value,
                 }
+                : value;
+        }
+
+        private string? DisplayValue(string? value)
+        {
+            return AllowsDecimal && value?.EndsWith(".0", StringComparison.Ordinal) == true
+                ? value[..^2]
                 : value;
         }
     }

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -370,6 +370,12 @@ namespace CtrDxEditor.ViewModels
             Fields.Add(new AttributeFieldViewModel(value, "x", AttrType.Whole, null, Changed, Changing));
             Fields.Add(new AttributeFieldViewModel(value, "y", AttrType.Whole, null, Changed, Changing));
 
+            if (value.Type == "star")
+            {
+                StarFieldBuilder.Build(Fields, value, Changed, Changing, () => PopulateFields(value));
+                return;
+            }
+
             if (value.Type == "grab" && Document is not null)
             {
                 GrabFieldBuilder.Build(Fields, value, Document, Changed, Changing, () => PopulateFields(value));

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -215,8 +215,13 @@ namespace CtrDxEditor.ViewModels
                 bool enabled = Document is not null && LockedObject is null && !Cardinality.IsAtCapacity(d, objs);
                 Palette.Add(new PaletteItemViewModel(
                     d.ElementName, Localizer.ObjectName(d.ElementName), enabled,
-                    Sprites.GetThumbnail(d.ElementName, ActiveCandySkin, ActiveOmNomSupport)));
+                    Sprites.GetThumbnail(PaletteSpriteKey(d.ElementName), ActiveCandySkin, ActiveOmNomSupport)));
             }
+        }
+
+        private static string PaletteSpriteKey(string element)
+        {
+            return element;
         }
 
         // Candy type follows twoParts. When no document is

--- a/src/CtrDxEditor.Shared/ViewModels/StarFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/StarFieldBuilder.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using CtrDxEditor.Core.Descriptors;
+using CtrDxEditor.Core.Document;
+
+namespace CtrDxEditor.ViewModels
+{
+    /// <summary>Builds star properties with timed-star disclosure.</summary>
+    public static class StarFieldBuilder
+    {
+        /// <summary>Appends the star's timed toggle and optional duration field.</summary>
+        public static void Build(
+            IList<AttributeFieldViewModel> fields,
+            LevelObject star,
+            Action onChanged,
+            Action onChanging,
+            Action rebuild)
+        {
+            bool timed = Timeout(star) > 0;
+
+            void Structural()
+            {
+                onChanged();
+                rebuild();
+            }
+
+            fields.Add(new AttributeFieldViewModel(
+                "timed",
+                AttrType.Bool,
+                () => timed ? "true" : "false",
+                v => star.SetAttr("timeout", v == "true" ? "5" : "-1"),
+                Structural,
+                onChanging));
+
+            if (timed)
+            {
+                fields.Add(new AttributeFieldViewModel(star, "timeout", AttrType.Number, null, onChanged, onChanging));
+            }
+        }
+
+        private static double Timeout(LevelObject star)
+        {
+            return double.TryParse(star.GetAttr("timeout"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? value
+                : 0;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Views/PropertyPanel.axaml
+++ b/src/CtrDxEditor.Shared/Views/PropertyPanel.axaml
@@ -46,6 +46,7 @@
                        IsEnabled="{Binding IsEnabled}"
                        Cursor="{Binding IsEnabled, Converter={x:Static conv:PropertyFieldStateConverters.Cursor}}"
                        Minimum="{Binding NumericMinimum}"
+                       AcceptDecimal="{Binding AllowsDecimal}"
                        Text="{Binding Value, Mode=TwoWay}" />
               <TextBox Grid.Column="1" IsVisible="{Binding IsText}"
                        IsEnabled="{Binding IsEnabled}"

--- a/src/CtrDxEditor.Tests/EditorPaletteGatingTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteGatingTests.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+
+using Avalonia.Media.Imaging;
 
 using CtrDxEditor.Content;
 using CtrDxEditor.Core.Document;
@@ -75,6 +80,23 @@ namespace CtrDxEditor.Tests
             Assert.True(PaletteHas(vm, "candyL"));
             Assert.True(PaletteHas(vm, "candyR"));
             Assert.True(PaletteHas(vm, "lightBulb"));
+        }
+
+        /// <summary>The star palette thumbnail stays on the normal star in night levels.</summary>
+        [Fact]
+        public void NightLevelStarPaletteUsesNormalStarIcon()
+        {
+            SpriteCache sprites = new(new EmptyStore());
+            Bitmap star = (Bitmap)RuntimeHelpers.GetUninitializedObject(typeof(Bitmap));
+            SetPrivateField(sprites, "_thumbnails", new Dictionary<string, Bitmap?>
+            {
+                ["star"] = star,
+            });
+            EditorViewModel vm = new(sprites);
+
+            vm.NewLevel(new LevelSettings(320, 480, 1.0f, 0, TwoParts: false, NightLevel: true));
+
+            Assert.Same(star, PaletteItem(vm, "star").Icon);
         }
 
         /// <summary>Updating level settings rewrites the document's resolution and special value.</summary>
@@ -158,6 +180,13 @@ namespace CtrDxEditor.Tests
 
             Assert.True(PaletteItem(vm, "star").Enabled);
             Assert.NotNull(vm.PlaceObject("star", 100, 120));
+        }
+
+        private static void SetPrivateField<T>(object target, string name, T value)
+        {
+            FieldInfo? field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field.SetValue(target, value);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/GrabPropertyTests.cs
+++ b/src/CtrDxEditor.Tests/GrabPropertyTests.cs
@@ -136,6 +136,44 @@ namespace CtrDxEditor.Tests
             Assert.Contains(vm.Fields, f => f.Name == "radius");
         }
 
+        /// <summary>Star timed disclosure keeps untimed stars compact, and toggling on authors a duration.</summary>
+        [Fact]
+        public void StarTimedToggleRevealsDuration()
+        {
+            EditorViewModel vm = Vm();
+            vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: false));
+            LevelObject star = vm.PlaceObject("star", 100, 120)!;
+            vm.SelectedObject = star;
+
+            AttributeFieldViewModel timed = vm.Fields.Single(f => f.Name == "timed");
+            Assert.True(timed.IsBool);
+            Assert.False(timed.BoolValue);
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "timeout");
+            Assert.Equal("-1", star.GetAttr("timeout"));
+
+            timed.BoolValue = true;
+
+            Assert.Equal("5", star.GetAttr("timeout"));
+            AttributeFieldViewModel duration = vm.Fields.Single(f => f.Name == "timeout");
+            Assert.Equal(1, duration.NumericMinimum);
+            Assert.True(duration.AllowsDecimal);
+        }
+
+        /// <summary>A loaded timeout of zero reads as untimed and is not rewritten by field construction.</summary>
+        [Fact]
+        public void StarTimeoutZeroReadsAsUntimed()
+        {
+            EditorViewModel vm = Vm();
+            vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: false));
+            LevelObject star = vm.PlaceObject("star", 100, 120)!;
+            star.SetAttr("timeout", "0");
+            vm.SelectedObject = star;
+
+            Assert.False(vm.Fields.Single(f => f.Name == "timed").BoolValue);
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "timeout");
+            Assert.Equal("0", star.GetAttr("timeout"));
+        }
+
         /// <summary>Movable rail toggles rail sub-field disclosure.</summary>
         [Fact]
         public void MovableToggleRevealsRailFields()

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -1,8 +1,17 @@
 using System.Reflection;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 
 using Avalonia;
+using Avalonia.Media.Imaging;
 
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Atlas;
+using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
 using CtrDxEditor.Rendering;
 
 using Xunit;
@@ -12,6 +21,29 @@ namespace CtrDxEditor.Tests
     /// <summary>Tests the pure framing math behind the level-screenshot export.</summary>
     public class LevelCanvasScreenshotTests
     {
+        private sealed class FakeStore : IContentStore
+        {
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(true);
+            }
+
+            public Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                return Task.FromResult<byte[]>([]);
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult(/*lang=json,strict*/ """{"frames":{}}""");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(true);
+            }
+        }
+
         /// <summary>No background: the frame is the playfield, rendered at MapScale, no pan.</summary>
         [Fact]
         public void NoBackgroundUsesLevelSizeAtMapScale()
@@ -82,6 +114,90 @@ namespace CtrDxEditor.Tests
             string label = (string)method.Invoke(null, [timeout])!;
 
             Assert.Equal(expected, label);
+        }
+
+        /// <summary>Night levels keep normal stars but draw classic sleeping Om Nom.</summary>
+        [Theory]
+        [InlineData("star", true, "star")]
+        [InlineData("target", true, "target_sleeping")]
+        [InlineData("star", false, "star")]
+        [InlineData("target", false, "target")]
+        public void CanvasSpriteKeyUsesNightLevelVariants(string element, bool nightLevel, string expected)
+        {
+            MethodInfo? method = typeof(LevelCanvas).GetMethod(
+                "CanvasSpriteKey",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                [typeof(string), typeof(bool)]);
+            Assert.NotNull(method);
+
+            string key = (string)method.Invoke(null, [element, nightLevel])!;
+
+            Assert.Equal(expected, key);
+        }
+
+        /// <summary>Night star selection keeps the normal star marquee instead of the smaller night atlas canvas.</summary>
+        [Fact]
+        public void NightStarSelectionBoundsUseNormalStarBounds()
+        {
+            SpriteCache sprites = SeedStarAtlases();
+            LevelObject star = new(new XElement("star", new XAttribute("x", "0"), new XAttribute("y", "0")));
+            MethodInfo? method = typeof(LevelCanvas).GetMethod(
+                "SelectionBounds",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            LevelBounds normal = (LevelBounds)method.Invoke(null, [sprites, star, 0, 0, false])!;
+            LevelBounds night = (LevelBounds)method.Invoke(null, [sprites, star, 0, 0, true])!;
+
+            Assert.Equal(normal.X, night.X, 3);
+            Assert.Equal(normal.Y, night.Y, 3);
+            Assert.Equal(normal.W, night.W, 3);
+            Assert.Equal(normal.H, night.H, 3);
+        }
+
+        private static SpriteCache SeedStarAtlases()
+        {
+            SpriteCache cache = new(new FakeStore());
+            Bitmap bitmap = (Bitmap)RuntimeHelpers.GetUninitializedObject(typeof(Bitmap));
+            SetPrivateField(cache, "_bitmaps", new Dictionary<string, Bitmap>
+            {
+                ["images/obj_star_idle.png"] = bitmap,
+            });
+            SetPrivateField(cache, "_atlases", new Dictionary<string, Atlas>
+            {
+                ["images/obj_star_idle.json"] = new Atlas(
+                [
+                    Frame("idle-glow", 236, 223, 155, 155, 552, 552),
+                    .. EmptyFrames(17),
+                    Frame("idle-body", 85, 80, 229, 229, 552, 552),
+                ]),
+            });
+            return cache;
+        }
+
+        private static IEnumerable<AtlasFrame> EmptyFrames(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return Frame($"empty-{i}", 1, 1, 0, 0, 1, 1);
+            }
+        }
+
+        private static AtlasFrame Frame(string filename, int w, int h, int sourceX, int sourceY, int sourceW, int sourceH)
+        {
+            return new AtlasFrame(
+                filename,
+                new IntRect(0, 0, w, h),
+                new IntRect(sourceX, sourceY, w, h),
+                new IntSize(sourceW, sourceH),
+                Rotated: false,
+                Trimmed: true);
+        }
+
+        private static void SetPrivateField<T>(SpriteCache cache, string fieldName, T value)
+        {
+            FieldInfo field = typeof(SpriteCache).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+            field.SetValue(cache, value);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -1,3 +1,7 @@
+using System.Reflection;
+
+using Avalonia;
+
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Rendering;
 
@@ -47,6 +51,37 @@ namespace CtrDxEditor.Tests
             Assert.Equal(3600, frame.Size.Width);
             Assert.Equal(1500, frame.Size.Height);
             Assert.Equal(0, frame.View.PanX, 3);
+        }
+
+        /// <summary>Timed star labels sit slightly inside the star top instead of floating above it.</summary>
+        [Fact]
+        public void StarDurationLabelSitsBelowStarTop()
+        {
+            MethodInfo? method = typeof(LevelCanvas).GetMethod(
+                "ComputeStarDurationOrigin",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            Point origin = (Point)method.Invoke(null, [new Point(120, 80), new Size(20, 12), 2.0])!;
+
+            Assert.Equal(110, origin.X, 3);
+            Assert.Equal(84, origin.Y, 3);
+        }
+
+        /// <summary>Timed star labels include the seconds unit without changing decimal trimming.</summary>
+        [Theory]
+        [InlineData(5.0, "5s")]
+        [InlineData(4.5, "4.5s")]
+        public void StarDurationLabelShowsSecondsUnit(double timeout, string expected)
+        {
+            MethodInfo? method = typeof(LevelCanvas).GetMethod(
+                "FormatStarDuration",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            string label = (string)method.Invoke(null, [timeout])!;
+
+            Assert.Equal(expected, label);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/NumericTextBoxTests.cs
+++ b/src/CtrDxEditor.Tests/NumericTextBoxTests.cs
@@ -41,5 +41,20 @@ namespace CtrDxEditor.Tests
             Assert.False(NumericTextBox.IsAcceptable("-", 0, 9999));
             Assert.False(NumericTextBox.IsAcceptable("-5", 0, 9999));
         }
+
+        /// <summary>Decimal input is accepted only by boxes that opt in.</summary>
+        [Fact]
+        public void DecimalInputRequiresOptIn()
+        {
+            Assert.True(NumericTextBox.IsAcceptable("4.5", 1, 9999, acceptDecimal: true));
+            Assert.False(NumericTextBox.IsAcceptable("4.5", 1, 9999));
+        }
+
+        /// <summary>Decimal input rejects a second decimal separator.</summary>
+        [Fact]
+        public void DecimalInputRejectsSecondPoint()
+        {
+            Assert.False(NumericTextBox.IsAcceptable("4.5.1", 1, 9999, acceptDecimal: true));
+        }
     }
 }

--- a/src/CtrDxEditor.Tests/SpriteCachePreloadTests.cs
+++ b/src/CtrDxEditor.Tests/SpriteCachePreloadTests.cs
@@ -175,6 +175,19 @@ namespace CtrDxEditor.Tests
             Assert.Equal("om-nom-quad-0", target.Layers[1].Frame.Filename);
         }
 
+        /// <summary>Sleeping target keeps the selected support and uses the classic sleeping spritesheet.</summary>
+        [Fact]
+        public void GetSpriteResolvesSleepingTargetPlatformAndSleepingFrame()
+        {
+            SpriteCache cache = new(new FakeStore());
+            SeedSleepingTargetAtlases(cache);
+
+            ObjectSprite target = Assert.IsType<ObjectSprite>(cache.GetSprite("target_sleeping", candySkin: 0, omNomSupport: 3));
+
+            Assert.Equal("support-quad-3", target.Layers[0].Frame.Filename);
+            Assert.Equal("sleeping-quad-6", target.Layers[1].Frame.Filename);
+        }
+
         private static void SeedTargetAtlases(SpriteCache cache)
         {
             Bitmap bitmap = (Bitmap)RuntimeHelpers.GetUninitializedObject(typeof(Bitmap));
@@ -202,6 +215,21 @@ namespace CtrDxEditor.Tests
             {
                 ["images/char_supports.json"] = new Atlas([.. Enumerable.Range(0, 17).Select(i => Frame($"support-quad-{i}"))]),
                 ["images/char_animations.json"] = new Atlas([Frame("om-nom-quad-0")]),
+            });
+        }
+
+        private static void SeedSleepingTargetAtlases(SpriteCache cache)
+        {
+            Bitmap bitmap = (Bitmap)RuntimeHelpers.GetUninitializedObject(typeof(Bitmap));
+            SetPrivateField(cache, "_bitmaps", new Dictionary<string, Bitmap>
+            {
+                ["images/char_supports.png"] = bitmap,
+                ["images/char_animations_sleeping.png"] = bitmap,
+            });
+            SetPrivateField(cache, "_atlases", new Dictionary<string, Atlas>
+            {
+                ["images/char_supports.json"] = new Atlas([.. Enumerable.Range(0, 17).Select(i => Frame($"support-quad-{i}"))]),
+                ["images/char_animations_sleeping.json"] = new Atlas([.. Enumerable.Range(0, 7).Select(i => Frame($"sleeping-quad-{i}"))]),
             });
         }
 

--- a/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
+++ b/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
@@ -46,6 +46,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal([3, 4], VisualDescriptorMap.For("grab_suction")!.Layers.Select(l => l.Quad));
             Assert.Equal([1, 2], VisualDescriptorMap.For("grab_suction_kicked")!.Layers.Select(l => l.Quad));
             Assert.Equal([0, 18], VisualDescriptorMap.For("star")!.Layers.Select(l => l.Quad));
+            Assert.Equal([20, 19], VisualDescriptorMap.For("star_timed")!.Layers.Select(l => l.Quad));
         }
 
         /// <summary>Verifies random back layers count toward the files a content bundle must provide.</summary>

--- a/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
+++ b/src/CtrDxEditor.Tests/VisualDescriptorMapTests.cs
@@ -49,6 +49,25 @@ namespace CtrDxEditor.Tests
             Assert.Equal([20, 19], VisualDescriptorMap.For("star_timed")!.Layers.Select(l => l.Quad));
         }
 
+        /// <summary>Night stars are not registered as a separate static editor sprite.</summary>
+        [Fact]
+        public void NightStarDescriptorIsNotRegistered()
+        {
+            Assert.Null(VisualDescriptorMap.For("star_night"));
+        }
+
+        /// <summary>Night Om Nom uses the classic sleeping spritesheet and keeps the support layer.</summary>
+        [Fact]
+        public void SleepingTargetUsesSupportAndClassicSleepingSprite()
+        {
+            VisualDescriptor target = VisualDescriptorMap.For("target_sleeping")!;
+
+            Assert.Equal(
+                ["images/char_supports.json", "images/char_animations_sleeping.json"],
+                target.Layers.Select(l => l.AtlasJsonRelPath));
+            Assert.Equal([0, 6], target.Layers.Select(l => l.Quad));
+        }
+
         /// <summary>Verifies random back layers count toward the files a content bundle must provide.</summary>
         [Fact]
         public void RequiredFilesCoverRandomBackLayerAtlases()


### PR DESCRIPTION
## Description

- Add timed star support in the editor, including a timed toggle, numeric timeout editing, XML round-trip coverage, and canvas countdown labels.
- Render timed stars with the timer ring and seconds label positioned on the star.
- Use sleeping Om Nom sprite for night level mode.
