### PR TITLE
Show force field indicator, fix hitbox not rotating with rotated objects

### DIFF
--- a/src/CtrDxEditor.Core/Editing/ForceFieldTable.cs
+++ b/src/CtrDxEditor.Core/Editing/ForceFieldTable.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// A directional force emitter's field: how far it pushes and which way relative to the object's
+    /// on-screen rotation. <see cref="Reach"/> is in game units (the same space as <see cref="HitboxDef"/>
+    /// boxes), converted to level units by the sprite's <c>scale / mapScale</c> like <see cref="HitboxTable"/>.
+    /// <see cref="DirectionOffset"/> is added to the object's display angle to get the push direction, so a
+    /// pump that blows along its mouth (game impulse <c>rotate((0,-1), rotation)</c>) is <c>-90</c>.
+    /// </summary>
+    public sealed record ForceFieldSpec(double Reach, double DirectionOffset);
+
+    /// <summary>
+    /// Registry of objects that emit a directional force, keyed by XML element name. Parallels
+    /// <see cref="RotationTable"/> and <see cref="HitboxTable"/>: the force overlay reads the reach and
+    /// direction from here, so adding an emitter (steam later) is one row. UI-free.
+    /// </summary>
+    public static class ForceFieldTable
+    {
+        private static readonly Dictionary<string, ForceFieldSpec> Specs = new()
+        {
+            // Pump: game Pump.FlowLength blown along the mouth (display angle - 90).
+            ["pump"] = new ForceFieldSpec(Reach: 624, DirectionOffset: -90),
+        };
+
+        /// <summary>The force spec for <paramref name="element"/>, or null when it emits none.</summary>
+        public static ForceFieldSpec? For(string element)
+        {
+            return Specs.TryGetValue(element, out ForceFieldSpec? spec) ? spec : null;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -292,30 +292,66 @@ namespace CtrDxEditor.Content
                 maxY = Math.Max(maxY, d.Y + d.H);
             }
 
-            double w = maxX - minX, h = maxY - minY;
-            if (w <= 0 || h <= 0)
+            if (maxX - minX <= 0 || maxY - minY <= 0)
             {
                 return null;
             }
 
+            // Rotatable objects render on the canvas turned by their display offset (e.g. pump +90), so the
+            // preview matches by rotating the art about the origin it was laid out around. The crop is taken
+            // from the rotated bounds so the whole turned sprite stays framed. Same rotation sign as the
+            // canvas (see LevelSceneRenderer.DrawLayer), which Avalonia's CreateRotation matches.
+            double rad = (RotationTable.For(element)?.DisplayOffset ?? 0) * Math.PI / 180.0;
+            (double rMinX, double rMinY, double rMaxX, double rMaxY) = RotatedBounds(minX, minY, maxX, maxY, rad);
+
+            double w = rMaxX - rMinX, h = rMaxY - rMinY;
             const double maxDim = 32.0;
             double f = Math.Min(1.0, maxDim / Math.Max(w, h));
             PixelSize size = new(Math.Max(1, (int)Math.Ceiling(w * f)), Math.Max(1, (int)Math.Ceiling(h * f)));
 
+            // Map a laid-out (origin-centered) point to bitmap pixels: rotate about the origin, shift the
+            // rotated bounds to (0,0), then scale to fit. One pushed transform covers every layer.
+            Matrix toBitmap = Matrix.CreateRotation(rad)
+                * Matrix.CreateTranslation(-rMinX, -rMinY)
+                * Matrix.CreateScale(f, f);
+
             RenderTargetBitmap rtb = new(size, new Vector(96, 96));
             using (DrawingContext ctx = rtb.CreateDrawingContext())
+            using (ctx.PushTransform(toBitmap))
             {
                 foreach (SpriteLayerDraw layer in drawn)
                 {
                     SpriteLayout layout = SpritePlacement.Compute(layer.Frame, 0, 0, sprite.Scale, mapScale: 1.0);
                     Rect src = new(layout.Source.X, layout.Source.Y, layout.Source.W, layout.Source.H);
-                    Rect dst = new(
-                        (layout.Dest.X - minX) * f, (layout.Dest.Y - minY) * f,
-                        layout.Dest.W * f, layout.Dest.H * f);
+                    Rect dst = new(layout.Dest.X, layout.Dest.Y, layout.Dest.W, layout.Dest.H);
                     ctx.DrawImage(layer.Bitmap, src, dst);
                 }
             }
             return rtb;
+        }
+
+        /// <summary>The axis-aligned bounds of the rectangle (<paramref name="minX"/>,<paramref name="minY"/>)-
+        /// (<paramref name="maxX"/>,<paramref name="maxY"/>) rotated by <paramref name="rad"/> radians about
+        /// the origin. Returns the input unchanged when the angle is zero.</summary>
+        private static (double MinX, double MinY, double MaxX, double MaxY) RotatedBounds(
+            double minX, double minY, double maxX, double maxY, double rad)
+        {
+            if (rad == 0)
+            {
+                return (minX, minY, maxX, maxY);
+            }
+            double cos = Math.Cos(rad), sin = Math.Sin(rad);
+            double rMinX = double.MaxValue, rMinY = double.MaxValue, rMaxX = double.MinValue, rMaxY = double.MinValue;
+            foreach ((double px, double py) in new[] { (minX, minY), (maxX, minY), (maxX, maxY), (minX, maxY) })
+            {
+                double rx = (px * cos) - (py * sin);
+                double ry = (px * sin) + (py * cos);
+                rMinX = Math.Min(rMinX, rx);
+                rMinY = Math.Min(rMinY, ry);
+                rMaxX = Math.Max(rMaxX, rx);
+                rMaxY = Math.Max(rMaxY, ry);
+            }
+            return (rMinX, rMinY, rMaxX, rMaxY);
         }
 
         /// <summary>Atlas holding Om Nom's sitting platforms (the target's back layer), one per frame.</summary>

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -22,6 +22,7 @@
     "Menu.View.SnapToGrid": "Snap to grid",
     "Menu.View.ShowHitboxes": "Show hitboxes",
     "Menu.View.ShowMobileHitboxes": "Show mobile hitboxes",
+    "Menu.View.ShowForceFields": "Show force fields",
 
     "Panel.Objects": "Objects",
     "Panel.Properties": "Properties",

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -43,6 +43,10 @@ namespace CtrDxEditor.Rendering
         /// <summary>Selection marquee for an unlocked object.</summary>
         public Pen ObjectSelected { get; private set; } = OverlayPen(Brushes.DeepSkyBlue, 1.5);
 
+        /// <summary>Solid arrow marking a directional force field's push direction (pump, and later steam).
+        /// Solid rather than dashed so it reads as an arrow against the dashed hitbox boxes.</summary>
+        public Pen ForceArrow { get; private set; } = new(new SolidColorBrush(Color.FromRgb(0x7F, 0x22, 0xFE)), 2);
+
         /// <summary>Text brush for a timed-star duration label on the blank (no-background) canvas:
         /// pure white in the dark theme, pure black in the light theme. When a background is applied
         /// the canvas draws these labels black regardless.</summary>
@@ -64,6 +68,7 @@ namespace CtrDxEditor.Rendering
             HitboxPhone = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
+            ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);
             StarDurationText = host.ActualThemeVariant == ThemeVariant.Dark ? Brushes.White : Brushes.Black;
         }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -94,6 +94,28 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
+            // A directional emitter shows which way and how far it pushes, toggled on its own: it is a force
+            // region, not a collision box, and its reach is model-independent (so no desktop/mobile split).
+            // Push direction is the display angle plus the field offset; reach is the game-unit flow length in
+            // level units (scale / mapScale, as hitboxes).
+            if (ShowForceFields)
+            {
+                foreach (LevelObject obj in objects)
+                {
+                    if (ForceFieldTable.For(obj.Type) is not { } field || RotationTable.For(obj.Type) is not { } forceSpec)
+                    {
+                        continue;
+                    }
+                    if (sprites.GetSprite(LevelSceneRenderer.CanvasSpriteKey(obj, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is not { } sprite)
+                    {
+                        continue;
+                    }
+                    double dir = (ObjectRotation.DisplayDegrees(obj, forceSpec) + field.DirectionOffset) * Math.PI / 180.0;
+                    double reach = field.Reach * sprite.Scale / SpritePlacement.MapScale;
+                    LevelSceneRenderer.DrawForceArrow(context, v, new Vec2(obj.X, obj.Y), dir, reach, _palette.ForceArrow);
+                }
+            }
+
             LevelObject? selected = SelectedObject;
             if (selected is not null)
             {

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -49,6 +49,10 @@ namespace CtrDxEditor.Rendering
         public static readonly StyledProperty<bool> ShowMobileHitboxesProperty =
             AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowMobileHitboxes));
 
+        /// <summary>Avalonia property backing <see cref="ShowForceFields"/>.</summary>
+        public static readonly StyledProperty<bool> ShowForceFieldsProperty =
+            AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowForceFields), defaultValue: true);
+
         /// <summary>Editor-decoration rope skin index applied to every rope (0 = default brown).</summary>
         public static readonly StyledProperty<int> ActiveRopeSkinProperty =
             AvaloniaProperty.Register<LevelCanvas, int>(nameof(ActiveRopeSkin));
@@ -96,7 +100,7 @@ namespace CtrDxEditor.Rendering
             AffectsRender<LevelCanvas>(
                 DocumentProperty, SpritesProperty, ViewProperty, SnapEnabledProperty,
                 SelectedObjectProperty, LockedObjectProperty,
-                ShowHitboxesProperty, ShowMobileHitboxesProperty,
+                ShowHitboxesProperty, ShowMobileHitboxesProperty, ShowForceFieldsProperty,
                 ActiveRopeSkinProperty, ActiveBackgroundProperty, ActiveCandySkinProperty,
                 ActiveOmNomSupportProperty);
         }
@@ -124,6 +128,9 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Whether phone hitboxes are drawn over objects.</summary>
         public bool ShowMobileHitboxes { get => GetValue(ShowMobileHitboxesProperty); set => SetValue(ShowMobileHitboxesProperty, value); }
+
+        /// <summary>Whether directional force-field arrows (e.g. the pump's flow) are drawn over objects.</summary>
+        public bool ShowForceFields { get => GetValue(ShowForceFieldsProperty); set => SetValue(ShowForceFieldsProperty, value); }
 
         /// <summary>Editor-decoration rope skin index applied to every rope (0 = default brown).</summary>
         public int ActiveRopeSkin { get => GetValue(ActiveRopeSkinProperty); set => SetValue(ActiveRopeSkinProperty, value); }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -560,5 +560,50 @@ namespace CtrDxEditor.Rendering
             }
             ctx.DrawRectangle(null, pen, box);
         }
+
+        /// <summary>
+        /// Draws an abstract force-field arrow: a shaft from <paramref name="centerLevel"/> along
+        /// <paramref name="directionRadians"/> for <paramref name="lengthLevel"/> level units, capped with a
+        /// V arrowhead. Object-agnostic on purpose so any directional emitter — the pump now, steam later —
+        /// reuses it by passing its own push direction. The direction is a plain screen angle: the view
+        /// transform is translation + uniform scale (no rotation/flip), so a level-space direction is the
+        /// same on screen.
+        /// </summary>
+        /// <param name="ctx">Destination drawing context.</param>
+        /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
+        /// <param name="centerLevel">Arrow tail (the emitter center) in level units.</param>
+        /// <param name="directionRadians">Push direction, clockwise-positive in the shared Y-down space.</param>
+        /// <param name="lengthLevel">Shaft length in level units.</param>
+        /// <param name="pen">Pen for the shaft and head.</param>
+        public static void DrawForceArrow(
+            DrawingContext ctx,
+            ViewTransform v,
+            Vec2 centerLevel,
+            double directionRadians,
+            double lengthLevel,
+            Pen pen)
+        {
+            Vec2 tipLevel = new(
+                centerLevel.X + (Math.Cos(directionRadians) * lengthLevel),
+                centerLevel.Y + (Math.Sin(directionRadians) * lengthLevel));
+            Vec2 tail = v.LevelToScreen(centerLevel);
+            Vec2 tip = v.LevelToScreen(tipLevel);
+            ctx.DrawLine(pen, new Point(tail.X, tail.Y), new Point(tip.X, tip.Y));
+
+            // V arrowhead swept back from the tip, sized to the on-screen shaft so it tracks zoom.
+            double shaft = GrabRadius.Distance(tail, tip);
+            if (shaft <= 0)
+            {
+                return;
+            }
+            double screenDir = Math.Atan2(tip.Y - tail.Y, tip.X - tail.X);
+            double head = Math.Min(shaft, 10.0);
+            double spread = Math.PI / 6;
+            foreach (double barb in new[] { screenDir + Math.PI - spread, screenDir + Math.PI + spread })
+            {
+                ctx.DrawLine(pen, new Point(tip.X, tip.Y),
+                    new Point(tip.X + (Math.Cos(barb) * head), tip.Y + (Math.Sin(barb) * head)));
+            }
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -541,7 +541,24 @@ namespace CtrDxEditor.Rendering
             }
             Vec2 tl = v.LevelToScreen(new Vec2(b.X, b.Y));
             Vec2 br = v.LevelToScreen(new Vec2(b.X + b.W, b.Y + b.H));
-            ctx.DrawRectangle(null, pen, new Rect(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y));
+            Rect box = new(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y);
+
+            // A rotatable object's box turns with its sprite about the same anchor (see DrawLayer). The view
+            // transform is translation + uniform scale, so rotating the projected box about the projected
+            // anchor equals rotating it in level space. Square boxes only diverge visibly off the axes.
+            if (RotationTable.For(obj.Type) is { } rotSpec && ObjectRotation.DisplayDegrees(obj, rotSpec) is var deg && deg != 0)
+            {
+                Vec2 center = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+                Matrix m = Matrix.CreateTranslation(-center.X, -center.Y)
+                    * Matrix.CreateRotation(deg * Math.PI / 180.0)
+                    * Matrix.CreateTranslation(center.X, center.Y);
+                using (ctx.PushTransform(m))
+                {
+                    ctx.DrawRectangle(null, pen, box);
+                }
+                return;
+            }
+            ctx.DrawRectangle(null, pen, box);
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -303,6 +303,7 @@
       <Color x:Key="EditorColor.OverlayHitboxPhone">#A800B7</Color>    <!-- fuchsia-700 -->
       <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700 -->
+      <Color x:Key="EditorColor.OverlayForceArrow">#7F22FE</Color>     <!-- violet-700 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->
@@ -341,6 +342,7 @@
       <Color x:Key="EditorColor.OverlayHitboxPhone">#F4A8FF</Color>    <!-- fuchsia-300, 10.10 -->
       <Color x:Key="EditorColor.OverlayObjectLocked">#FFA2A2</Color>   <!-- red-300, 9.29 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#00BCFF</Color> <!-- sky-400, 8.18 -->
+      <Color x:Key="EditorColor.OverlayForceArrow">#C4B4FF</Color>     <!-- violet-300, 8.90 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Deep blues so the light row text stays readable. -->

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -39,6 +39,7 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial bool SnapEnabled { get; set; }
         [ObservableProperty] public partial bool ShowHitboxes { get; set; } = true;
         [ObservableProperty] public partial bool ShowMobileHitboxes { get; set; }
+        [ObservableProperty] public partial bool ShowForceFields { get; set; } = true;
         [ObservableProperty] public partial int ActiveRopeSkin { get; set; }
         [ObservableProperty] public partial int ActiveBackground { get; set; }
         [ObservableProperty] public partial int ActiveCandySkin { get; set; }

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -169,6 +169,18 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
+        <MenuItem Click="ShowForceFieldsToggle_Click" IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <Border Width="16" Height="16" Background="Transparent" />
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <TextBlock Grid.Column="0" Text="{loc:Tr Menu.View.ShowForceFields}" VerticalAlignment="Center" />
+              <icons:MaterialIcon Grid.Column="1" Kind="CheckBold" Width="14" Height="14"
+                                  Margin="24,0,0,0" VerticalAlignment="Center" IsVisible="{Binding ShowForceFields}" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
       </MenuItem>
     </Menu>
     <Grid ColumnDefinitions="160,1,*,1,280">
@@ -199,6 +211,7 @@
                             SnapEnabled="{Binding SnapEnabled}"
                             ShowHitboxes="{Binding ShowHitboxes}"
                             ShowMobileHitboxes="{Binding ShowMobileHitboxes}"
+                            ShowForceFields="{Binding ShowForceFields}"
                             ActiveRopeSkin="{Binding ActiveRopeSkin}"
                             ActiveBackground="{Binding ActiveBackground}"
                             ActiveCandySkin="{Binding ActiveCandySkin}"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -164,6 +164,14 @@ namespace CtrDxEditor.Views
             }
         }
 
+        private void ShowForceFieldsToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.ShowForceFields = !vm.ShowForceFields;
+            }
+        }
+
         private void ObjectList_DoubleTapped(object? sender, TappedEventArgs e)
         {
             if (DataContext is EditorViewModel vm)


### PR DESCRIPTION
## Description

- Show force field indicator, available in View menu. This renders an arrow that extends to the bounding box of the force field, e.g., air cushion.
- Fix hitbox not rotating with rotated objects.