### PR TITLE
feat: Add support for attributes for circular movements

### DIFF
--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
 
 using Xunit;
 
@@ -173,6 +174,38 @@ namespace CtrDxEditor.Core.Tests
         public void PreviewDegreesUsesSignedWholeSpeed(string rotateSpeed, double elapsedSeconds, double expected)
         {
             Assert.Equal(expected, ObjectSpin.PreviewDegrees(Obj("star", rotateSpeed), elapsedSeconds));
+        }
+
+        /// <summary>Orbital preview starts at the first generated DX circular path point.</summary>
+        [Fact]
+        public void PreviewPositionStartsAtFirstCircularPathPoint()
+        {
+            Vec2 preview = ObjectSpin.PreviewPosition(Obj("star", path: "RC8", moveSpeed: "10"), 0.0);
+
+            Assert.Equal(8.0, preview.X);
+            Assert.Equal(0.0, preview.Y, precision: 6);
+        }
+
+        /// <summary>Orbital preview advances along RC and RW generated path points using moveSpeed.</summary>
+        [Fact]
+        public void PreviewPositionUsesMoveSpeedAndOrbitDirection()
+        {
+            Vec2 clockwise = ObjectSpin.PreviewPosition(Obj("star", path: "RC8", moveSpeed: "8"), 1.0);
+            Vec2 counterClockwise = ObjectSpin.PreviewPosition(Obj("star", path: "RW8", moveSpeed: "8"), 1.0);
+
+            Assert.Equal(2.3431457505, clockwise.X, precision: 6);
+            Assert.Equal(5.6568542495, clockwise.Y, precision: 6);
+            Assert.Equal(2.3431457505, counterClockwise.X, precision: 6);
+            Assert.Equal(-5.6568542495, counterClockwise.Y, precision: 6);
+        }
+
+        /// <summary>Objects without orbital data preview at their authored position.</summary>
+        [Fact]
+        public void PreviewPositionFallsBackToAuthoredPositionWithoutOrbit()
+        {
+            Vec2 preview = ObjectSpin.PreviewPosition(Obj("star", rotateSpeed: "70"), 2.0);
+
+            Assert.Equal(new Vec2(0.0, 0.0), preview);
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -152,6 +152,30 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(40, ObjectSpin.OrbitRadius(star));
         }
 
+        /// <summary>Orbit speed exposes DX moveSpeed as a positive whole-number movement speed.</summary>
+        [Theory]
+        [InlineData("80", 80)]
+        [InlineData("-90", 90)]
+        [InlineData("12.9", 12)]
+        [InlineData("not-a-number", 0)]
+        public void OrbitSpeedUsesMoveSpeedMagnitude(string moveSpeed, int expected)
+        {
+            Assert.Equal(expected, ObjectSpin.OrbitSpeed(Obj("star", path: "RC40", moveSpeed: moveSpeed)));
+        }
+
+        /// <summary>Writing orbit speed updates moveSpeed without changing the circular path or rotateSpeed.</summary>
+        [Fact]
+        public void SetOrbitSpeedWritesMoveSpeedOnly()
+        {
+            LevelObject star = Obj("star", rotateSpeed: "-70", path: "RW60", moveSpeed: "80");
+
+            ObjectSpin.SetOrbitSpeed(star, speed: 120);
+
+            Assert.Equal("120", star.GetAttr("moveSpeed"));
+            Assert.Equal("RW60", star.GetAttr("path"));
+            Assert.Equal("-70", star.GetAttr("rotateSpeed"));
+        }
+
         /// <summary>Writing self-spin preserves existing circular orbit data.</summary>
         [Fact]
         public void SetSpinPreservesCircularOrbit()

--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -1,0 +1,78 @@
+using System.Xml.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for the rotateSpeed-backed object spin model.</summary>
+    public class ObjectSpinTests
+    {
+        private static LevelObject Obj(string type, string? rotateSpeed = null)
+        {
+            XElement e = new(type);
+            if (rotateSpeed is not null)
+            {
+                e.SetAttributeValue("rotateSpeed", rotateSpeed);
+            }
+            return new LevelObject(e);
+        }
+
+        /// <summary>Spin opt-in follows the object registry, parallel to RotationTable.</summary>
+        [Fact]
+        public void SpinTableKnowsStarsAndSpikes()
+        {
+            Assert.True(SpinTable.IsSpinnable("star"));
+            Assert.True(SpinTable.IsSpinnable("spike1"));
+            Assert.True(SpinTable.IsSpinnable("spike4"));
+            Assert.False(SpinTable.IsSpinnable("grab"));
+        }
+
+        /// <summary>Missing, zero, and invalid rotateSpeed values are treated as no active spin.</summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("0")]
+        [InlineData("not-a-number")]
+        public void ActiveSpinRequiresNonZeroRotateSpeed(string? rotateSpeed)
+        {
+            Assert.False(ObjectSpin.IsSpinning(Obj("star", rotateSpeed)));
+        }
+
+        /// <summary>Speed is exposed as a positive whole-number magnitude, hiding XML sign from the user.</summary>
+        [Theory]
+        [InlineData("70", 70)]
+        [InlineData("-130", 130)]
+        [InlineData("12.9", 12)]
+        public void SpeedMagnitudeUsesAbsoluteTruncatedWholeNumber(string rotateSpeed, int expected)
+        {
+            Assert.True(ObjectSpin.IsSpinning(Obj("star", rotateSpeed)));
+            Assert.Equal(expected, ObjectSpin.Speed(Obj("star", rotateSpeed)));
+        }
+
+        /// <summary>The clockwise checkbox maps directly to positive rotateSpeed values.</summary>
+        [Theory]
+        [InlineData("70", true)]
+        [InlineData("-130", false)]
+        public void ClockwiseFollowsRotateSpeedSign(string rotateSpeed, bool expected)
+        {
+            Assert.Equal(expected, ObjectSpin.Clockwise(Obj("star", rotateSpeed)));
+        }
+
+        /// <summary>Writing spin stores a signed whole-number rotateSpeed and disabling removes the attribute.</summary>
+        [Fact]
+        public void SetSpinWritesSignedSpeedAndDisableRemovesAttribute()
+        {
+            LevelObject star = Obj("star");
+
+            ObjectSpin.SetSpin(star, enabled: true, speed: 70, clockwise: false);
+
+            Assert.Equal("-70", star.GetAttr("rotateSpeed"));
+
+            ObjectSpin.SetSpin(star, enabled: true, speed: 0, clockwise: true);
+
+            Assert.Null(star.GetAttr("rotateSpeed"));
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -10,12 +10,16 @@ namespace CtrDxEditor.Core.Tests
     /// <summary>Tests for the rotateSpeed-backed object spin model.</summary>
     public class ObjectSpinTests
     {
-        private static LevelObject Obj(string type, string? rotateSpeed = null)
+        private static LevelObject Obj(string type, string? rotateSpeed = null, string? path = null)
         {
             XElement e = new(type);
             if (rotateSpeed is not null)
             {
                 e.SetAttributeValue("rotateSpeed", rotateSpeed);
+            }
+            if (path is not null)
+            {
+                e.SetAttributeValue("path", path);
             }
             return new LevelObject(e);
         }
@@ -73,6 +77,20 @@ namespace CtrDxEditor.Core.Tests
             ObjectSpin.SetSpin(star, enabled: true, speed: 0, clockwise: true);
 
             Assert.Null(star.GetAttr("rotateSpeed"));
+        }
+
+        /// <summary>Writing spin creates the minimal static path DX needs to construct a rotating mover.</summary>
+        [Fact]
+        public void SetSpinAddsStaticPathWithoutOverwritingAuthoredPath()
+        {
+            LevelObject star = Obj("star");
+            LevelObject movingSpike = Obj("spike2", path: "10,0,10,10");
+
+            ObjectSpin.SetSpin(star, enabled: true, speed: 70, clockwise: true);
+            ObjectSpin.SetSpin(movingSpike, enabled: true, speed: 130, clockwise: false);
+
+            Assert.Equal("0,0", star.GetAttr("path"));
+            Assert.Equal("10,0,10,10", movingSpike.GetAttr("path"));
         }
 
         /// <summary>Live preview rotation advances by signed rotateSpeed degrees per elapsed second.</summary>

--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -74,5 +74,16 @@ namespace CtrDxEditor.Core.Tests
 
             Assert.Null(star.GetAttr("rotateSpeed"));
         }
+
+        /// <summary>Live preview rotation advances by signed rotateSpeed degrees per elapsed second.</summary>
+        [Theory]
+        [InlineData("70", 0.5, 35.0)]
+        [InlineData("-130", 2.0, -260.0)]
+        [InlineData("0", 10.0, 0.0)]
+        [InlineData("12.9", 1.0, 12.0)]
+        public void PreviewDegreesUsesSignedWholeSpeed(string rotateSpeed, double elapsedSeconds, double expected)
+        {
+            Assert.Equal(expected, ObjectSpin.PreviewDegrees(Obj("star", rotateSpeed), elapsedSeconds));
+        }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ObjectSpinTests.cs
@@ -7,10 +7,10 @@ using Xunit;
 
 namespace CtrDxEditor.Core.Tests
 {
-    /// <summary>Tests for the rotateSpeed-backed object spin model.</summary>
+    /// <summary>Tests for the mover-backed object spin model.</summary>
     public class ObjectSpinTests
     {
-        private static LevelObject Obj(string type, string? rotateSpeed = null, string? path = null)
+        private static LevelObject Obj(string type, string? rotateSpeed = null, string? path = null, string? moveSpeed = null)
         {
             XElement e = new(type);
             if (rotateSpeed is not null)
@@ -20,6 +20,10 @@ namespace CtrDxEditor.Core.Tests
             if (path is not null)
             {
                 e.SetAttributeValue("path", path);
+            }
+            if (moveSpeed is not null)
+            {
+                e.SetAttributeValue("moveSpeed", moveSpeed);
             }
             return new LevelObject(e);
         }
@@ -52,7 +56,7 @@ namespace CtrDxEditor.Core.Tests
         public void SpeedMagnitudeUsesAbsoluteTruncatedWholeNumber(string rotateSpeed, int expected)
         {
             Assert.True(ObjectSpin.IsSpinning(Obj("star", rotateSpeed)));
-            Assert.Equal(expected, ObjectSpin.Speed(Obj("star", rotateSpeed)));
+            Assert.Equal(expected, ObjectSpin.SpinSpeed(Obj("star", rotateSpeed)));
         }
 
         /// <summary>The clockwise checkbox maps directly to positive rotateSpeed values.</summary>
@@ -61,7 +65,7 @@ namespace CtrDxEditor.Core.Tests
         [InlineData("-130", false)]
         public void ClockwiseFollowsRotateSpeedSign(string rotateSpeed, bool expected)
         {
-            Assert.Equal(expected, ObjectSpin.Clockwise(Obj("star", rotateSpeed)));
+            Assert.Equal(expected, ObjectSpin.SpinClockwise(Obj("star", rotateSpeed)));
         }
 
         /// <summary>Writing spin stores a signed whole-number rotateSpeed and disabling removes the attribute.</summary>
@@ -91,6 +95,73 @@ namespace CtrDxEditor.Core.Tests
 
             Assert.Equal("0,0", star.GetAttr("path"));
             Assert.Equal("10,0,10,10", movingSpike.GetAttr("path"));
+        }
+
+        /// <summary>Orbital movement follows DX circular path syntax and defaults movement speed separately.</summary>
+        [Fact]
+        public void SetOrbitalWritesCircularPathRadiusWithoutClearingRotateSpeed()
+        {
+            LevelObject star = Obj("star", rotateSpeed: "70");
+
+            ObjectSpin.SetOrbital(star, enabled: true, radius: 45, clockwise: false);
+
+            Assert.Equal("RW45", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.Equal("70", star.GetAttr("rotateSpeed"));
+            Assert.True(ObjectSpin.IsSpinning(star));
+            Assert.True(ObjectSpin.IsOrbital(star));
+            Assert.Equal(45, ObjectSpin.OrbitRadius(star));
+            Assert.False(ObjectSpin.OrbitClockwise(star));
+        }
+
+        /// <summary>Disabling orbital movement removes circular mover attributes without clearing self-spin.</summary>
+        [Fact]
+        public void DisablingOrbitalRemovesCircularPathAndMoveSpeedWithoutClearingRotateSpeed()
+        {
+            LevelObject star = Obj("star", rotateSpeed: "-70", path: "RC40", moveSpeed: "70");
+
+            ObjectSpin.SetOrbital(star, enabled: false, radius: 70, clockwise: true);
+
+            Assert.Null(star.GetAttr("path"));
+            Assert.Null(star.GetAttr("moveSpeed"));
+            Assert.Equal("-70", star.GetAttr("rotateSpeed"));
+            Assert.True(ObjectSpin.IsSpinning(star));
+        }
+
+        /// <summary>Orbit-only data is active without rotateSpeed.</summary>
+        [Fact]
+        public void OrbitDoesNotCountAsSelfSpin()
+        {
+            LevelObject star = Obj("star", path: "RC40", moveSpeed: "70");
+
+            Assert.False(ObjectSpin.IsSpinning(star));
+            Assert.True(ObjectSpin.IsOrbital(star));
+        }
+
+        /// <summary>Orbital movement speed is preserved when switching direction or radius.</summary>
+        [Fact]
+        public void SetOrbitalSpinPreservesAuthoredMoveSpeed()
+        {
+            LevelObject star = Obj("star", path: "RW60", moveSpeed: "80");
+
+            ObjectSpin.SetOrbital(star, enabled: true, radius: 40, clockwise: true);
+
+            Assert.Equal("RC40", star.GetAttr("path"));
+            Assert.Equal("80", star.GetAttr("moveSpeed"));
+            Assert.Equal(40, ObjectSpin.OrbitRadius(star));
+        }
+
+        /// <summary>Writing self-spin preserves existing circular orbit data.</summary>
+        [Fact]
+        public void SetSpinPreservesCircularOrbit()
+        {
+            LevelObject star = Obj("star", path: "RW60", moveSpeed: "80");
+
+            ObjectSpin.SetSpin(star, enabled: true, speed: 130, clockwise: false);
+
+            Assert.Equal("-130", star.GetAttr("rotateSpeed"));
+            Assert.Equal("RW60", star.GetAttr("path"));
+            Assert.Equal("80", star.GetAttr("moveSpeed"));
         }
 
         /// <summary>Live preview rotation advances by signed rotateSpeed degrees per elapsed second.</summary>

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -99,6 +99,14 @@ namespace CtrDxEditor.Core.Editing
                 : DefaultOrbitRadius;
         }
 
+        /// <summary>The positive whole-number movement speed encoded in DX <c>moveSpeed</c>.</summary>
+        /// <param name="obj">Object whose <c>moveSpeed</c> attribute is inspected.</param>
+        /// <returns>The absolute whole-number movement speed, or zero when absent or invalid.</returns>
+        public static int OrbitSpeed(LevelObject obj)
+        {
+            return RawMoveSpeed(obj);
+        }
+
         /// <summary>Writes or clears orbit data using DX circular path syntax (<c>RC</c>/<c>RW</c>).</summary>
         /// <param name="obj">Object whose orbital spin attributes are updated.</param>
         /// <param name="enabled">Whether orbital spin should remain enabled.</param>
@@ -123,6 +131,20 @@ namespace CtrDxEditor.Core.Editing
                 moveSpeed = SpinSpeed(obj);
             }
             obj.SetAttr("moveSpeed", (moveSpeed > 0 ? moveSpeed : DefaultSpeed).ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>Writes the DX <c>moveSpeed</c> used to advance along an orbital path.</summary>
+        /// <param name="obj">Object whose orbital movement speed is updated.</param>
+        /// <param name="speed">Positive whole-number movement speed magnitude.</param>
+        public static void SetOrbitSpeed(LevelObject obj, int speed)
+        {
+            if (speed <= 0)
+            {
+                obj.RemoveAttr("moveSpeed");
+                return;
+            }
+
+            obj.SetAttr("moveSpeed", speed.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>Computes the signed live-preview rotation angle for elapsed playback time.</summary>

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 
 using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Geometry;
 
 namespace CtrDxEditor.Core.Editing
 {
@@ -133,6 +134,61 @@ namespace CtrDxEditor.Core.Editing
             return RawSpeed(obj) * elapsedSeconds;
         }
 
+        /// <summary>Computes the live-preview position for DX circular orbit paths.</summary>
+        /// <param name="obj">Object whose <c>RC</c>/<c>RW</c> path and <c>moveSpeed</c> are inspected.</param>
+        /// <param name="elapsedSeconds">Elapsed preview time in seconds.</param>
+        /// <returns>The preview position, or the authored position when no active orbit exists.</returns>
+        public static Vec2 PreviewPosition(LevelObject obj, double elapsedSeconds)
+        {
+            Vec2 authored = new(obj.X, obj.Y);
+            string? path = obj.GetAttr("path");
+            int moveSpeed = RawMoveSpeed(obj);
+            if (!IsCircularPath(path) || moveSpeed <= 0)
+            {
+                return authored;
+            }
+
+            int radius = OrbitRadius(obj);
+            int pointsCount = radius / 2;
+            if (pointsCount <= 0)
+            {
+                return authored;
+            }
+
+            Vec2[] points = BuildCircularPath(authored, radius, path![1] == 'C', pointsCount);
+            if (points.Length == 1 || elapsedSeconds <= 0)
+            {
+                return points[0];
+            }
+
+            double remaining = moveSpeed * elapsedSeconds;
+            int index = 0;
+            while (remaining > 0)
+            {
+                Vec2 start = points[index];
+                Vec2 end = points[(index + 1) % points.Length];
+                double dx = end.X - start.X;
+                double dy = end.Y - start.Y;
+                double distance = Math.Sqrt((dx * dx) + (dy * dy));
+                if (distance <= 0)
+                {
+                    index = (index + 1) % points.Length;
+                    continue;
+                }
+
+                if (remaining <= distance)
+                {
+                    double t = remaining / distance;
+                    return new Vec2(start.X + (dx * t), start.Y + (dy * t));
+                }
+
+                remaining -= distance;
+                index = (index + 1) % points.Length;
+            }
+
+            return points[index];
+        }
+
         private static int RawSpeed(LevelObject obj)
         {
             return double.TryParse(obj.GetAttr("rotateSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
@@ -145,6 +201,27 @@ namespace CtrDxEditor.Core.Editing
             return double.TryParse(obj.GetAttr("moveSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
                 ? Math.Abs((int)value)
                 : 0;
+        }
+
+        private static Vec2[] BuildCircularPath(Vec2 start, int radius, bool clockwise, int pointsCount)
+        {
+            Vec2[] points = new Vec2[pointsCount];
+            double angleStep = Math.Tau / pointsCount;
+            if (!clockwise)
+            {
+                angleStep = -angleStep;
+            }
+
+            double theta = 0.0;
+            for (int i = 0; i < points.Length; i++)
+            {
+                points[i] = new Vec2(
+                    start.X + (radius * Math.Cos(theta)),
+                    start.Y + (radius * Math.Sin(theta)));
+                theta += angleStep;
+            }
+
+            return points;
         }
 
         private static bool IsCircularPath(string? path)

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -52,6 +52,15 @@ namespace CtrDxEditor.Core.Editing
             obj.SetAttr("rotateSpeed", signed.ToString(CultureInfo.InvariantCulture));
         }
 
+        /// <summary>Computes the signed live-preview rotation angle for elapsed playback time.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute drives preview rotation.</param>
+        /// <param name="elapsedSeconds">Elapsed preview time in seconds.</param>
+        /// <returns>Signed clockwise-positive degrees to add to the object's authored rotation.</returns>
+        public static double PreviewDegrees(LevelObject obj, double elapsedSeconds)
+        {
+            return RawSpeed(obj) * elapsedSeconds;
+        }
+
         private static int RawSpeed(LevelObject obj)
         {
             return double.TryParse(obj.GetAttr("rotateSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Globalization;
+
+using CtrDxEditor.Core.Document;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>Helpers for the game's <c>rotateSpeed</c> attribute, exposed as Spin in the editor.</summary>
+    public static class ObjectSpin
+    {
+        /// <summary>Default spin speed written when enabling spin on an object without an existing speed.</summary>
+        public const int DefaultSpeed = 70;
+
+        /// <summary>Whether <paramref name="obj"/> has an active non-zero spin speed.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
+        /// <returns><see langword="true"/> when <paramref name="obj"/> stores a non-zero speed.</returns>
+        public static bool IsSpinning(LevelObject obj)
+        {
+            return RawSpeed(obj) != 0;
+        }
+
+        /// <summary>The positive whole-number spin speed magnitude shown in the editor.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
+        /// <returns>The absolute whole-number speed, or zero when absent or invalid.</returns>
+        public static int Speed(LevelObject obj)
+        {
+            return Math.Abs(RawSpeed(obj));
+        }
+
+        /// <summary>Whether the stored speed is clockwise. Zero defaults to clockwise for new spins.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
+        /// <returns><see langword="true"/> when the stored speed is zero or positive.</returns>
+        public static bool Clockwise(LevelObject obj)
+        {
+            return RawSpeed(obj) >= 0;
+        }
+
+        /// <summary>Writes or clears <c>rotateSpeed</c>, storing direction as the sign of <paramref name="speed"/>.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is updated.</param>
+        /// <param name="enabled">Whether spin should remain enabled.</param>
+        /// <param name="speed">Positive whole-number spin speed magnitude.</param>
+        /// <param name="clockwise">Whether the stored speed should be positive.</param>
+        public static void SetSpin(LevelObject obj, bool enabled, int speed, bool clockwise)
+        {
+            if (!enabled || speed <= 0)
+            {
+                obj.RemoveAttr("rotateSpeed");
+                return;
+            }
+
+            int signed = clockwise ? speed : -speed;
+            obj.SetAttr("rotateSpeed", signed.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static int RawSpeed(LevelObject obj)
+        {
+            return double.TryParse(obj.GetAttr("rotateSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? (int)value
+                : 0;
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -5,11 +5,14 @@ using CtrDxEditor.Core.Document;
 
 namespace CtrDxEditor.Core.Editing
 {
-    /// <summary>Helpers for the game's <c>rotateSpeed</c> attribute, exposed as Spin in the editor.</summary>
+    /// <summary>Helpers for the game's mover-backed spin attributes, exposed as Spin in the editor.</summary>
     public static class ObjectSpin
     {
         /// <summary>Default spin speed written when enabling spin on an object without an existing speed.</summary>
         public const int DefaultSpeed = 70;
+
+        /// <summary>Minimal non-moving path required for DX to construct a rotating mover.</summary>
+        public const string StaticPath = "0,0";
 
         /// <summary>Whether <paramref name="obj"/> has an active non-zero spin speed.</summary>
         /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
@@ -35,8 +38,8 @@ namespace CtrDxEditor.Core.Editing
             return RawSpeed(obj) >= 0;
         }
 
-        /// <summary>Writes or clears <c>rotateSpeed</c>, storing direction as the sign of <paramref name="speed"/>.</summary>
-        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is updated.</param>
+        /// <summary>Writes or clears spin data, storing direction as the sign of <paramref name="speed"/>.</summary>
+        /// <param name="obj">Object whose spin attributes are updated.</param>
         /// <param name="enabled">Whether spin should remain enabled.</param>
         /// <param name="speed">Positive whole-number spin speed magnitude.</param>
         /// <param name="clockwise">Whether the stored speed should be positive.</param>
@@ -50,6 +53,10 @@ namespace CtrDxEditor.Core.Editing
 
             int signed = clockwise ? speed : -speed;
             obj.SetAttr("rotateSpeed", signed.ToString(CultureInfo.InvariantCulture));
+            if (string.IsNullOrEmpty(obj.GetAttr("path")))
+            {
+                obj.SetAttr("path", StaticPath);
+            }
         }
 
         /// <summary>Computes the signed live-preview rotation angle for elapsed playback time.</summary>

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -5,7 +5,7 @@ using CtrDxEditor.Core.Document;
 
 namespace CtrDxEditor.Core.Editing
 {
-    /// <summary>Helpers for the game's mover-backed spin attributes, exposed as Spin in the editor.</summary>
+    /// <summary>Helpers for the game's mover-backed spin and orbit attributes, exposed as Spin in the editor.</summary>
     public static class ObjectSpin
     {
         /// <summary>Default spin speed written when enabling spin on an object without an existing speed.</summary>
@@ -14,28 +14,56 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Minimal non-moving path required for DX to construct a rotating mover.</summary>
         public const string StaticPath = "0,0";
 
-        /// <summary>Whether <paramref name="obj"/> has an active non-zero spin speed.</summary>
-        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
-        /// <returns><see langword="true"/> when <paramref name="obj"/> stores a non-zero speed.</returns>
+        /// <summary>Default radius used when enabling DX circular orbit paths.</summary>
+        public const int DefaultOrbitRadius = 30;
+
+        /// <summary>Whether <paramref name="obj"/> has active in-place spin data.</summary>
+        /// <param name="obj">Object whose spin-related mover attributes are inspected.</param>
+        /// <returns><see langword="true"/> when <paramref name="obj"/> stores non-zero rotateSpeed.</returns>
         public static bool IsSpinning(LevelObject obj)
+        {
+            return IsRotatingInPlace(obj);
+        }
+
+        /// <summary>Whether the object has active rotateSpeed-backed in-place spin.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
+        /// <returns><see langword="true"/> when <paramref name="obj"/> stores a non-zero rotate speed.</returns>
+        public static bool IsRotatingInPlace(LevelObject obj)
         {
             return RawSpeed(obj) != 0;
         }
 
-        /// <summary>The positive whole-number spin speed magnitude shown in the editor.</summary>
-        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
+        /// <summary>Whether the object uses DX circular mover syntax (<c>RC</c>/<c>RW</c>) with speed.</summary>
+        /// <param name="obj">Object whose <c>path</c> and <c>moveSpeed</c> attributes are inspected.</param>
+        /// <returns><see langword="true"/> when the object has a circular path and non-zero move speed.</returns>
+        public static bool IsOrbital(LevelObject obj)
+        {
+            return IsCircularPath(obj.GetAttr("path")) && RawMoveSpeed(obj) > 0;
+        }
+
+        /// <summary>The positive whole-number speed magnitude shown in the editor.</summary>
+        /// <param name="obj">Object whose <c>rotateSpeed</c> or orbital <c>moveSpeed</c> attribute is inspected.</param>
         /// <returns>The absolute whole-number speed, or zero when absent or invalid.</returns>
-        public static int Speed(LevelObject obj)
+        public static int SpinSpeed(LevelObject obj)
         {
             return Math.Abs(RawSpeed(obj));
         }
 
-        /// <summary>Whether the stored speed is clockwise. Zero defaults to clockwise for new spins.</summary>
-        /// <param name="obj">Object whose <c>rotateSpeed</c> attribute is inspected.</param>
-        /// <returns><see langword="true"/> when the stored speed is zero or positive.</returns>
-        public static bool Clockwise(LevelObject obj)
+        /// <summary>Whether the stored self-spin direction is clockwise. Zero defaults to clockwise for new spins.</summary>
+        /// <param name="obj">Object whose spin-related mover attributes are inspected.</param>
+        /// <returns><see langword="true"/> for non-negative rotate speeds.</returns>
+        public static bool SpinClockwise(LevelObject obj)
         {
             return RawSpeed(obj) >= 0;
+        }
+
+        /// <summary>Whether the stored orbital path direction is clockwise.</summary>
+        /// <param name="obj">Object whose <c>path</c> attribute is inspected.</param>
+        /// <returns><see langword="true"/> for <c>RC</c> paths, and as the default for new orbit paths.</returns>
+        public static bool OrbitClockwise(LevelObject obj)
+        {
+            string? path = obj.GetAttr("path");
+            return !IsCircularPath(path) || path![1] == 'C';
         }
 
         /// <summary>Writes or clears spin data, storing direction as the sign of <paramref name="speed"/>.</summary>
@@ -59,6 +87,43 @@ namespace CtrDxEditor.Core.Editing
             }
         }
 
+        /// <summary>The positive radius encoded in a DX circular path, defaulting when no valid path exists.</summary>
+        /// <param name="obj">Object whose <c>path</c> attribute is inspected.</param>
+        /// <returns>The positive <c>RC</c>/<c>RW</c> radius, or <see cref="DefaultOrbitRadius"/>.</returns>
+        public static int OrbitRadius(LevelObject obj)
+        {
+            string? path = obj.GetAttr("path");
+            return IsCircularPath(path) && int.TryParse(path![2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0
+                ? radius
+                : DefaultOrbitRadius;
+        }
+
+        /// <summary>Writes or clears orbit data using DX circular path syntax (<c>RC</c>/<c>RW</c>).</summary>
+        /// <param name="obj">Object whose orbital spin attributes are updated.</param>
+        /// <param name="enabled">Whether orbital spin should remain enabled.</param>
+        /// <param name="radius">Positive circular path radius.</param>
+        /// <param name="clockwise">Whether the path should use clockwise <c>RC</c> direction.</param>
+        public static void SetOrbital(LevelObject obj, bool enabled, int radius, bool clockwise)
+        {
+            if (!enabled || radius <= 0)
+            {
+                if (IsCircularPath(obj.GetAttr("path")))
+                {
+                    obj.RemoveAttr("path");
+                    obj.RemoveAttr("moveSpeed");
+                }
+                return;
+            }
+
+            obj.SetAttr("path", $"{(clockwise ? "RC" : "RW")}{radius.ToString(CultureInfo.InvariantCulture)}");
+            int moveSpeed = RawMoveSpeed(obj);
+            if (moveSpeed == 0)
+            {
+                moveSpeed = SpinSpeed(obj);
+            }
+            obj.SetAttr("moveSpeed", (moveSpeed > 0 ? moveSpeed : DefaultSpeed).ToString(CultureInfo.InvariantCulture));
+        }
+
         /// <summary>Computes the signed live-preview rotation angle for elapsed playback time.</summary>
         /// <param name="obj">Object whose <c>rotateSpeed</c> attribute drives preview rotation.</param>
         /// <param name="elapsedSeconds">Elapsed preview time in seconds.</param>
@@ -73,6 +138,22 @@ namespace CtrDxEditor.Core.Editing
             return double.TryParse(obj.GetAttr("rotateSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
                 ? (int)value
                 : 0;
+        }
+
+        private static int RawMoveSpeed(LevelObject obj)
+        {
+            return double.TryParse(obj.GetAttr("moveSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? Math.Abs((int)value)
+                : 0;
+        }
+
+        private static bool IsCircularPath(string? path)
+        {
+            return path is { Length: > 2 }
+                && path[0] == 'R'
+                && (path[1] == 'C' || path[1] == 'W')
+                && int.TryParse(path[2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius)
+                && radius > 0;
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/SpinTable.cs
+++ b/src/CtrDxEditor.Core/Editing/SpinTable.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>Registry of objects whose <c>rotateSpeed</c> attribute is exposed as editor spin.</summary>
+    public static class SpinTable
+    {
+        private static readonly HashSet<string> Elements =
+        [
+            "star",
+            "spike1",
+            "spike2",
+            "spike3",
+            "spike4",
+        ];
+
+        /// <summary>Whether <paramref name="element"/> can expose spin controls.</summary>
+        /// <param name="element">XML element name to look up.</param>
+        /// <returns><see langword="true"/> when the editor should show spin fields.</returns>
+        public static bool IsSpinnable(string element)
+        {
+            return Elements.Contains(element);
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Converters/ObjectEqualsConverter.cs
+++ b/src/CtrDxEditor.Shared/Converters/ObjectEqualsConverter.cs
@@ -6,7 +6,7 @@ using Avalonia.Data.Converters;
 
 namespace CtrDxEditor.Converters
 {
-    /// <summary>True when the two bound values are equal — used to show the lock icon on the locked row.</summary>
+    /// <summary>True when the two bound values are equal; optional Invert flips the result.</summary>
     public sealed class ObjectEqualsConverter : IMultiValueConverter
     {
         /// <summary>Shared converter instance for XAML bindings.</summary>
@@ -15,7 +15,8 @@ namespace CtrDxEditor.Converters
         /// <inheritdoc />
         public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
         {
-            return values.Count == 2 && values[0] is not null && Equals(values[0], values[1]);
+            bool equal = values.Count == 2 && values[0] is not null && Equals(values[0], values[1]);
+            return string.Equals(parameter as string, "Invert", StringComparison.Ordinal) ? !equal : equal;
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
+++ b/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
@@ -16,6 +16,9 @@ namespace CtrDxEditor.Converters
         /// <summary>True for objects that have active spin data and can show a per-object preview button.</summary>
         public static readonly IValueConverter Available = new SpinPreviewAvailableConverter();
 
+        /// <summary>True for objects that have active spin data, re-evaluated when object-row state changes.</summary>
+        public static readonly IMultiValueConverter AvailableForVersion = new SpinPreviewAvailableForVersionConverter();
+
         /// <summary>True when the row object is the active object-scoped preview target.</summary>
         public static readonly IMultiValueConverter IsObjectPreviewing = new ObjectAnimationPreviewingConverter();
 
@@ -29,6 +32,17 @@ namespace CtrDxEditor.Converters
             public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
                 throw new NotSupportedException();
+            }
+        }
+
+        private sealed class SpinPreviewAvailableForVersionConverter : IMultiValueConverter
+        {
+            public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+            {
+                return values.Count >= 1
+                    && values[0] is LevelObject obj
+                    && SpinTable.IsSpinnable(obj.Type)
+                    && ObjectSpin.IsSpinning(obj);
             }
         }
 

--- a/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
+++ b/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
@@ -13,10 +13,10 @@ namespace CtrDxEditor.Converters
     /// <summary>Converters for object-list live animation preview controls.</summary>
     public static class SpinPreviewConverters
     {
-        /// <summary>True for objects that have active spin data and can show a per-object preview button.</summary>
+        /// <summary>True for objects that have active in-place spin data and can show a per-object preview button.</summary>
         public static readonly IValueConverter Available = new SpinPreviewAvailableConverter();
 
-        /// <summary>True for objects that have active spin data, re-evaluated when object-row state changes.</summary>
+        /// <summary>True for objects that have active in-place spin data, re-evaluated when object-row state changes.</summary>
         public static readonly IMultiValueConverter AvailableForVersion = new SpinPreviewAvailableForVersionConverter();
 
         /// <summary>True when the row object is the active object-scoped preview target.</summary>
@@ -26,7 +26,7 @@ namespace CtrDxEditor.Converters
         {
             public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
-                return value is LevelObject obj && SpinTable.IsSpinnable(obj.Type) && ObjectSpin.IsSpinning(obj);
+                return value is LevelObject obj && SpinTable.IsSpinnable(obj.Type) && ObjectSpin.IsRotatingInPlace(obj);
             }
 
             public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -42,7 +42,7 @@ namespace CtrDxEditor.Converters
                 return values.Count >= 1
                     && values[0] is LevelObject obj
                     && SpinTable.IsSpinnable(obj.Type)
-                    && ObjectSpin.IsSpinning(obj);
+                    && ObjectSpin.IsRotatingInPlace(obj);
             }
         }
 

--- a/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
+++ b/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
@@ -13,10 +13,10 @@ namespace CtrDxEditor.Converters
     /// <summary>Converters for object-list live animation preview controls.</summary>
     public static class SpinPreviewConverters
     {
-        /// <summary>True for objects that have active in-place spin data and can show a per-object preview button.</summary>
+        /// <summary>True for objects that have active spin or orbit data and can show a per-object preview button.</summary>
         public static readonly IValueConverter Available = new SpinPreviewAvailableConverter();
 
-        /// <summary>True for objects that have active in-place spin data, re-evaluated when object-row state changes.</summary>
+        /// <summary>True for objects that have active spin or orbit data, re-evaluated when object-row state changes.</summary>
         public static readonly IMultiValueConverter AvailableForVersion = new SpinPreviewAvailableForVersionConverter();
 
         /// <summary>True when the row object is the active object-scoped preview target.</summary>
@@ -26,7 +26,7 @@ namespace CtrDxEditor.Converters
         {
             public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
             {
-                return value is LevelObject obj && SpinTable.IsSpinnable(obj.Type) && ObjectSpin.IsRotatingInPlace(obj);
+                return value is LevelObject obj && SpinTable.IsSpinnable(obj.Type) && HasPreviewAnimation(obj);
             }
 
             public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -42,8 +42,13 @@ namespace CtrDxEditor.Converters
                 return values.Count >= 1
                     && values[0] is LevelObject obj
                     && SpinTable.IsSpinnable(obj.Type)
-                    && ObjectSpin.IsRotatingInPlace(obj);
+                    && HasPreviewAnimation(obj);
             }
+        }
+
+        private static bool HasPreviewAnimation(LevelObject obj)
+        {
+            return ObjectSpin.IsRotatingInPlace(obj) || ObjectSpin.IsOrbital(obj);
         }
 
         private sealed class ObjectAnimationPreviewingConverter : IMultiValueConverter

--- a/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
+++ b/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Avalonia.Data.Converters;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.ViewModels;
+
+namespace CtrDxEditor.Converters
+{
+    /// <summary>Converters for object-list live animation preview controls.</summary>
+    public static class SpinPreviewConverters
+    {
+        /// <summary>True for objects that have active spin data and can show a per-object preview button.</summary>
+        public static readonly IValueConverter Available = new SpinPreviewAvailableConverter();
+
+        /// <summary>True when the row object is the active object-scoped preview target.</summary>
+        public static readonly IMultiValueConverter IsObjectPreviewing = new ObjectAnimationPreviewingConverter();
+
+        private sealed class SpinPreviewAvailableConverter : IValueConverter
+        {
+            public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                return value is LevelObject obj && SpinTable.IsSpinnable(obj.Type) && ObjectSpin.IsSpinning(obj);
+            }
+
+            public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private sealed class ObjectAnimationPreviewingConverter : IMultiValueConverter
+        {
+            public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+            {
+                bool previewing = values.Count == 3
+                    && values[1] is AnimationPreviewMode.Focused
+                    && values[0] is not null
+                    && Equals(values[0], values[2]);
+                return string.Equals(parameter as string, "Invert", StringComparison.Ordinal) ? !previewing : previewing;
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -168,5 +168,6 @@
     "Attr.spin": "Spin object",
     "Attr.spinSpeed": "Speed",
     "Attr.spinClockwise": "Clockwise",
+    "Tooltip.ObjectLock": "Lock or unlock this object\nYou can also double click this object on the level canvas to lock/unlock it",
     "Tooltip.ObjectAnimationPreview": "Play or stop this object's animation"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -25,6 +25,7 @@
     "Menu.View.ShowHitboxes": "Show hitboxes",
     "Menu.View.ShowMobileHitboxes": "Show mobile hitboxes",
     "Menu.View.ShowForceFields": "Show force fields",
+    "Menu.View.ShowMovementPaths": "Show movement paths",
 
     "Panel.Objects": "Objects",
     "Panel.Properties": "Properties",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -162,5 +162,8 @@
     "Attr.angle": "Angle",
     "Attr.size": "Size",
     "Attr.toggled": "Toggled",
-    "Attr.toggleGroup": "Group"
+    "Attr.toggleGroup": "Group",
+    "Attr.spin": "Spin object",
+    "Attr.spinSpeed": "Speed",
+    "Attr.spinClockwise": "Clockwise"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -124,6 +124,9 @@
     "Dialog.Close.Body": "Close the current level?",
     "Dialog.Close.Proceed": "Close level",
 
+    "Tooltip.ObjectLock": "Lock or unlock this object\nYou can also double click this object on the level canvas to lock/unlock it",
+    "Tooltip.ObjectAnimationPreview": "Play or stop this object's animation",
+
     "Object.target": "Om Nom",
     "Object.candy": "Candy",
     "Object.candyL": "Candy (Left)",
@@ -168,6 +171,7 @@
     "Attr.spin": "Spin object",
     "Attr.spinSpeed": "Spin speed",
     "Attr.spinClockwise": "Spin clockwise",
-    "Tooltip.ObjectLock": "Lock or unlock this object\nYou can also double click this object on the level canvas to lock/unlock it",
-    "Tooltip.ObjectAnimationPreview": "Play or stop this object's animation"
+    "Attr.spinOrbital": "Orbit object",
+    "Attr.orbitRadius": "Orbit radius",
+    "Attr.orbitClockwise": "Orbit clockwise"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -19,6 +19,8 @@
     "Menu.View.ZoomIn": "Zoom _In",
     "Menu.View.ZoomOut": "Zoom _Out",
     "Menu.View.ZoomFit": "Zoom to _Fit",
+    "Menu.View.PlayAnimations": "Play animations",
+    "Menu.View.StopAnimations": "Stop animations",
     "Menu.View.SnapToGrid": "Snap to grid",
     "Menu.View.ShowHitboxes": "Show hitboxes",
     "Menu.View.ShowMobileHitboxes": "Show mobile hitboxes",
@@ -165,5 +167,6 @@
     "Attr.toggleGroup": "Group",
     "Attr.spin": "Spin object",
     "Attr.spinSpeed": "Speed",
-    "Attr.spinClockwise": "Clockwise"
+    "Attr.spinClockwise": "Clockwise",
+    "Tooltip.ObjectAnimationPreview": "Play or stop this object's animation"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -166,8 +166,8 @@
     "Attr.toggled": "Toggled",
     "Attr.toggleGroup": "Group",
     "Attr.spin": "Spin object",
-    "Attr.spinSpeed": "Speed",
-    "Attr.spinClockwise": "Clockwise",
+    "Attr.spinSpeed": "Spin speed",
+    "Attr.spinClockwise": "Spin clockwise",
     "Tooltip.ObjectLock": "Lock or unlock this object\nYou can also double click this object on the level canvas to lock/unlock it",
     "Tooltip.ObjectAnimationPreview": "Play or stop this object's animation"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -174,5 +174,6 @@
     "Attr.spinClockwise": "Spin clockwise",
     "Attr.spinOrbital": "Orbit object",
     "Attr.orbitRadius": "Orbit radius",
+    "Attr.orbitSpeed": "Orbit speed",
     "Attr.orbitClockwise": "Orbit clockwise"
 }

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -50,6 +50,12 @@ namespace CtrDxEditor.Rendering
         /// <summary>Solid curved arrow marking a rotateSpeed-backed object spin.</summary>
         public Pen SpinArrow { get; private set; } = new(new SolidColorBrush(Color.FromRgb(0x0E, 0x74, 0x9A)), 2);
 
+        /// <summary>Dotted circular path marking RC/RW orbital movement.</summary>
+        public Pen OrbitPath { get; private set; } = DottedPen(Color.FromRgb(0x25, 0x63, 0xEB), 1.5);
+
+        /// <summary>Solid direction arrow for RC/RW orbital movement.</summary>
+        public Pen OrbitPathArrow { get; private set; } = SolidPen(Color.FromRgb(0x25, 0x63, 0xEB), 2.25);
+
         /// <summary>Text brush for a timed-star duration label on the blank (no-background) canvas:
         /// pure white in the dark theme, pure black in the light theme. When a background is applied
         /// the canvas draws these labels black regardless.</summary>
@@ -73,6 +79,9 @@ namespace CtrDxEditor.Rendering
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
             ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);
             SpinArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlaySpinArrow", Color.FromRgb(0x0E, 0x74, 0x9A))), 2);
+            Color orbitColor = ThemeColor(host, "EditorColor.OverlayOrbitPath", Color.FromRgb(0x25, 0x63, 0xEB));
+            OrbitPath = DottedPen(orbitColor, 1.5);
+            OrbitPathArrow = SolidPen(orbitColor, 2.25);
             StarDurationText = host.ActualThemeVariant == ThemeVariant.Dark ? Brushes.White : Brushes.Black;
         }
 
@@ -95,6 +104,18 @@ namespace CtrDxEditor.Rendering
         private static Pen OverlayPen(Color color, double thickness)
         {
             return OverlayPen(new SolidColorBrush(color), thickness);
+        }
+
+        /// <summary>Builds a dotted overlay pen from a solid color.</summary>
+        private static Pen DottedPen(Color color, double thickness)
+        {
+            return new Pen(new SolidColorBrush(color), thickness) { DashStyle = new DashStyle([1, 3], 0) };
+        }
+
+        /// <summary>Builds a solid overlay pen from a solid color.</summary>
+        private static Pen SolidPen(Color color, double thickness)
+        {
+            return new Pen(new SolidColorBrush(color), thickness);
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -47,6 +47,9 @@ namespace CtrDxEditor.Rendering
         /// Solid rather than dashed so it reads as an arrow against the dashed hitbox boxes.</summary>
         public Pen ForceArrow { get; private set; } = new(new SolidColorBrush(Color.FromRgb(0x7F, 0x22, 0xFE)), 2);
 
+        /// <summary>Solid curved arrow marking a rotateSpeed-backed object spin.</summary>
+        public Pen SpinArrow { get; private set; } = new(new SolidColorBrush(Color.FromRgb(0x0E, 0x74, 0x9A)), 2);
+
         /// <summary>Text brush for a timed-star duration label on the blank (no-background) canvas:
         /// pure white in the dark theme, pure black in the light theme. When a background is applied
         /// the canvas draws these labels black regardless.</summary>
@@ -69,6 +72,7 @@ namespace CtrDxEditor.Rendering
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
             ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);
+            SpinArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlaySpinArrow", Color.FromRgb(0x0E, 0x74, 0x9A))), 2);
             StarDurationText = host.ActualThemeVariant == ThemeVariant.Dark ? Brushes.White : Brushes.Black;
         }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -75,6 +75,11 @@ namespace CtrDxEditor.Rendering
 
             GrabRenderer.DrawRadiusRings(context, v, objects, _palette.GrabRadius, _palette.BulbRadius);
 
+            foreach (LevelObject obj in objects)
+            {
+                LevelSceneRenderer.DrawSpinArrow(context, v, obj, _palette.SpinArrow);
+            }
+
             if (ShowHitboxes || ShowMobileHitboxes)
             {
                 foreach (LevelObject obj in objects)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -69,7 +69,7 @@ namespace CtrDxEditor.Rendering
             }
 
             ViewTransform v = View;
-            DrawLevelContent(context, v, Bounds.Size, doc, sprites, drawGrid: true, grabRadiusPen: null);
+            DrawLevelContent(context, v, Bounds.Size, doc, sprites, drawGrid: true, grabRadiusPen: null, useAnimationPreview: true);
 
             IReadOnlyList<LevelObject> objects = doc.Objects;
 
@@ -77,7 +77,10 @@ namespace CtrDxEditor.Rendering
 
             foreach (LevelObject obj in objects)
             {
-                LevelSceneRenderer.DrawSpinArrow(context, v, obj, _palette.SpinArrow);
+                if (!IsAnimationPreviewing(obj))
+                {
+                    LevelSceneRenderer.DrawSpinArrow(context, v, obj, _palette.SpinArrow);
+                }
             }
 
             if (ShowHitboxes || ShowMobileHitboxes)
@@ -90,11 +93,11 @@ namespace CtrDxEditor.Rendering
                     }
                     if (ShowHitboxes)
                     {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop);
+                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop, PreviewSpinDegrees(obj));
                     }
                     if (ShowMobileHitboxes)
                     {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone);
+                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone, PreviewSpinDegrees(obj));
                     }
                 }
             }
@@ -127,7 +130,7 @@ namespace CtrDxEditor.Rendering
                 LevelBounds sb = LevelSceneRenderer.SelectionBounds(sprites, selected, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
                 // Both boxes are dashed; a locked object is red, an unlocked one blue.
                 Pen pen = Equals(LockedObject, selected) ? _palette.ObjectLocked : _palette.ObjectSelected;
-                Point[] points = LevelSceneRenderer.SelectionOutlinePoints(v, selected, sb);
+                Point[] points = LevelSceneRenderer.SelectionOutlinePointsWithPreview(v, selected, sb, PreviewSpinDegrees(selected));
                 for (int i = 0; i < points.Length; i++)
                 {
                     context.DrawLine(pen, points[i], points[(i + 1) % points.Length]);
@@ -165,6 +168,7 @@ namespace CtrDxEditor.Rendering
         /// When set, bakes the grab auto-catch rings into the image with this pen (the screenshot's game-blue ring);
         /// <see cref="Render"/> passes null and draws its own themed rings in the chrome pass instead.
         /// </param>
+        /// <param name="useAnimationPreview">When true, applies live-preview elapsed spin to eligible objects.</param>
         private void DrawLevelContent(
             DrawingContext context,
             ViewTransform v,
@@ -172,7 +176,8 @@ namespace CtrDxEditor.Rendering
             LevelDocument doc,
             SpriteCache sprites,
             bool drawGrid,
-            Pen? grabRadiusPen)
+            Pen? grabRadiusPen,
+            bool useAnimationPreview)
         {
             Vec2 tl = v.LevelToScreen(new Vec2(0, 0));
             Vec2 br = v.LevelToScreen(new Vec2(doc.Width, doc.Height));
@@ -277,7 +282,8 @@ namespace CtrDxEditor.Rendering
                 else
                 {
                     LevelSceneRenderer.DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel,
-                        ActiveBackground > 0 ? Brushes.Black : _palette.StarDurationText);
+                        ActiveBackground > 0 ? Brushes.Black : _palette.StarDurationText,
+                        useAnimationPreview && IsAnimationPreviewing(obj) ? AnimationPreviewElapsedSeconds : null);
                 }
             }
 
@@ -307,9 +313,20 @@ namespace CtrDxEditor.Rendering
             using (DrawingContext ctx = rtb.CreateDrawingContext())
             {
                 ctx.FillRectangle(Brushes.Black, new Rect(renderSize));
-                DrawLevelContent(ctx, frame.View, renderSize, doc, sprites, drawGrid: false, grabRadiusPen: ScreenshotGrabRadiusPen);
+                DrawLevelContent(ctx, frame.View, renderSize, doc, sprites, drawGrid: false, grabRadiusPen: ScreenshotGrabRadiusPen, useAnimationPreview: false);
             }
             return rtb;
+        }
+
+        private bool IsAnimationPreviewing(LevelObject obj)
+        {
+            return AnimationPreviewMode == CtrDxEditor.ViewModels.AnimationPreviewMode.All
+                || (AnimationPreviewMode == CtrDxEditor.ViewModels.AnimationPreviewMode.Focused && Equals(AnimationPreviewObject, obj));
+        }
+
+        private double PreviewSpinDegrees(LevelObject obj)
+        {
+            return IsAnimationPreviewing(obj) ? ObjectSpin.PreviewDegrees(obj, AnimationPreviewElapsedSeconds) : 0.0;
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -77,6 +77,10 @@ namespace CtrDxEditor.Rendering
 
             foreach (LevelObject obj in objects)
             {
+                if (ShowMovementPaths)
+                {
+                    LevelSceneRenderer.DrawOrbitPath(context, v, obj, _palette.OrbitPath, _palette.OrbitPathArrow);
+                }
                 if (!IsAnimationPreviewing(obj))
                 {
                     LevelSceneRenderer.DrawSpinArrow(context, v, obj, _palette.SpinArrow);
@@ -93,11 +97,11 @@ namespace CtrDxEditor.Rendering
                     }
                     if (ShowHitboxes)
                     {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop, PreviewSpinDegrees(obj));
+                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
                     }
                     if (ShowMobileHitboxes)
                     {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone, PreviewSpinDegrees(obj));
+                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
                     }
                 }
             }
@@ -130,7 +134,7 @@ namespace CtrDxEditor.Rendering
                 LevelBounds sb = LevelSceneRenderer.SelectionBounds(sprites, selected, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
                 // Both boxes are dashed; a locked object is red, an unlocked one blue.
                 Pen pen = Equals(LockedObject, selected) ? _palette.ObjectLocked : _palette.ObjectSelected;
-                Point[] points = LevelSceneRenderer.SelectionOutlinePointsWithPreview(v, selected, sb, PreviewSpinDegrees(selected));
+                Point[] points = LevelSceneRenderer.SelectionOutlinePointsWithPreview(v, selected, sb, PreviewSpinDegrees(selected), PreviewAnimationSeconds(selected));
                 for (int i = 0; i < points.Length; i++)
                 {
                     context.DrawLine(pen, points[i], points[(i + 1) % points.Length]);
@@ -327,6 +331,11 @@ namespace CtrDxEditor.Rendering
         private double PreviewSpinDegrees(LevelObject obj)
         {
             return IsAnimationPreviewing(obj) ? ObjectSpin.PreviewDegrees(obj, AnimationPreviewElapsedSeconds) : 0.0;
+        }
+
+        private double? PreviewAnimationSeconds(LevelObject obj)
+        {
+            return IsAnimationPreviewing(obj) ? AnimationPreviewElapsedSeconds : null;
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -9,6 +9,7 @@ using CtrDxEditor.Content;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
+using CtrDxEditor.ViewModels;
 
 namespace CtrDxEditor.Rendering
 {
@@ -69,6 +70,18 @@ namespace CtrDxEditor.Rendering
         public static readonly StyledProperty<int> ActiveOmNomSupportProperty =
             AvaloniaProperty.Register<LevelCanvas, int>(nameof(ActiveOmNomSupport));
 
+        /// <summary>Avalonia property backing <see cref="AnimationPreviewMode"/>.</summary>
+        public static readonly StyledProperty<AnimationPreviewMode> AnimationPreviewModeProperty =
+            AvaloniaProperty.Register<LevelCanvas, AnimationPreviewMode>(nameof(AnimationPreviewMode));
+
+        /// <summary>Avalonia property backing <see cref="AnimationPreviewObject"/>.</summary>
+        public static readonly StyledProperty<LevelObject?> AnimationPreviewObjectProperty =
+            AvaloniaProperty.Register<LevelCanvas, LevelObject?>(nameof(AnimationPreviewObject));
+
+        /// <summary>Avalonia property backing <see cref="AnimationPreviewElapsedSeconds"/>.</summary>
+        public static readonly StyledProperty<double> AnimationPreviewElapsedSecondsProperty =
+            AvaloniaProperty.Register<LevelCanvas, double>(nameof(AnimationPreviewElapsedSeconds));
+
         /// <summary>Avalonia property backing <see cref="HorizontalScrollMaximum"/>.</summary>
         public static readonly StyledProperty<double> HorizontalScrollMaximumProperty =
             AvaloniaProperty.Register<LevelCanvas, double>(nameof(HorizontalScrollMaximum));
@@ -102,7 +115,8 @@ namespace CtrDxEditor.Rendering
                 SelectedObjectProperty, LockedObjectProperty,
                 ShowHitboxesProperty, ShowMobileHitboxesProperty, ShowForceFieldsProperty,
                 ActiveRopeSkinProperty, ActiveBackgroundProperty, ActiveCandySkinProperty,
-                ActiveOmNomSupportProperty);
+                ActiveOmNomSupportProperty,
+                AnimationPreviewModeProperty, AnimationPreviewObjectProperty, AnimationPreviewElapsedSecondsProperty);
         }
 
         /// <summary>The loaded level document to render and edit.</summary>
@@ -143,6 +157,15 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Editor-decoration Om Nom sitting platform index applied to the target (0 = default).</summary>
         public int ActiveOmNomSupport { get => GetValue(ActiveOmNomSupportProperty); set => SetValue(ActiveOmNomSupportProperty, value); }
+
+        /// <summary>Which live object-animation preview is active.</summary>
+        public AnimationPreviewMode AnimationPreviewMode { get => GetValue(AnimationPreviewModeProperty); set => SetValue(AnimationPreviewModeProperty, value); }
+
+        /// <summary>The object targeted by object-scoped live preview, or null.</summary>
+        public LevelObject? AnimationPreviewObject { get => GetValue(AnimationPreviewObjectProperty); set => SetValue(AnimationPreviewObjectProperty, value); }
+
+        /// <summary>Elapsed live-preview time in seconds.</summary>
+        public double AnimationPreviewElapsedSeconds { get => GetValue(AnimationPreviewElapsedSecondsProperty); set => SetValue(AnimationPreviewElapsedSecondsProperty, value); }
 
         /// <summary>Largest horizontal scroll offset in screen pixels.</summary>
         public double HorizontalScrollMaximum { get => GetValue(HorizontalScrollMaximumProperty); private set => SetValue(HorizontalScrollMaximumProperty, value); }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -54,6 +54,10 @@ namespace CtrDxEditor.Rendering
         public static readonly StyledProperty<bool> ShowForceFieldsProperty =
             AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowForceFields), defaultValue: true);
 
+        /// <summary>Avalonia property backing <see cref="ShowMovementPaths"/>.</summary>
+        public static readonly StyledProperty<bool> ShowMovementPathsProperty =
+            AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowMovementPaths), defaultValue: true);
+
         /// <summary>Editor-decoration rope skin index applied to every rope (0 = default brown).</summary>
         public static readonly StyledProperty<int> ActiveRopeSkinProperty =
             AvaloniaProperty.Register<LevelCanvas, int>(nameof(ActiveRopeSkin));
@@ -113,7 +117,7 @@ namespace CtrDxEditor.Rendering
             AffectsRender<LevelCanvas>(
                 DocumentProperty, SpritesProperty, ViewProperty, SnapEnabledProperty,
                 SelectedObjectProperty, LockedObjectProperty,
-                ShowHitboxesProperty, ShowMobileHitboxesProperty, ShowForceFieldsProperty,
+                ShowHitboxesProperty, ShowMobileHitboxesProperty, ShowForceFieldsProperty, ShowMovementPathsProperty,
                 ActiveRopeSkinProperty, ActiveBackgroundProperty, ActiveCandySkinProperty,
                 ActiveOmNomSupportProperty,
                 AnimationPreviewModeProperty, AnimationPreviewObjectProperty, AnimationPreviewElapsedSecondsProperty);
@@ -145,6 +149,9 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Whether directional force-field arrows (e.g. the pump's flow) are drawn over objects.</summary>
         public bool ShowForceFields { get => GetValue(ShowForceFieldsProperty); set => SetValue(ShowForceFieldsProperty, value); }
+
+        /// <summary>Whether object movement path guides are drawn over objects.</summary>
+        public bool ShowMovementPaths { get => GetValue(ShowMovementPathsProperty); set => SetValue(ShowMovementPathsProperty, value); }
 
         /// <summary>Editor-decoration rope skin index applied to every rope (0 = default brown).</summary>
         public int ActiveRopeSkin { get => GetValue(ActiveRopeSkinProperty); set => SetValue(ActiveRopeSkinProperty, value); }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -120,7 +120,7 @@ namespace CtrDxEditor.Rendering
         /// <param name="omNomSupport">Active Om Nom support index.</param>
         /// <param name="nightLevel">Whether night sprite variants apply.</param>
         /// <param name="starDurationText">Brush for the timed-star duration label.</param>
-        /// <param name="spinPreviewSeconds">Elapsed live-preview seconds, or null for authored static rendering.</param>
+        /// <param name="animationPreviewSeconds">Elapsed live-preview seconds, or null for authored static rendering.</param>
         public static void DrawObject(
             DrawingContext ctx,
             ViewTransform v,
@@ -130,21 +130,24 @@ namespace CtrDxEditor.Rendering
             int omNomSupport,
             bool nightLevel,
             IBrush starDurationText,
-            double? spinPreviewSeconds = null)
+            double? animationPreviewSeconds = null)
         {
-            double? spinRotation = SpinPreviewRotation(obj, spinPreviewSeconds);
+            Vec2 previewPosition = PreviewPosition(obj, animationPreviewSeconds);
+            double x = previewPosition.X;
+            double y = previewPosition.Y;
+            double? spinRotation = SpinPreviewRotation(obj, animationPreviewSeconds);
             if (obj.Type == "star" && StarTimeout(obj) is double timeout && timeout > 0)
             {
                 if (sprites.GetSprite("star_timed") is { } timed)
                 {
-                    DrawSprite(ctx, v, timed, obj.X, obj.Y, spinRotation);
+                    DrawSprite(ctx, v, timed, x, y, spinRotation);
                 }
                 if (sprites.GetSprite(CanvasSpriteKey("star", nightLevel), candySkin, omNomSupport) is { } star)
                 {
-                    DrawSprite(ctx, v, star, obj.X, obj.Y, spinRotation);
-                    DrawStarDuration(ctx, v, star, obj, timeout, starDurationText);
+                    DrawSprite(ctx, v, star, x, y, spinRotation);
+                    DrawStarDuration(ctx, v, star, x, y, timeout, starDurationText);
                 }
-                DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+                DrawOverlays(ctx, v, sprites, obj, x, y);
                 return;
             }
 
@@ -156,10 +159,10 @@ namespace CtrDxEditor.Rendering
                     double deg = ObjectRotation.DisplayDegrees(obj, rotSpec) + (spinRotation ?? 0.0);
                     foreach (SpriteLayerDraw layer in rotSprite.Layers)
                     {
-                        DrawLayer(ctx, v, layer, obj.X, obj.Y, rotSprite.Scale, deg);
+                        DrawLayer(ctx, v, layer, x, y, rotSprite.Scale, deg);
                     }
                 }
-                DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+                DrawOverlays(ctx, v, sprites, obj, x, y);
                 return;
             }
 
@@ -169,11 +172,18 @@ namespace CtrDxEditor.Rendering
             {
                 if (sprite.Variants.Count > 0)
                 {
-                    DrawLayer(ctx, v, sprite.Variants[SpriteVariantPicker.Pick(obj.Element, sprite.Variants.Count)], obj.X, obj.Y, sprite.Scale, spinRotation);
+                    DrawLayer(ctx, v, sprite.Variants[SpriteVariantPicker.Pick(obj.Element, sprite.Variants.Count)], x, y, sprite.Scale, spinRotation);
                 }
-                DrawSprite(ctx, v, sprite, obj.X, obj.Y, spinRotation);
+                DrawSprite(ctx, v, sprite, x, y, spinRotation);
             }
-            DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+            DrawOverlays(ctx, v, sprites, obj, x, y);
+        }
+
+        private static Vec2 PreviewPosition(LevelObject obj, double? animationPreviewSeconds)
+        {
+            return animationPreviewSeconds is double seconds
+                ? ObjectSpin.PreviewPosition(obj, seconds)
+                : new Vec2(obj.X, obj.Y);
         }
 
         private static double? SpinPreviewRotation(LevelObject obj, double? spinPreviewSeconds)
@@ -246,13 +256,16 @@ namespace CtrDxEditor.Rendering
         /// <param name="obj">The selected object.</param>
         /// <param name="bounds">The unrotated level-space selection bounds.</param>
         /// <param name="previewRotationDegrees">Live-preview spin degrees to add to the authored rotation.</param>
+        /// <param name="animationPreviewSeconds">Elapsed live-preview seconds used to translate orbiting objects.</param>
         /// <returns>Four screen-space corners ordered clockwise from top-left.</returns>
         public static Point[] SelectionOutlinePointsWithPreview(
             ViewTransform v,
             LevelObject obj,
             LevelBounds bounds,
-            double previewRotationDegrees)
+            double previewRotationDegrees,
+            double? animationPreviewSeconds = null)
         {
+            bounds = PreviewSelectionBounds(obj, bounds, animationPreviewSeconds);
             Point[] points =
             [
                 ScreenPoint(v, bounds.X, bounds.Y),
@@ -284,6 +297,16 @@ namespace CtrDxEditor.Rendering
             return points;
         }
 
+        private static LevelBounds PreviewSelectionBounds(LevelObject obj, LevelBounds bounds, double? animationPreviewSeconds)
+        {
+            Vec2 position = PreviewPosition(obj, animationPreviewSeconds);
+            double dx = position.X - obj.X;
+            double dy = position.Y - obj.Y;
+            return dx == 0.0 && dy == 0.0
+                ? bounds
+                : new LevelBounds(bounds.X + dx, bounds.Y + dy, bounds.W, bounds.H);
+        }
+
         private static Point ScreenPoint(ViewTransform v, double x, double y)
         {
             Vec2 point = v.LevelToScreen(new Vec2(x, y));
@@ -294,21 +317,23 @@ namespace CtrDxEditor.Rendering
         /// <param name="ctx">Destination drawing context.</param>
         /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
         /// <param name="star">The star sprite, used to find its visible top edge.</param>
-        /// <param name="obj">The star object.</param>
+        /// <param name="x">Star anchor X in level units.</param>
+        /// <param name="y">Star anchor Y in level units.</param>
         /// <param name="timeout">The star's timeout in seconds.</param>
         /// <param name="foreground">Brush for the label text.</param>
         private static void DrawStarDuration(
             DrawingContext ctx,
             ViewTransform v,
             ObjectSprite star,
-            LevelObject obj,
+            double x,
+            double y,
             double timeout,
             IBrush foreground)
         {
             FormattedText formatted = CreateStarDurationText(FormatStarDuration(timeout), v.Zoom, foreground);
 
-            double top = StarTop(star, obj);
-            Vec2 anchor = v.LevelToScreen(new Vec2(obj.X, top));
+            double top = StarTop(star, x, y);
+            Vec2 anchor = v.LevelToScreen(new Vec2(x, top));
             Point origin = ComputeStarDurationOrigin(
                 new Point(anchor.X, anchor.Y),
                 new Size(formatted.Width, formatted.Height),
@@ -352,17 +377,18 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Finds the visible top edge of a star's art in level units.</summary>
         /// <param name="star">The star sprite.</param>
-        /// <param name="obj">The star object providing the anchor position.</param>
+        /// <param name="x">Star anchor X in level units.</param>
+        /// <param name="y">Star anchor Y in level units.</param>
         /// <returns>The topmost drawn Y, or the object's Y when the sprite has no layers.</returns>
-        private static double StarTop(ObjectSprite star, LevelObject obj)
+        private static double StarTop(ObjectSprite star, double x, double y)
         {
             double top = double.MaxValue;
             foreach (SpriteLayerDraw layer in star.Layers)
             {
-                LevelBounds bounds = SpritePlacement.Compute(layer.Frame, obj.X, obj.Y, star.Scale).Dest;
+                LevelBounds bounds = SpritePlacement.Compute(layer.Frame, x, y, star.Scale).Dest;
                 top = Math.Min(top, bounds.Y);
             }
-            return top == double.MaxValue ? obj.Y : top;
+            return top == double.MaxValue ? y : top;
         }
 
         /// <summary>
@@ -630,6 +656,7 @@ namespace CtrDxEditor.Rendering
         /// <param name="model">Which device hitbox model (desktop or phone) to compute.</param>
         /// <param name="pen">Pen for the hitbox outline.</param>
         /// <param name="previewRotationDegrees">Live-preview spin degrees to add to the authored rotation.</param>
+        /// <param name="animationPreviewSeconds">Elapsed live-preview seconds used to translate orbiting objects.</param>
         public static void DrawHitbox(
             DrawingContext ctx,
             ViewTransform v,
@@ -637,9 +664,10 @@ namespace CtrDxEditor.Rendering
             double scale,
             HitboxModel model,
             Pen pen,
-            double previewRotationDegrees = 0.0)
+            double previewRotationDegrees = 0.0,
+            double? animationPreviewSeconds = null)
         {
-            if (HitboxTable.Compute(obj, scale, model) is not { } b)
+            if (PreviewHitboxBounds(obj, scale, model, animationPreviewSeconds) is not { } b)
             {
                 return;
             }
@@ -654,7 +682,8 @@ namespace CtrDxEditor.Rendering
                 + (RotationTable.For(obj.Type) is { } rotSpec ? ObjectRotation.DisplayDegrees(obj, rotSpec) : 0.0);
             if (deg != 0)
             {
-                Vec2 center = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+                Vec2 previewPosition = PreviewPosition(obj, animationPreviewSeconds);
+                Vec2 center = v.LevelToScreen(previewPosition);
                 Matrix m = Matrix.CreateTranslation(-center.X, -center.Y)
                     * Matrix.CreateRotation(deg * Math.PI / 180.0)
                     * Matrix.CreateTranslation(center.X, center.Y);
@@ -665,6 +694,110 @@ namespace CtrDxEditor.Rendering
                 return;
             }
             ctx.DrawRectangle(null, pen, box);
+        }
+
+        /// <summary>Computes hitbox bounds translated to the live orbit-preview position.</summary>
+        public static LevelBounds? PreviewHitboxBounds(
+            LevelObject obj,
+            double scale,
+            HitboxModel model,
+            double? animationPreviewSeconds)
+        {
+            if (HitboxTable.Compute(obj, scale, model) is not { } bounds)
+            {
+                return null;
+            }
+
+            Vec2 position = PreviewPosition(obj, animationPreviewSeconds);
+            double dx = position.X - obj.X;
+            double dy = position.Y - obj.Y;
+            return dx == 0.0 && dy == 0.0
+                ? bounds
+                : new LevelBounds(bounds.X + dx, bounds.Y + dy, bounds.W, bounds.H);
+        }
+
+        /// <summary>Draws the circular path used by active <c>RC</c>/<c>RW</c> orbit movement.</summary>
+        public static void DrawOrbitPath(DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pathPen, Pen arrowPen)
+        {
+            Point[] points = ComputeOrbitPathPoints(v, obj);
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            for (int i = 0; i < points.Length; i++)
+            {
+                ctx.DrawLine(pathPen, points[i], points[(i + 1) % points.Length]);
+            }
+
+            Point[] arrow = ComputeOrbitArrowPoints(v, obj);
+            if (arrow.Length == 4)
+            {
+                ctx.DrawLine(arrowPen, arrow[0], arrow[1]);
+                ctx.DrawLine(arrowPen, arrow[1], arrow[2]);
+                ctx.DrawLine(arrowPen, arrow[1], arrow[3]);
+            }
+        }
+
+        /// <summary>Computes screen-space points for the circular orbit path centered on authored object coordinates.</summary>
+        public static Point[] ComputeOrbitPathPoints(ViewTransform v, LevelObject obj)
+        {
+            if (!ObjectSpin.IsOrbital(obj))
+            {
+                return [];
+            }
+
+            int radius = ObjectSpin.OrbitRadius(obj);
+            int segments = Math.Max(24, radius);
+            Point[] points = new Point[segments];
+            Vec2 center = new(obj.X, obj.Y);
+            for (int i = 0; i < points.Length; i++)
+            {
+                double angle = Math.Tau * i / points.Length;
+                Vec2 level = new(
+                    center.X + (Math.Cos(angle) * radius),
+                    center.Y + (Math.Sin(angle) * radius));
+                Vec2 screen = v.LevelToScreen(level);
+                points[i] = new Point(screen.X, screen.Y);
+            }
+
+            return points;
+        }
+
+        /// <summary>Computes a small screen-space tangent arrow for the RC/RW orbit path direction.</summary>
+        public static Point[] ComputeOrbitArrowPoints(ViewTransform v, LevelObject obj)
+        {
+            if (!ObjectSpin.IsOrbital(obj))
+            {
+                return [];
+            }
+
+            int radius = ObjectSpin.OrbitRadius(obj);
+            if (radius <= 0)
+            {
+                return [];
+            }
+
+            Vec2 center = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+            double radiusScreen = radius * v.Zoom;
+            double arrowLength = Math.Min(Math.Max(radiusScreen * 0.35, 8.0), 18.0);
+            double direction = ObjectSpin.OrbitClockwise(obj) ? 0.0 : Math.PI;
+            Point tail = new(
+                center.X + (Math.Cos(-Math.PI / 2.0) * radiusScreen),
+                center.Y + (Math.Sin(-Math.PI / 2.0) * radiusScreen));
+            Point tip = new(
+                tail.X + (Math.Cos(direction) * arrowLength),
+                tail.Y + (Math.Sin(direction) * arrowLength));
+            double barbLength = Math.Min(arrowLength * 0.6, 8.0);
+            double spread = Math.PI / 6.0;
+            Point barb1 = new(
+                tip.X + (Math.Cos(direction + Math.PI - spread) * barbLength),
+                tip.Y + (Math.Sin(direction + Math.PI - spread) * barbLength));
+            Point barb2 = new(
+                tip.X + (Math.Cos(direction + Math.PI + spread) * barbLength),
+                tip.Y + (Math.Sin(direction + Math.PI + spread) * barbLength));
+
+            return [tail, tip, barb1, barb2];
         }
 
         /// <summary>

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -178,7 +178,7 @@ namespace CtrDxEditor.Rendering
 
         private static double? SpinPreviewRotation(LevelObject obj, double? spinPreviewSeconds)
         {
-            if (spinPreviewSeconds is not double seconds || !SpinTable.IsSpinnable(obj.Type) || !ObjectSpin.IsSpinning(obj))
+            if (spinPreviewSeconds is not double seconds || !SpinTable.IsSpinnable(obj.Type) || !ObjectSpin.IsRotatingInPlace(obj))
             {
                 return null;
             }
@@ -745,7 +745,7 @@ namespace CtrDxEditor.Rendering
             Vec2 centerLevel = new(obj.X, obj.Y);
             Vec2 screen = v.LevelToScreen(centerLevel);
             Point center = new(screen.X, screen.Y);
-            bool clockwise = ObjectSpin.Clockwise(obj);
+            bool clockwise = ObjectSpin.SpinClockwise(obj);
             const int arcSegments = 18;
             double start = -Math.PI * 0.75;
             double sweep = Math.PI * 1.5 * (clockwise ? 1 : -1);

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -281,7 +281,8 @@ namespace CtrDxEditor.Rendering
                 return points;
             }
 
-            Point center = ScreenPoint(v, obj.X, obj.Y);
+            Vec2 previewPosition = PreviewPosition(obj, animationPreviewSeconds);
+            Point center = ScreenPoint(v, previewPosition.X, previewPosition.Y);
             double radians = degrees * Math.PI / 180.0;
             double sin = Math.Sin(radians);
             double cos = Math.Cos(radians);

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -681,5 +681,66 @@ namespace CtrDxEditor.Rendering
                     new Point(tip.X + (Math.Cos(barb) * head), tip.Y + (Math.Sin(barb) * head)));
             }
         }
+
+        /// <summary>Draws a curved arrow around an object with active rotateSpeed-backed spin.</summary>
+        /// <param name="ctx">Destination drawing context.</param>
+        /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
+        /// <param name="obj">Object that may carry <c>rotateSpeed</c>.</param>
+        /// <param name="pen">Pen used for the arc and arrowhead.</param>
+        public static void DrawSpinArrow(DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pen)
+        {
+            if (!SpinTable.IsSpinnable(obj.Type) || !ObjectSpin.IsSpinning(obj))
+            {
+                return;
+            }
+
+            Point[] points = ComputeSpinArrowPoints(v, obj, radiusScreen: 18.0);
+            for (int i = 1; i < points.Length - 2; i++)
+            {
+                ctx.DrawLine(pen, points[i - 1], points[i]);
+            }
+
+            Point tip = points[^3];
+            ctx.DrawLine(pen, tip, points[^2]);
+            ctx.DrawLine(pen, tip, points[^1]);
+        }
+
+        /// <summary>Computes screen-space points for the spin arrow arc plus the two arrowhead barbs.</summary>
+        /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
+        /// <param name="obj">Object with a non-zero <c>rotateSpeed</c>.</param>
+        /// <param name="radiusScreen">Arrow radius in screen pixels.</param>
+        /// <returns>Arc points followed by the two arrowhead barb endpoints.</returns>
+        public static Point[] ComputeSpinArrowPoints(ViewTransform v, LevelObject obj, double radiusScreen)
+        {
+            Vec2 centerLevel = new(obj.X, obj.Y);
+            Vec2 screen = v.LevelToScreen(centerLevel);
+            Point center = new(screen.X, screen.Y);
+            bool clockwise = ObjectSpin.Clockwise(obj);
+            const int arcSegments = 18;
+            double start = -Math.PI * 0.75;
+            double sweep = Math.PI * 1.5 * (clockwise ? 1 : -1);
+            Point[] points = new Point[arcSegments + 3];
+            for (int i = 0; i <= arcSegments; i++)
+            {
+                double t = i / (double)arcSegments;
+                double angle = start + (sweep * t);
+                points[i] = new Point(
+                    center.X + (Math.Cos(angle) * radiusScreen),
+                    center.Y + (Math.Sin(angle) * radiusScreen));
+            }
+
+            Point prev = points[arcSegments - 1];
+            Point tip = points[arcSegments];
+            double direction = Math.Atan2(tip.Y - prev.Y, tip.X - prev.X);
+            double head = Math.Min(radiusScreen * 0.45, 9.0);
+            double spread = Math.PI / 6;
+            points[^2] = new Point(
+                tip.X + (Math.Cos(direction + Math.PI - spread) * head),
+                tip.Y + (Math.Sin(direction + Math.PI - spread) * head));
+            points[^1] = new Point(
+                tip.X + (Math.Cos(direction + Math.PI + spread) * head),
+                tip.Y + (Math.Sin(direction + Math.PI + spread) * head));
+            return points;
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -120,6 +120,7 @@ namespace CtrDxEditor.Rendering
         /// <param name="omNomSupport">Active Om Nom support index.</param>
         /// <param name="nightLevel">Whether night sprite variants apply.</param>
         /// <param name="starDurationText">Brush for the timed-star duration label.</param>
+        /// <param name="spinPreviewSeconds">Elapsed live-preview seconds, or null for authored static rendering.</param>
         public static void DrawObject(
             DrawingContext ctx,
             ViewTransform v,
@@ -128,17 +129,19 @@ namespace CtrDxEditor.Rendering
             int candySkin,
             int omNomSupport,
             bool nightLevel,
-            IBrush starDurationText)
+            IBrush starDurationText,
+            double? spinPreviewSeconds = null)
         {
+            double? spinRotation = SpinPreviewRotation(obj, spinPreviewSeconds);
             if (obj.Type == "star" && StarTimeout(obj) is double timeout && timeout > 0)
             {
                 if (sprites.GetSprite("star_timed") is { } timed)
                 {
-                    DrawSprite(ctx, v, timed, obj.X, obj.Y);
+                    DrawSprite(ctx, v, timed, obj.X, obj.Y, spinRotation);
                 }
                 if (sprites.GetSprite(CanvasSpriteKey("star", nightLevel), candySkin, omNomSupport) is { } star)
                 {
-                    DrawSprite(ctx, v, star, obj.X, obj.Y);
+                    DrawSprite(ctx, v, star, obj.X, obj.Y, spinRotation);
                     DrawStarDuration(ctx, v, star, obj, timeout, starDurationText);
                 }
                 DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
@@ -150,7 +153,7 @@ namespace CtrDxEditor.Rendering
                 string rotKey = SpikeObject.IsSpike(obj.Type) ? SpikeObject.SpriteKey(obj) : obj.Type;
                 if (sprites.GetSprite(CanvasSpriteKey(rotKey, nightLevel), candySkin, omNomSupport) is { } rotSprite)
                 {
-                    double deg = ObjectRotation.DisplayDegrees(obj, rotSpec);
+                    double deg = ObjectRotation.DisplayDegrees(obj, rotSpec) + (spinRotation ?? 0.0);
                     foreach (SpriteLayerDraw layer in rotSprite.Layers)
                     {
                         DrawLayer(ctx, v, layer, obj.X, obj.Y, rotSprite.Scale, deg);
@@ -166,11 +169,22 @@ namespace CtrDxEditor.Rendering
             {
                 if (sprite.Variants.Count > 0)
                 {
-                    DrawLayer(ctx, v, sprite.Variants[SpriteVariantPicker.Pick(obj.Element, sprite.Variants.Count)], obj.X, obj.Y, sprite.Scale);
+                    DrawLayer(ctx, v, sprite.Variants[SpriteVariantPicker.Pick(obj.Element, sprite.Variants.Count)], obj.X, obj.Y, sprite.Scale, spinRotation);
                 }
-                DrawSprite(ctx, v, sprite, obj.X, obj.Y);
+                DrawSprite(ctx, v, sprite, obj.X, obj.Y, spinRotation);
             }
             DrawOverlays(ctx, v, sprites, obj, obj.X, obj.Y);
+        }
+
+        private static double? SpinPreviewRotation(LevelObject obj, double? spinPreviewSeconds)
+        {
+            if (spinPreviewSeconds is not double seconds || !SpinTable.IsSpinnable(obj.Type) || !ObjectSpin.IsSpinning(obj))
+            {
+                return null;
+            }
+
+            double degrees = ObjectSpin.PreviewDegrees(obj, seconds);
+            return degrees == 0 ? null : degrees;
         }
 
         /// <summary>Reads a star's <c>timeout</c> attribute in seconds.</summary>
@@ -224,6 +238,21 @@ namespace CtrDxEditor.Rendering
         /// <returns>Four screen-space corners ordered clockwise from top-left.</returns>
         public static Point[] SelectionOutlinePoints(ViewTransform v, LevelObject obj, LevelBounds bounds)
         {
+            return SelectionOutlinePointsWithPreview(v, obj, bounds, previewRotationDegrees: 0.0);
+        }
+
+        /// <summary>Screen-space selection outline corners with optional live-preview spin added.</summary>
+        /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
+        /// <param name="obj">The selected object.</param>
+        /// <param name="bounds">The unrotated level-space selection bounds.</param>
+        /// <param name="previewRotationDegrees">Live-preview spin degrees to add to the authored rotation.</param>
+        /// <returns>Four screen-space corners ordered clockwise from top-left.</returns>
+        public static Point[] SelectionOutlinePointsWithPreview(
+            ViewTransform v,
+            LevelObject obj,
+            LevelBounds bounds,
+            double previewRotationDegrees)
+        {
             Point[] points =
             [
                 ScreenPoint(v, bounds.X, bounds.Y),
@@ -232,12 +261,8 @@ namespace CtrDxEditor.Rendering
                 ScreenPoint(v, bounds.X, bounds.Y + bounds.H),
             ];
 
-            if (RotationTable.For(obj.Type) is not { } rotSpec)
-            {
-                return points;
-            }
-
-            double degrees = ObjectRotation.DisplayDegrees(obj, rotSpec);
+            double degrees = previewRotationDegrees
+                + (RotationTable.For(obj.Type) is { } rotSpec ? ObjectRotation.DisplayDegrees(obj, rotSpec) : 0.0);
             if (degrees == 0)
             {
                 return points;
@@ -526,11 +551,12 @@ namespace CtrDxEditor.Rendering
         /// <param name="sprite">The sprite to draw.</param>
         /// <param name="x">Anchor X in level units.</param>
         /// <param name="y">Anchor Y in level units.</param>
-        public static void DrawSprite(DrawingContext ctx, ViewTransform v, ObjectSprite sprite, double x, double y)
+        /// <param name="rotationDegrees">Rotation about the anchor in degrees, or null for no rotation.</param>
+        public static void DrawSprite(DrawingContext ctx, ViewTransform v, ObjectSprite sprite, double x, double y, double? rotationDegrees = null)
         {
             foreach (SpriteLayerDraw layer in sprite.Layers)
             {
-                DrawLayer(ctx, v, layer, x, y, sprite.Scale);
+                DrawLayer(ctx, v, layer, x, y, sprite.Scale, rotationDegrees);
             }
         }
 
@@ -603,13 +629,15 @@ namespace CtrDxEditor.Rendering
         /// <param name="scale">Sprite scale factor, used to size the hitbox.</param>
         /// <param name="model">Which device hitbox model (desktop or phone) to compute.</param>
         /// <param name="pen">Pen for the hitbox outline.</param>
+        /// <param name="previewRotationDegrees">Live-preview spin degrees to add to the authored rotation.</param>
         public static void DrawHitbox(
             DrawingContext ctx,
             ViewTransform v,
             LevelObject obj,
             double scale,
             HitboxModel model,
-            Pen pen)
+            Pen pen,
+            double previewRotationDegrees = 0.0)
         {
             if (HitboxTable.Compute(obj, scale, model) is not { } b)
             {
@@ -622,7 +650,9 @@ namespace CtrDxEditor.Rendering
             // A rotatable object's box turns with its sprite about the same anchor (see DrawLayer). The view
             // transform is translation + uniform scale, so rotating the projected box about the projected
             // anchor equals rotating it in level space. Square boxes only diverge visibly off the axes.
-            if (RotationTable.For(obj.Type) is { } rotSpec && ObjectRotation.DisplayDegrees(obj, rotSpec) is var deg && deg != 0)
+            double deg = previewRotationDegrees
+                + (RotationTable.For(obj.Type) is { } rotSpec ? ObjectRotation.DisplayDegrees(obj, rotSpec) : 0.0);
+            if (deg != 0)
             {
                 Vec2 center = v.LevelToScreen(new Vec2(obj.X, obj.Y));
                 Matrix m = Matrix.CreateTranslation(-center.X, -center.Y)

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -282,6 +282,7 @@
       <Color x:Key="EditorColor.DangerHover">#C10007</Color>  <!-- red-700 -->
       <Color x:Key="EditorColor.DangerPressed">#9F0712</Color>  <!-- red-800 -->
       <Color x:Key="EditorColor.DangerText">#E7000B</Color>  <!-- red-600 -->
+      <Color x:Key="EditorColor.SuccessText">#008236</Color>  <!-- green-700 -->
       <Color x:Key="EditorColor.Warning">#BB4D00</Color>  <!-- amber-700 -->
       <Color x:Key="EditorColor.SurfacePanel">#F8FAFC</Color>  <!-- slate-50 -->
       <Color x:Key="EditorColor.SurfaceDivider">#E2E8F0</Color>  <!-- slate-200 -->
@@ -322,6 +323,7 @@
       <Color x:Key="EditorColor.DangerHover">#FB2C36</Color>  <!-- red-500 -->
       <Color x:Key="EditorColor.DangerPressed">#C10007</Color>  <!-- red-700 -->
       <Color x:Key="EditorColor.DangerText">#FF6467</Color>  <!-- red-400 -->
+      <Color x:Key="EditorColor.SuccessText">#05DF72</Color>  <!-- green-400 -->
       <Color x:Key="EditorColor.Warning">#FFB900</Color>  <!-- amber-400 -->
       <Color x:Key="EditorColor.SurfacePanel">#0F172B</Color>  <!-- slate-900 -->
       <Color x:Key="EditorColor.SurfaceDivider">#314158</Color>  <!-- slate-700 -->
@@ -361,6 +363,7 @@
   <SolidColorBrush x:Key="EditorBrush.OnPrimary" Color="{DynamicResource EditorColor.OnPrimary}" />
   <SolidColorBrush x:Key="EditorBrush.Danger" Color="{DynamicResource EditorColor.Danger}" />
   <SolidColorBrush x:Key="EditorBrush.DangerText" Color="{DynamicResource EditorColor.DangerText}" />
+  <SolidColorBrush x:Key="EditorBrush.SuccessText" Color="{DynamicResource EditorColor.SuccessText}" />
   <SolidColorBrush x:Key="EditorBrush.DangerHover" Color="{DynamicResource EditorColor.DangerHover}" />
   <SolidColorBrush x:Key="EditorBrush.DangerPressed" Color="{DynamicResource EditorColor.DangerPressed}" />
   <SolidColorBrush x:Key="EditorBrush.Warning" Color="{DynamicResource EditorColor.Warning}" />

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -306,6 +306,7 @@
       <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#7F22FE</Color>     <!-- violet-700 -->
       <Color x:Key="EditorColor.OverlaySpinArrow">#0E7490</Color>      <!-- cyan-700 -->
+      <Color x:Key="EditorColor.OverlayOrbitPath">#2563EB</Color>      <!-- blue-600 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->
@@ -347,6 +348,7 @@
       <Color x:Key="EditorColor.OverlayObjectSelected">#00BCFF</Color> <!-- sky-400, 8.18 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#C4B4FF</Color>     <!-- violet-300, 8.90 -->
       <Color x:Key="EditorColor.OverlaySpinArrow">#67E8F9</Color>      <!-- cyan-300, 11.07 -->
+      <Color x:Key="EditorColor.OverlayOrbitPath">#93C5FD</Color>      <!-- blue-300, 8.37 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Deep blues so the light row text stays readable. -->

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -304,6 +304,7 @@
       <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#7F22FE</Color>     <!-- violet-700 -->
+      <Color x:Key="EditorColor.OverlaySpinArrow">#0E7490</Color>      <!-- cyan-700 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Light tints so the dark row text stays readable. -->
@@ -343,6 +344,7 @@
       <Color x:Key="EditorColor.OverlayObjectLocked">#FFA2A2</Color>   <!-- red-300, 9.29 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#00BCFF</Color> <!-- sky-400, 8.18 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#C4B4FF</Color>     <!-- violet-300, 8.90 -->
+      <Color x:Key="EditorColor.OverlaySpinArrow">#67E8F9</Color>      <!-- cyan-300, 11.07 -->
 
       <!-- FluentTheme list-selection accent (ListBox/TreeView selected row) -> Tailwind blue.
            Deep blues so the light row text stays readable. -->

--- a/src/CtrDxEditor.Shared/ViewModels/AnimationPreviewMode.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AnimationPreviewMode.cs
@@ -1,0 +1,15 @@
+namespace CtrDxEditor.ViewModels
+{
+    /// <summary>Which live object-animation preview is currently active.</summary>
+    public enum AnimationPreviewMode
+    {
+        /// <summary>No live preview; objects render at their authored static state.</summary>
+        Off,
+
+        /// <summary>Every eligible animated object renders with live elapsed motion.</summary>
+        All,
+
+        /// <summary>Only <see cref="EditorViewModel.AnimationPreviewObject"/> renders with live elapsed motion.</summary>
+        Focused,
+    }
+}

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -110,7 +110,7 @@ namespace CtrDxEditor.ViewModels
         public int NumericMinimum => Name switch
         {
             "timeout" => 1,
-            "spinSpeed" => 1,
+            "spinSpeed" or "orbitRadius" => 1,
             "length" or "radius" or "moveLength" or "moveOffset" or "litRadius" => 0,
             _ => -9999,
         };

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -110,6 +110,7 @@ namespace CtrDxEditor.ViewModels
         public int NumericMinimum => Name switch
         {
             "timeout" => 1,
+            "spinSpeed" => 1,
             "length" or "radius" or "moveLength" or "moveOffset" or "litRadius" => 0,
             _ => -9999,
         };

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -110,7 +110,7 @@ namespace CtrDxEditor.ViewModels
         public int NumericMinimum => Name switch
         {
             "timeout" => 1,
-            "spinSpeed" or "orbitRadius" => 1,
+            "spinSpeed" or "orbitRadius" or "orbitSpeed" => 1,
             "length" or "radius" or "moveLength" or "moveOffset" or "litRadius" => 0,
             _ => -9999,
         };

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -44,6 +44,9 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial int ActiveBackground { get; set; }
         [ObservableProperty] public partial int ActiveCandySkin { get; set; }
         [ObservableProperty] public partial int ActiveOmNomSupport { get; set; }
+        [ObservableProperty] public partial AnimationPreviewMode AnimationPreviewMode { get; set; }
+        [ObservableProperty] public partial LevelObject? AnimationPreviewObject { get; set; }
+        [ObservableProperty] public partial double AnimationPreviewElapsedSeconds { get; set; }
 
         /// <summary>Sprite cache for the active content.</summary>
         public SpriteCache Sprites { get; } = sprites;
@@ -75,9 +78,17 @@ namespace CtrDxEditor.ViewModels
         /// <summary>True when a redo snapshot is available.</summary>
         public bool CanRedo => _redoStack.Count > 0;
 
+        /// <summary>True when live object-animation preview is currently running.</summary>
+        public bool IsAnimationPreviewActive => AnimationPreviewMode != AnimationPreviewMode.Off;
+
+        /// <summary>View-menu label for starting or stopping live object-animation preview.</summary>
+        public string AnimationPreviewMenuText => Localizer.Get(
+            IsAnimationPreviewActive ? "Menu.View.StopAnimations" : "Menu.View.PlayAnimations");
+
         /// <summary>Loads a level from its XML text into the editor.</summary>
         public void LoadLevelXml(string xml)
         {
+            StopAnimationPreview();
             Document = LevelDocument.Parse(xml);
             SelectedObject = null;
             LockedObject = null;
@@ -91,6 +102,7 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Closes the current level and clears document-scoped editor state.</summary>
         public void CloseLevel()
         {
+            StopAnimationPreview();
             Document = null;
             SelectedObject = null;
             LockedObject = null;
@@ -115,6 +127,7 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Creates a new empty level from the given settings and applies the chosen editor decoration.</summary>
         public void NewLevel(LevelSettings settings, int ropeSkin = 0, int background = 0, int candySkin = 0, int omNomSupport = 0)
         {
+            StopAnimationPreview();
             Document = LevelDocument.CreateNew(settings);
             ActiveRopeSkin = ropeSkin;
             ActiveBackground = background;
@@ -135,6 +148,7 @@ namespace CtrDxEditor.ViewModels
             {
                 return;
             }
+            StopAnimationPreview();
             CaptureUndoSnapshot();
             Document.UpdateSettings(settings);
             RefreshPalette();
@@ -161,6 +175,10 @@ namespace CtrDxEditor.ViewModels
             }
 
             LevelObject removed = SelectedObject;
+            if (IsAnimationPreviewing(removed))
+            {
+                StopAnimationPreview();
+            }
             CaptureUndoSnapshot();
             LevelDocument.Remove(removed);
             if (Equals(LockedObject, removed))
@@ -186,6 +204,57 @@ namespace CtrDxEditor.ViewModels
             {
                 SelectedObject = obj;
             }
+        }
+
+        /// <summary>Starts live preview for every spinning object, resetting elapsed time to zero.</summary>
+        public void PlayAllAnimations()
+        {
+            AnimationPreviewObject = null;
+            AnimationPreviewElapsedSeconds = 0;
+            AnimationPreviewMode = AnimationPreviewMode.All;
+        }
+
+        /// <summary>Stops live preview and resets visual playback to the authored static state.</summary>
+        public void StopAnimationPreview()
+        {
+            AnimationPreviewMode = AnimationPreviewMode.Off;
+            AnimationPreviewObject = null;
+            AnimationPreviewElapsedSeconds = 0;
+        }
+
+        /// <summary>Toggles the View-menu playback command: any active preview stops; otherwise all objects play.</summary>
+        public void ToggleAnimationPreviewAll()
+        {
+            if (IsAnimationPreviewActive)
+            {
+                StopAnimationPreview();
+                return;
+            }
+            PlayAllAnimations();
+        }
+
+        /// <summary>Starts live preview for one object, or stops when that same object is already the object preview.</summary>
+        /// <param name="obj">Object to preview.</param>
+        public void ToggleAnimationPreviewObject(LevelObject obj)
+        {
+            if (AnimationPreviewMode == AnimationPreviewMode.Focused && Equals(AnimationPreviewObject, obj))
+            {
+                StopAnimationPreview();
+                return;
+            }
+
+            AnimationPreviewObject = obj;
+            AnimationPreviewElapsedSeconds = 0;
+            AnimationPreviewMode = AnimationPreviewMode.Focused;
+        }
+
+        /// <summary>Whether live preview motion applies to the given object right now.</summary>
+        /// <param name="obj">Object to inspect.</param>
+        /// <returns>True when global preview is active, or when object-scoped preview targets <paramref name="obj"/>.</returns>
+        public bool IsAnimationPreviewing(LevelObject obj)
+        {
+            return AnimationPreviewMode == AnimationPreviewMode.All
+                || (AnimationPreviewMode == AnimationPreviewMode.Focused && Equals(AnimationPreviewObject, obj));
         }
 
         /// <summary>Refreshes the object list from the current document.</summary>
@@ -334,6 +403,12 @@ namespace CtrDxEditor.ViewModels
         partial void OnDocumentChanged(LevelDocument? value)
         {
             OnPropertyChanged(nameof(HasDocument));
+        }
+
+        partial void OnAnimationPreviewModeChanged(AnimationPreviewMode value)
+        {
+            OnPropertyChanged(nameof(IsAnimationPreviewActive));
+            OnPropertyChanged(nameof(AnimationPreviewMenuText));
         }
 
         partial void OnLockedObjectChanged(LevelObject? value)

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -47,6 +47,7 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial AnimationPreviewMode AnimationPreviewMode { get; set; }
         [ObservableProperty] public partial LevelObject? AnimationPreviewObject { get; set; }
         [ObservableProperty] public partial double AnimationPreviewElapsedSeconds { get; set; }
+        [ObservableProperty] public partial int ObjectListVersion { get; set; }
 
         /// <summary>Sprite cache for the active content.</summary>
         public SpriteCache Sprites { get; } = sprites;
@@ -441,6 +442,7 @@ namespace CtrDxEditor.ViewModels
 
             void Changed()
             {
+                ObjectListVersion++;
                 ObjectMutated?.Invoke();
             }
 

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -40,6 +40,7 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial bool ShowHitboxes { get; set; } = true;
         [ObservableProperty] public partial bool ShowMobileHitboxes { get; set; }
         [ObservableProperty] public partial bool ShowForceFields { get; set; } = true;
+        [ObservableProperty] public partial bool ShowMovementPaths { get; set; } = true;
         [ObservableProperty] public partial int ActiveRopeSkin { get; set; }
         [ObservableProperty] public partial int ActiveBackground { get; set; }
         [ObservableProperty] public partial int ActiveCandySkin { get; set; }

--- a/src/CtrDxEditor.Shared/ViewModels/SpikeFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpikeFieldBuilder.cs
@@ -40,17 +40,26 @@ namespace CtrDxEditor.ViewModels
                 v => SpikeObject.SetSize(value, v),
                 onChanged,
                 onChanging));
-            fields.Add(new AttributeFieldViewModel(
+            AttributeFieldViewModel toggled = new(
                 "toggled",
                 AttrType.Bool,
                 () => SpikeObject.IsToggled(value) ? "true" : "false",
                 v =>
                 {
+                    if (v == "true")
+                    {
+                        ObjectSpin.SetSpin(value, enabled: false, speed: 0, clockwise: true);
+                    }
+
                     SpikeObject.SetToggled(value, v == "true");
                     rebuild();
                 },
                 onChanged,
-                onChanging));
+                onChanging)
+            {
+                IsEnabled = !ObjectSpin.IsSpinning(value),
+            };
+            fields.Add(toggled);
 
             if (SpikeObject.IsToggled(value))
             {
@@ -63,7 +72,14 @@ namespace CtrDxEditor.ViewModels
                     onChanging));
             }
 
-            SpinFieldBuilder.Build(fields, value, onChanged, onChanging, rebuild);
+            SpinFieldBuilder.Build(
+                fields,
+                value,
+                onChanged,
+                onChanging,
+                rebuild,
+                canEnable: !SpikeObject.IsToggled(value),
+                beforeEnable: () => SpikeObject.SetToggled(value, false));
         }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/SpikeFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpikeFieldBuilder.cs
@@ -62,6 +62,8 @@ namespace CtrDxEditor.ViewModels
                     onChanged,
                     onChanging));
             }
+
+            SpinFieldBuilder.Build(fields, value, onChanged, onChanging, rebuild);
         }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+using CtrDxEditor.Core.Descriptors;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+
+namespace CtrDxEditor.ViewModels
+{
+    /// <summary>Builds rotateSpeed-backed spin property fields for spinnable objects.</summary>
+    internal static class SpinFieldBuilder
+    {
+        /// <summary>Adds spin opt-in, positive speed, and direction fields when supported by <see cref="SpinTable"/>.</summary>
+        /// <param name="fields">Property field collection to append to.</param>
+        /// <param name="value">Selected object whose spin attributes are edited.</param>
+        /// <param name="onChanged">Callback invoked after a field writes to the document.</param>
+        /// <param name="onChanging">Callback invoked before a field writes to the document.</param>
+        /// <param name="rebuild">Callback that rebuilds fields after spin disclosure changes.</param>
+        public static void Build(
+            IList<AttributeFieldViewModel> fields,
+            LevelObject value,
+            System.Action onChanged,
+            System.Action onChanging,
+            System.Action rebuild)
+        {
+            if (!SpinTable.IsSpinnable(value.Type))
+            {
+                return;
+            }
+
+            fields.Add(new AttributeFieldViewModel(
+                "spin",
+                AttrType.Bool,
+                () => ObjectSpin.IsSpinning(value) ? "true" : "false",
+                v =>
+                {
+                    bool enabled = v == "true";
+                    int speed = ObjectSpin.Speed(value);
+                    if (enabled && speed == 0)
+                    {
+                        speed = ObjectSpin.DefaultSpeed;
+                    }
+
+                    ObjectSpin.SetSpin(value, enabled, speed, ObjectSpin.Clockwise(value));
+                    rebuild();
+                },
+                onChanged,
+                onChanging));
+
+            if (!ObjectSpin.IsSpinning(value))
+            {
+                return;
+            }
+
+            fields.Add(new AttributeFieldViewModel(
+                "spinSpeed",
+                AttrType.Whole,
+                () => ObjectSpin.Speed(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                v =>
+                {
+                    int speed = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
+                        ? parsed
+                        : 0;
+                    ObjectSpin.SetSpin(value, enabled: true, speed, ObjectSpin.Clockwise(value));
+                    if (speed <= 0)
+                    {
+                        rebuild();
+                    }
+                },
+                onChanged,
+                onChanging));
+
+            fields.Add(new AttributeFieldViewModel(
+                "spinClockwise",
+                AttrType.Bool,
+                () => ObjectSpin.Clockwise(value) ? "true" : "false",
+                v => ObjectSpin.SetSpin(value, enabled: true, ObjectSpin.Speed(value), clockwise: v == "true"),
+                onChanged,
+                onChanging));
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 using CtrDxEditor.Core.Descriptors;
 using CtrDxEditor.Core.Document;
@@ -32,10 +33,21 @@ namespace CtrDxEditor.ViewModels
                 return;
             }
 
+            void Structural()
+            {
+                onChanged();
+                rebuild();
+            }
+
+            bool spinning = ObjectSpin.IsSpinning(value);
+            bool spinClockwise = ObjectSpin.SpinClockwise(value);
+            bool orbital = ObjectSpin.IsOrbital(value);
+            bool orbitClockwise = ObjectSpin.OrbitClockwise(value);
+
             AttributeFieldViewModel spin = new(
                 "spin",
                 AttrType.Bool,
-                () => ObjectSpin.IsSpinning(value) ? "true" : "false",
+                () => spinning ? "true" : "false",
                 v =>
                 {
                     bool enabled = v == "true";
@@ -50,37 +62,53 @@ namespace CtrDxEditor.ViewModels
                     }
 
                     int spinSpeed = ObjectSpin.SpinSpeed(value);
-                    if (enabled && spinSpeed == 0)
+                    if (enabled && spinSpeed <= 0)
                     {
                         spinSpeed = ObjectSpin.DefaultSpeed;
                     }
 
-                    ObjectSpin.SetSpin(value, enabled, spinSpeed, ObjectSpin.SpinClockwise(value));
-                    rebuild();
+                    ObjectSpin.SetSpin(
+                        value,
+                        enabled,
+                        spinSpeed,
+                        spinClockwise);
+
+                    Structural();
                 },
-                onChanged,
+                Structural,
                 onChanging)
             {
                 IsEnabled = canEnable,
             };
             fields.Add(spin);
 
-            if (ObjectSpin.IsSpinning(value))
+            if (spinning)
             {
                 fields.Add(new AttributeFieldViewModel(
                     "spinSpeed",
                     AttrType.Whole,
-                    () => ObjectSpin.SpinSpeed(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    () => SpinSpeedValue(value),
                     v =>
                     {
-                        int speed = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
-                            ? parsed
-                            : 0;
-                        ObjectSpin.SetSpin(value, enabled: true, speed, ObjectSpin.SpinClockwise(value));
+                        int speed = int.TryParse(
+                            v,
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out int parsed)
+                                ? parsed
+                                : 0;
+
                         if (speed <= 0)
                         {
-                            rebuild();
+                            value.SetAttr("rotateSpeed", v ?? string.Empty);
+                            return;
                         }
+
+                        ObjectSpin.SetSpin(
+                            value,
+                            enabled: true,
+                            speed,
+                            spinClockwise);
                     },
                     onChanged,
                     onChanging));
@@ -88,8 +116,20 @@ namespace CtrDxEditor.ViewModels
                 fields.Add(new AttributeFieldViewModel(
                     "spinClockwise",
                     AttrType.Bool,
-                    () => ObjectSpin.SpinClockwise(value) ? "true" : "false",
-                    v => ObjectSpin.SetSpin(value, enabled: true, ObjectSpin.SpinSpeed(value), clockwise: v == "true"),
+                    () => spinClockwise ? "true" : "false",
+                    v =>
+                    {
+                        spinClockwise = v == "true";
+                        int speed = ObjectSpin.SpinSpeed(value);
+                        if (speed > 0)
+                        {
+                            ObjectSpin.SetSpin(
+                                value,
+                                enabled: true,
+                                speed,
+                                clockwise: spinClockwise);
+                        }
+                    },
                     onChanged,
                     onChanging));
             }
@@ -97,38 +137,55 @@ namespace CtrDxEditor.ViewModels
             fields.Add(new AttributeFieldViewModel(
                 "spinOrbital",
                 AttrType.Bool,
-                () => ObjectSpin.IsOrbital(value) ? "true" : "false",
+                () => orbital ? "true" : "false",
                 v =>
                 {
-                    if (v == "true")
+                    bool enabled = v == "true";
+
+                    int orbitRadius = ObjectSpin.OrbitRadius(value);
+                    if (enabled && orbitRadius <= 0)
                     {
-                        ObjectSpin.SetOrbital(value, enabled: true, ObjectSpin.OrbitRadius(value), ObjectSpin.OrbitClockwise(value));
+                        orbitRadius = ObjectSpin.DefaultOrbitRadius;
                     }
-                    else
-                    {
-                        ObjectSpin.SetOrbital(value, enabled: false, ObjectSpin.OrbitRadius(value), ObjectSpin.OrbitClockwise(value));
-                    }
-                    rebuild();
+
+                    ObjectSpin.SetOrbital(
+                        value,
+                        enabled,
+                        orbitRadius,
+                        orbitClockwise);
+
+                    Structural();
                 },
-                onChanged,
+                Structural,
                 onChanging));
 
-            if (ObjectSpin.IsOrbital(value))
+            if (orbital)
             {
                 fields.Add(new AttributeFieldViewModel(
                     "orbitRadius",
                     AttrType.Whole,
-                    () => ObjectSpin.OrbitRadius(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    () => OrbitRadiusValue(value),
                     v =>
                     {
-                        int radius = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
-                            ? parsed
-                            : 0;
-                        ObjectSpin.SetOrbital(value, enabled: true, radius, ObjectSpin.OrbitClockwise(value));
+                        int radius = int.TryParse(
+                            v,
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out int parsed)
+                                ? parsed
+                                : 0;
+
                         if (radius <= 0)
                         {
-                            rebuild();
+                            value.SetAttr("path", OrbitPrefix(orbitClockwise) + (v ?? string.Empty));
+                            return;
                         }
+
+                        ObjectSpin.SetOrbital(
+                            value,
+                            enabled: true,
+                            radius,
+                            orbitClockwise);
                     },
                     onChanged,
                     onChanging));
@@ -136,11 +193,48 @@ namespace CtrDxEditor.ViewModels
                 fields.Add(new AttributeFieldViewModel(
                     "orbitClockwise",
                     AttrType.Bool,
-                    () => ObjectSpin.OrbitClockwise(value) ? "true" : "false",
-                    v => ObjectSpin.SetOrbital(value, enabled: true, ObjectSpin.OrbitRadius(value), clockwise: v == "true"),
+                    () => orbitClockwise ? "true" : "false",
+                    v =>
+                    {
+                        orbitClockwise = v == "true";
+                        string radiusValue = OrbitRadiusValue(value);
+                        if (int.TryParse(radiusValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0)
+                        {
+                            ObjectSpin.SetOrbital(
+                                value,
+                                enabled: true,
+                                radius,
+                                clockwise: orbitClockwise);
+                        }
+                        else
+                        {
+                            value.SetAttr("path", OrbitPrefix(orbitClockwise) + radiusValue);
+                        }
+                    },
                     onChanged,
                     onChanging));
             }
+        }
+
+        private static string SpinSpeedValue(LevelObject value)
+        {
+            string? raw = value.GetAttr("rotateSpeed");
+            return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double speed) && speed != 0
+                ? Math.Abs((int)speed).ToString(CultureInfo.InvariantCulture)
+                : raw ?? string.Empty;
+        }
+
+        private static string OrbitRadiusValue(LevelObject value)
+        {
+            string? path = value.GetAttr("path");
+            return path is { Length: >= 2 } && path[0] == 'R' && (path[1] == 'C' || path[1] == 'W')
+                ? path[2..]
+                : ObjectSpin.OrbitRadius(value).ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string OrbitPrefix(bool clockwise)
+        {
+            return clockwise ? "RC" : "RW";
         }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -49,13 +49,13 @@ namespace CtrDxEditor.ViewModels
                         beforeEnable?.Invoke();
                     }
 
-                    int speed = ObjectSpin.Speed(value);
-                    if (enabled && speed == 0)
+                    int spinSpeed = ObjectSpin.SpinSpeed(value);
+                    if (enabled && spinSpeed == 0)
                     {
-                        speed = ObjectSpin.DefaultSpeed;
+                        spinSpeed = ObjectSpin.DefaultSpeed;
                     }
 
-                    ObjectSpin.SetSpin(value, enabled, speed, ObjectSpin.Clockwise(value));
+                    ObjectSpin.SetSpin(value, enabled, spinSpeed, ObjectSpin.SpinClockwise(value));
                     rebuild();
                 },
                 onChanged,
@@ -65,36 +65,82 @@ namespace CtrDxEditor.ViewModels
             };
             fields.Add(spin);
 
-            if (!ObjectSpin.IsSpinning(value))
+            if (ObjectSpin.IsSpinning(value))
             {
-                return;
+                fields.Add(new AttributeFieldViewModel(
+                    "spinSpeed",
+                    AttrType.Whole,
+                    () => ObjectSpin.SpinSpeed(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    v =>
+                    {
+                        int speed = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
+                            ? parsed
+                            : 0;
+                        ObjectSpin.SetSpin(value, enabled: true, speed, ObjectSpin.SpinClockwise(value));
+                        if (speed <= 0)
+                        {
+                            rebuild();
+                        }
+                    },
+                    onChanged,
+                    onChanging));
+
+                fields.Add(new AttributeFieldViewModel(
+                    "spinClockwise",
+                    AttrType.Bool,
+                    () => ObjectSpin.SpinClockwise(value) ? "true" : "false",
+                    v => ObjectSpin.SetSpin(value, enabled: true, ObjectSpin.SpinSpeed(value), clockwise: v == "true"),
+                    onChanged,
+                    onChanging));
             }
 
             fields.Add(new AttributeFieldViewModel(
-                "spinSpeed",
-                AttrType.Whole,
-                () => ObjectSpin.Speed(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                "spinOrbital",
+                AttrType.Bool,
+                () => ObjectSpin.IsOrbital(value) ? "true" : "false",
                 v =>
                 {
-                    int speed = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
-                        ? parsed
-                        : 0;
-                    ObjectSpin.SetSpin(value, enabled: true, speed, ObjectSpin.Clockwise(value));
-                    if (speed <= 0)
+                    if (v == "true")
                     {
-                        rebuild();
+                        ObjectSpin.SetOrbital(value, enabled: true, ObjectSpin.OrbitRadius(value), ObjectSpin.OrbitClockwise(value));
                     }
+                    else
+                    {
+                        ObjectSpin.SetOrbital(value, enabled: false, ObjectSpin.OrbitRadius(value), ObjectSpin.OrbitClockwise(value));
+                    }
+                    rebuild();
                 },
                 onChanged,
                 onChanging));
 
-            fields.Add(new AttributeFieldViewModel(
-                "spinClockwise",
-                AttrType.Bool,
-                () => ObjectSpin.Clockwise(value) ? "true" : "false",
-                v => ObjectSpin.SetSpin(value, enabled: true, ObjectSpin.Speed(value), clockwise: v == "true"),
-                onChanged,
-                onChanging));
+            if (ObjectSpin.IsOrbital(value))
+            {
+                fields.Add(new AttributeFieldViewModel(
+                    "orbitRadius",
+                    AttrType.Whole,
+                    () => ObjectSpin.OrbitRadius(value).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    v =>
+                    {
+                        int radius = int.TryParse(v, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
+                            ? parsed
+                            : 0;
+                        ObjectSpin.SetOrbital(value, enabled: true, radius, ObjectSpin.OrbitClockwise(value));
+                        if (radius <= 0)
+                        {
+                            rebuild();
+                        }
+                    },
+                    onChanged,
+                    onChanging));
+
+                fields.Add(new AttributeFieldViewModel(
+                    "orbitClockwise",
+                    AttrType.Bool,
+                    () => ObjectSpin.OrbitClockwise(value) ? "true" : "false",
+                    v => ObjectSpin.SetOrbital(value, enabled: true, ObjectSpin.OrbitRadius(value), clockwise: v == "true"),
+                    onChanged,
+                    onChanging));
+            }
         }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CtrDxEditor.Core.Descriptors;
@@ -15,25 +16,39 @@ namespace CtrDxEditor.ViewModels
         /// <param name="onChanged">Callback invoked after a field writes to the document.</param>
         /// <param name="onChanging">Callback invoked before a field writes to the document.</param>
         /// <param name="rebuild">Callback that rebuilds fields after spin disclosure changes.</param>
+        /// <param name="canEnable">Whether the spin checkbox should be editable.</param>
+        /// <param name="beforeEnable">Optional normalization to run before spin is enabled.</param>
         public static void Build(
             IList<AttributeFieldViewModel> fields,
             LevelObject value,
-            System.Action onChanged,
-            System.Action onChanging,
-            System.Action rebuild)
+            Action onChanged,
+            Action onChanging,
+            Action rebuild,
+            bool canEnable = true,
+            Action? beforeEnable = null)
         {
             if (!SpinTable.IsSpinnable(value.Type))
             {
                 return;
             }
 
-            fields.Add(new AttributeFieldViewModel(
+            AttributeFieldViewModel spin = new(
                 "spin",
                 AttrType.Bool,
                 () => ObjectSpin.IsSpinning(value) ? "true" : "false",
                 v =>
                 {
                     bool enabled = v == "true";
+                    if (enabled && !canEnable)
+                    {
+                        return;
+                    }
+
+                    if (enabled)
+                    {
+                        beforeEnable?.Invoke();
+                    }
+
                     int speed = ObjectSpin.Speed(value);
                     if (enabled && speed == 0)
                     {
@@ -44,7 +59,11 @@ namespace CtrDxEditor.ViewModels
                     rebuild();
                 },
                 onChanged,
-                onChanging));
+                onChanging)
+            {
+                IsEnabled = canEnable,
+            };
+            fields.Add(spin);
 
             if (!ObjectSpin.IsSpinning(value))
             {

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -191,6 +191,31 @@ namespace CtrDxEditor.ViewModels
                     onChanging));
 
                 fields.Add(new AttributeFieldViewModel(
+                    "orbitSpeed",
+                    AttrType.Whole,
+                    () => OrbitSpeedValue(value),
+                    v =>
+                    {
+                        int speed = int.TryParse(
+                            v,
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out int parsed)
+                                ? parsed
+                                : 0;
+
+                        if (speed <= 0)
+                        {
+                            value.SetAttr("moveSpeed", v ?? string.Empty);
+                            return;
+                        }
+
+                        ObjectSpin.SetOrbitSpeed(value, speed);
+                    },
+                    onChanged,
+                    onChanging));
+
+                fields.Add(new AttributeFieldViewModel(
                     "orbitClockwise",
                     AttrType.Bool,
                     () => orbitClockwise ? "true" : "false",
@@ -198,6 +223,7 @@ namespace CtrDxEditor.ViewModels
                     {
                         orbitClockwise = v == "true";
                         string radiusValue = OrbitRadiusValue(value);
+                        string speedValue = OrbitSpeedValue(value);
                         if (int.TryParse(radiusValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0)
                         {
                             ObjectSpin.SetOrbital(
@@ -205,6 +231,14 @@ namespace CtrDxEditor.ViewModels
                                 enabled: true,
                                 radius,
                                 clockwise: orbitClockwise);
+                            if (int.TryParse(speedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int speed) && speed > 0)
+                            {
+                                ObjectSpin.SetOrbitSpeed(value, speed);
+                            }
+                            else
+                            {
+                                value.SetAttr("moveSpeed", speedValue);
+                            }
                         }
                         else
                         {
@@ -230,6 +264,14 @@ namespace CtrDxEditor.ViewModels
             return path is { Length: >= 2 } && path[0] == 'R' && (path[1] == 'C' || path[1] == 'W')
                 ? path[2..]
                 : ObjectSpin.OrbitRadius(value).ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string OrbitSpeedValue(LevelObject value)
+        {
+            string? raw = value.GetAttr("moveSpeed");
+            return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double speed) && speed != 0
+                ? Math.Abs((int)speed).ToString(CultureInfo.InvariantCulture)
+                : raw ?? string.Empty;
         }
 
         private static string OrbitPrefix(bool clockwise)

--- a/src/CtrDxEditor.Shared/ViewModels/StarFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/StarFieldBuilder.cs
@@ -38,6 +38,8 @@ namespace CtrDxEditor.ViewModels
             {
                 fields.Add(new AttributeFieldViewModel(star, "timeout", AttrType.Number, null, onChanged, onChanging));
             }
+
+            SpinFieldBuilder.Build(fields, star, onChanged, onChanging, rebuild);
         }
 
         private static double Timeout(LevelObject star)

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -264,8 +264,7 @@
         <ListBox Grid.Row="1" Margin="4,0,4,4" x:Name="ObjectsListBox"
                  Background="Transparent"
                  ItemsSource="{Binding ObjectList}"
-                 SelectedItem="{Binding SelectedObject, Mode=TwoWay}"
-                 DoubleTapped="ObjectList_DoubleTapped">
+                 SelectedItem="{Binding SelectedObject, Mode=TwoWay}">
           <ListBox.Styles>
             <!-- While a lock is active, every row except the locked one is disabled (dimmed, unselectable). -->
             <Style Selector="ListBoxItem">
@@ -284,15 +283,30 @@
               <Grid ColumnDefinitions="*,Auto,Auto">
                 <TextBlock Grid.Column="0" VerticalAlignment="Center"
                            Text="{Binding Type, Converter={x:Static loc:ObjectNameConverter.Instance}}" />
-                <icons:MaterialIcon Grid.Column="1" Kind="Lock" Width="14" Height="14"
-                                    Margin="6,0,0,0" Foreground="{DynamicResource EditorBrush.Warning}">
-                  <icons:MaterialIcon.IsVisible>
-                    <MultiBinding Converter="{x:Static conv:ObjectEqualsConverter.Instance}">
-                      <Binding Path="." />
-                      <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).LockedObject" />
-                    </MultiBinding>
-                  </icons:MaterialIcon.IsVisible>
-                </icons:MaterialIcon>
+                <Button Grid.Column="1" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
+                        Background="Transparent" BorderBrush="Transparent"
+                        Tag="{Binding .}" Click="ObjectLock_Click">
+                  <Grid>
+                    <icons:MaterialIcon Kind="LockOpenVariant" Width="14" Height="14"
+                                        Foreground="{DynamicResource EditorBrush.Text.Subtle}">
+                      <icons:MaterialIcon.IsVisible>
+                        <MultiBinding Converter="{x:Static conv:ObjectEqualsConverter.Instance}" ConverterParameter="Invert">
+                          <Binding Path="." />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).LockedObject" />
+                        </MultiBinding>
+                      </icons:MaterialIcon.IsVisible>
+                    </icons:MaterialIcon>
+                    <icons:MaterialIcon Kind="Lock" Width="14" Height="14"
+                                        Foreground="{DynamicResource EditorBrush.Warning}">
+                      <icons:MaterialIcon.IsVisible>
+                        <MultiBinding Converter="{x:Static conv:ObjectEqualsConverter.Instance}">
+                          <Binding Path="." />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).LockedObject" />
+                        </MultiBinding>
+                      </icons:MaterialIcon.IsVisible>
+                    </icons:MaterialIcon>
+                  </Grid>
+                </Button>
                 <Button Grid.Column="2" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
                         Background="Transparent" BorderBrush="Transparent"
                         Tag="{Binding .}" Click="ObjectAnimationPreview_Click"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -131,6 +131,25 @@
           </MenuItem.Header>
         </MenuItem>
         <Separator />
+        <MenuItem Click="AnimationPreviewToggle_Click" IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <Grid>
+              <icons:MaterialIcon Kind="PlayArrow">
+                <icons:MaterialIcon.IsVisible>
+                  <Binding Path="IsAnimationPreviewActive" Converter="{x:Static BoolConverters.Not}" />
+                </icons:MaterialIcon.IsVisible>
+              </icons:MaterialIcon>
+              <icons:MaterialIcon Kind="Stop" IsVisible="{Binding IsAnimationPreviewActive}" />
+            </Grid>
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <AccessText Grid.Column="0" Text="{Binding AnimationPreviewMenuText}" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="{x:Static views:ShortcutHint.AnimationPreview}" Opacity="0.6" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
+        <Separator />
         <!-- Transparent icon placeholder reserves the icon column so the check lines up with the
              zoom shortcuts above; the check sits at the header's right edge via the same MinWidth. -->
         <MenuItem Click="SnapToggle_Click" IsEnabled="{Binding HasDocument}">
@@ -216,6 +235,9 @@
                             ActiveBackground="{Binding ActiveBackground}"
                             ActiveCandySkin="{Binding ActiveCandySkin}"
                             ActiveOmNomSupport="{Binding ActiveOmNomSupport}"
+                            AnimationPreviewMode="{Binding AnimationPreviewMode}"
+                            AnimationPreviewObject="{Binding AnimationPreviewObject}"
+                            AnimationPreviewElapsedSeconds="{Binding AnimationPreviewElapsedSeconds}"
                             SelectedObject="{Binding SelectedObject, Mode=TwoWay}"
                             LockedObject="{Binding LockedObject, Mode=TwoWay}" />
         <ScrollBar Grid.Row="0" Grid.Column="1"
@@ -259,7 +281,7 @@
           </ListBox.Styles>
           <ListBox.ItemTemplate>
             <DataTemplate x:DataType="core:LevelObject">
-              <Grid ColumnDefinitions="*,Auto">
+              <Grid ColumnDefinitions="*,Auto,Auto">
                 <TextBlock Grid.Column="0" VerticalAlignment="Center"
                            Text="{Binding Type, Converter={x:Static loc:ObjectNameConverter.Instance}}" />
                 <icons:MaterialIcon Grid.Column="1" Kind="Lock" Width="14" Height="14"
@@ -271,6 +293,34 @@
                     </MultiBinding>
                   </icons:MaterialIcon.IsVisible>
                 </icons:MaterialIcon>
+                <Button Grid.Column="2" Width="24" Height="24" Padding="2" Margin="6,0,0,0"
+                        Background="Transparent" BorderBrush="Transparent"
+                        Tag="{Binding .}" Click="ObjectAnimationPreview_Click"
+                        ToolTip.Tip="{loc:Tr Tooltip.ObjectAnimationPreview}"
+                        IsVisible="{Binding ., Converter={x:Static conv:SpinPreviewConverters.Available}}">
+                  <Grid>
+                    <icons:MaterialIcon Kind="PlayArrow" Width="16" Height="16"
+                                        Foreground="{DynamicResource EditorBrush.SuccessText}">
+                      <icons:MaterialIcon.IsVisible>
+                        <MultiBinding Converter="{x:Static conv:SpinPreviewConverters.IsObjectPreviewing}" ConverterParameter="Invert">
+                          <Binding Path="." />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).AnimationPreviewMode" />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).AnimationPreviewObject" />
+                        </MultiBinding>
+                      </icons:MaterialIcon.IsVisible>
+                    </icons:MaterialIcon>
+                    <icons:MaterialIcon Kind="Stop" Width="16" Height="16"
+                                        Foreground="{DynamicResource EditorBrush.DangerText}">
+                      <icons:MaterialIcon.IsVisible>
+                        <MultiBinding Converter="{x:Static conv:SpinPreviewConverters.IsObjectPreviewing}">
+                          <Binding Path="." />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).AnimationPreviewMode" />
+                          <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).AnimationPreviewObject" />
+                        </MultiBinding>
+                      </icons:MaterialIcon.IsVisible>
+                    </icons:MaterialIcon>
+                  </Grid>
+                </Button>
               </Grid>
             </DataTemplate>
           </ListBox.ItemTemplate>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -200,6 +200,18 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
+        <MenuItem Click="ShowMovementPathsToggle_Click" IsEnabled="{Binding HasDocument}">
+          <MenuItem.Icon>
+            <Border Width="16" Height="16" Background="Transparent" />
+          </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <TextBlock Grid.Column="0" Text="{loc:Tr Menu.View.ShowMovementPaths}" VerticalAlignment="Center" />
+              <icons:MaterialIcon Grid.Column="1" Kind="CheckBold" Width="14" Height="14"
+                                  Margin="24,0,0,0" VerticalAlignment="Center" IsVisible="{Binding ShowMovementPaths}" />
+            </Grid>
+          </MenuItem.Header>
+        </MenuItem>
       </MenuItem>
     </Menu>
     <Grid ColumnDefinitions="160,1,*,1,280">
@@ -231,6 +243,7 @@
                             ShowHitboxes="{Binding ShowHitboxes}"
                             ShowMobileHitboxes="{Binding ShowMobileHitboxes}"
                             ShowForceFields="{Binding ShowForceFields}"
+                            ShowMovementPaths="{Binding ShowMovementPaths}"
                             ActiveRopeSkin="{Binding ActiveRopeSkin}"
                             ActiveBackground="{Binding ActiveBackground}"
                             ActiveCandySkin="{Binding ActiveCandySkin}"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -293,11 +293,16 @@
                     </MultiBinding>
                   </icons:MaterialIcon.IsVisible>
                 </icons:MaterialIcon>
-                <Button Grid.Column="2" Width="24" Height="24" Padding="2" Margin="6,0,0,0"
+                <Button Grid.Column="2" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
                         Background="Transparent" BorderBrush="Transparent"
                         Tag="{Binding .}" Click="ObjectAnimationPreview_Click"
-                        ToolTip.Tip="{loc:Tr Tooltip.ObjectAnimationPreview}"
-                        IsVisible="{Binding ., Converter={x:Static conv:SpinPreviewConverters.Available}}">
+                        ToolTip.Tip="{loc:Tr Tooltip.ObjectAnimationPreview}">
+                  <Button.IsVisible>
+                    <MultiBinding Converter="{x:Static conv:SpinPreviewConverters.AvailableForVersion}">
+                      <Binding Path="." />
+                      <Binding Path="$parent[ListBox].((vm:EditorViewModel)DataContext).ObjectListVersion" />
+                    </MultiBinding>
+                  </Button.IsVisible>
                   <Grid>
                     <icons:MaterialIcon Kind="PlayArrow" Width="16" Height="16"
                                         Foreground="{DynamicResource EditorBrush.SuccessText}">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -285,7 +285,8 @@
                            Text="{Binding Type, Converter={x:Static loc:ObjectNameConverter.Instance}}" />
                 <Button Grid.Column="1" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
                         Background="Transparent" BorderBrush="Transparent"
-                        Tag="{Binding .}" Click="ObjectLock_Click">
+                        Tag="{Binding .}" Click="ObjectLock_Click"
+                        ToolTip.Tip="{loc:Tr Tooltip.ObjectLock}">
                   <Grid>
                     <icons:MaterialIcon Kind="LockOpenVariant" Width="14" Height="14"
                                         Foreground="{DynamicResource EditorBrush.Text.Subtle}">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,6 +33,8 @@ namespace CtrDxEditor.Views
     {
         private EditorViewModel? _mutatedSubscription;
         private readonly Action _invalidateCanvas;
+        private readonly DispatcherTimer _animationPreviewTimer = new() { Interval = TimeSpan.FromMilliseconds(16) };
+        private DateTimeOffset _animationPreviewStartedAt;
         private IStorageFile? _currentLevelFile;
         private WindowNotificationManager? _notifications;
 
@@ -43,6 +46,7 @@ namespace CtrDxEditor.Views
             _invalidateCanvas = canvas.InvalidateVisual;
             DataContextChanged += (_, _) => WireObjectMutated();
             WireObjectMutated();
+            _animationPreviewTimer.Tick += AnimationPreviewTimer_Tick;
 
             canvas.PlaceAt = (element, x, y) =>
                 DataContext is EditorViewModel vm ? vm.PlaceObject(element, x, y) : null;
@@ -110,6 +114,13 @@ namespace CtrDxEditor.Views
                             e.Handled = true;
                         }
                         break;
+                    case Key.Space when !ctrl && !shift && e.KeyModifiers == KeyModifiers.None:
+                        if (!IsTextInputFocused(e.Source) && DataContext is EditorViewModel { HasDocument: true } previewVm)
+                        {
+                            previewVm.ToggleAnimationPreviewAll();
+                            e.Handled = true;
+                        }
+                        break;
                 }
 #pragma warning restore IDE0010
             };
@@ -169,6 +180,23 @@ namespace CtrDxEditor.Views
             if (DataContext is EditorViewModel vm)
             {
                 vm.ShowForceFields = !vm.ShowForceFields;
+            }
+        }
+
+        private void AnimationPreviewToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.ToggleAnimationPreviewAll();
+            }
+        }
+
+        private void ObjectAnimationPreview_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm && sender is Button { Tag: LevelObject obj })
+            {
+                vm.ToggleAnimationPreviewObject(obj);
+                e.Handled = true;
             }
         }
 
@@ -291,13 +319,58 @@ namespace CtrDxEditor.Views
 
             _mutatedSubscription?.ObjectMutated -= _invalidateCanvas;
             _mutatedSubscription?.LevelLoaded -= FocusCanvasAfterLevelLoaded;
+            _mutatedSubscription?.PropertyChanged -= ViewModel_PropertyChanged;
 
             _mutatedSubscription = DataContext as EditorViewModel;
             if (_mutatedSubscription is not null)
             {
                 _mutatedSubscription.ObjectMutated += _invalidateCanvas;
                 _mutatedSubscription.LevelLoaded += FocusCanvasAfterLevelLoaded;
+                _mutatedSubscription.PropertyChanged += ViewModel_PropertyChanged;
             }
+
+            SyncAnimationPreviewTimer();
+        }
+
+        private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is nameof(EditorViewModel.AnimationPreviewMode) or nameof(EditorViewModel.AnimationPreviewObject))
+            {
+                SyncAnimationPreviewTimer();
+            }
+        }
+
+        private void SyncAnimationPreviewTimer()
+        {
+            if (DataContext is not EditorViewModel vm || !vm.IsAnimationPreviewActive)
+            {
+                _animationPreviewTimer.Stop();
+                this.FindControl<LevelCanvas>("Canvas")!.InvalidateVisual();
+                return;
+            }
+
+            _animationPreviewStartedAt = DateTimeOffset.UtcNow - TimeSpan.FromSeconds(vm.AnimationPreviewElapsedSeconds);
+            if (!_animationPreviewTimer.IsEnabled)
+            {
+                _animationPreviewTimer.Start();
+            }
+        }
+
+        private void AnimationPreviewTimer_Tick(object? sender, EventArgs e)
+        {
+            if (DataContext is not EditorViewModel { IsAnimationPreviewActive: true } vm)
+            {
+                _animationPreviewTimer.Stop();
+                return;
+            }
+
+            vm.AnimationPreviewElapsedSeconds = (DateTimeOffset.UtcNow - _animationPreviewStartedAt).TotalSeconds;
+            this.FindControl<LevelCanvas>("Canvas")!.InvalidateVisual();
+        }
+
+        private static bool IsTextInputFocused(object? source)
+        {
+            return (source as Visual)?.FindAncestorOfType<TextBox>(includeSelf: true) is not null;
         }
 
         private void FocusCanvasAfterLevelLoaded()
@@ -603,6 +676,20 @@ namespace CtrDxEditor.Views
             // the first save. A manager constructed at the first Show() call drops that first notification
             // (it is not yet in the visual tree), which is why the initial "Saving…" toast went missing.
             _ = Notifications();
+        }
+
+        /// <inheritdoc />
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            _animationPreviewTimer.Stop();
+            if (_mutatedSubscription is not null)
+            {
+                _mutatedSubscription.ObjectMutated -= _invalidateCanvas;
+                _mutatedSubscription.LevelLoaded -= FocusCanvasAfterLevelLoaded;
+                _mutatedSubscription.PropertyChanged -= ViewModel_PropertyChanged;
+                _mutatedSubscription = null;
+            }
+            base.OnDetachedFromVisualTree(e);
         }
 
         // The toast host, created against the current TopLevel and reused. Null only before the view is

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -200,11 +200,12 @@ namespace CtrDxEditor.Views
             }
         }
 
-        private void ObjectList_DoubleTapped(object? sender, TappedEventArgs e)
+        private void ObjectLock_Click(object? sender, RoutedEventArgs e)
         {
-            if (DataContext is EditorViewModel vm)
+            if (DataContext is EditorViewModel vm && sender is Button { Tag: LevelObject obj })
             {
-                vm.ToggleLock(vm.SelectedObject);
+                vm.ToggleLock(obj);
+                e.Handled = true;
             }
         }
 

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -183,6 +183,14 @@ namespace CtrDxEditor.Views
             }
         }
 
+        private void ShowMovementPathsToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is EditorViewModel vm)
+            {
+                vm.ShowMovementPaths = !vm.ShowMovementPaths;
+            }
+        }
+
         private void AnimationPreviewToggle_Click(object? sender, RoutedEventArgs e)
         {
             if (DataContext is EditorViewModel vm)

--- a/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
+++ b/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
@@ -27,5 +27,8 @@ namespace CtrDxEditor.Views
 
         /// <summary>Localized platform shortcut text for deleting the selected object.</summary>
         public static string Delete { get; } = "Delete";
+
+        /// <summary>Localized platform shortcut text for toggling live animation preview.</summary>
+        public static string AnimationPreview { get; } = "Space";
     }
 }

--- a/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
+++ b/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading.Tasks;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests the shared live-animation preview state exposed by the editor view model.</summary>
+    public class EditorAnimationPreviewTests
+    {
+        private sealed class EmptyStore : IContentStore
+        {
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                return Task.FromResult(Array.Empty<byte>());
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult("");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        private static EditorViewModel Loaded()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(
+                "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer>"
+                + "<layer name=\"Objects\"><star x=\"20\" y=\"30\" rotateSpeed=\"70\" /><spike1 x=\"50\" y=\"60\" rotateSpeed=\"-40\" /></layer></map>");
+            return vm;
+        }
+
+        /// <summary>Global playback toggles between all-object playback and the stopped authored view.</summary>
+        [Fact]
+        public void ToggleAllPreviewPlaysAndStopsAllObjects()
+        {
+            EditorViewModel vm = Loaded();
+            LevelObject star = vm.ObjectList[0];
+            LevelObject spike = vm.ObjectList[1];
+
+            vm.ToggleAnimationPreviewAll();
+
+            Assert.Equal(AnimationPreviewMode.All, vm.AnimationPreviewMode);
+            Assert.True(vm.IsAnimationPreviewing(star));
+            Assert.True(vm.IsAnimationPreviewing(spike));
+
+            vm.ToggleAnimationPreviewAll();
+
+            Assert.Equal(AnimationPreviewMode.Off, vm.AnimationPreviewMode);
+            Assert.False(vm.IsAnimationPreviewing(star));
+            Assert.False(vm.IsAnimationPreviewing(spike));
+        }
+
+        /// <summary>Per-object playback switches focus and a second click on the same object stops preview.</summary>
+        [Fact]
+        public void ToggleObjectPreviewSwitchesObjectAndStopsSameObject()
+        {
+            EditorViewModel vm = Loaded();
+            LevelObject star = vm.ObjectList[0];
+            LevelObject spike = vm.ObjectList[1];
+
+            vm.ToggleAnimationPreviewObject(star);
+
+            Assert.Equal(AnimationPreviewMode.Focused, vm.AnimationPreviewMode);
+            Assert.Same(star, vm.AnimationPreviewObject);
+            Assert.True(vm.IsAnimationPreviewing(star));
+            Assert.False(vm.IsAnimationPreviewing(spike));
+
+            vm.ToggleAnimationPreviewObject(spike);
+
+            Assert.Equal(AnimationPreviewMode.Focused, vm.AnimationPreviewMode);
+            Assert.Same(spike, vm.AnimationPreviewObject);
+            Assert.False(vm.IsAnimationPreviewing(star));
+            Assert.True(vm.IsAnimationPreviewing(spike));
+
+            vm.ToggleAnimationPreviewObject(spike);
+
+            Assert.Equal(AnimationPreviewMode.Off, vm.AnimationPreviewMode);
+            Assert.Null(vm.AnimationPreviewObject);
+        }
+
+        /// <summary>Document replacement clears playback state because object identities no longer apply.</summary>
+        [Fact]
+        public void LoadingOrClosingLevelStopsAnimationPreview()
+        {
+            EditorViewModel vm = Loaded();
+            vm.ToggleAnimationPreviewObject(vm.ObjectList[0]);
+            vm.AnimationPreviewElapsedSeconds = 1.25;
+
+            vm.LoadLevelXml("<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer></map>");
+
+            Assert.Equal(AnimationPreviewMode.Off, vm.AnimationPreviewMode);
+            Assert.Null(vm.AnimationPreviewObject);
+            Assert.Equal(0.0, vm.AnimationPreviewElapsedSeconds);
+
+            vm.ToggleAnimationPreviewAll();
+            vm.CloseLevel();
+
+            Assert.Equal(AnimationPreviewMode.Off, vm.AnimationPreviewMode);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
+++ b/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 
 using CtrDxEditor.Content;
+using CtrDxEditor.Converters;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.ViewModels;
 
@@ -111,6 +114,25 @@ namespace CtrDxEditor.Tests
             vm.CloseLevel();
 
             Assert.Equal(AnimationPreviewMode.Off, vm.AnimationPreviewMode);
+        }
+
+        /// <summary>Orbit-only objects expose the same row preview affordance as rotateSpeed objects.</summary>
+        [Fact]
+        public void OrbitOnlyObjectHasAnimationPreviewAvailable()
+        {
+            LevelObject star = new(new XElement("star",
+                new XAttribute("x", "20"),
+                new XAttribute("y", "30"),
+                new XAttribute("path", "RC30"),
+                new XAttribute("moveSpeed", "70")));
+
+            object? available = SpinPreviewConverters.Available.Convert(
+                star,
+                typeof(bool),
+                parameter: null,
+                CultureInfo.InvariantCulture);
+
+            Assert.True(available is true);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -5,6 +6,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 
 using Avalonia;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 
 using CtrDxEditor.Content;
@@ -23,7 +25,7 @@ namespace CtrDxEditor.Tests
     {
         // The scene-drawing helpers live on the internal LevelSceneRenderer; reflect into it by name
         // since the test assembly can't reference the internal type directly.
-        private static readonly System.Type SceneRenderer =
+        private static readonly Type SceneRenderer =
             typeof(LevelCanvas).Assembly.GetType("CtrDxEditor.Rendering.LevelSceneRenderer")!;
 
         private sealed class FakeStore : IContentStore
@@ -221,6 +223,114 @@ namespace CtrDxEditor.Tests
             Assert.Equal(cw[0].Y, ccw[0].Y, 3);
             Assert.True(cw[1].Y < cw[0].Y);
             Assert.True(ccw[1].Y > ccw[0].Y);
+        }
+
+        /// <summary>Live orbit preview moves hitbox bounds with the object position, matching DX mover updates.</summary>
+        [Fact]
+        public void OrbitPreviewHitboxFollowsPreviewPosition()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "PreviewHitboxBounds",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject star = new(new XElement(
+                "star",
+                new XAttribute("x", "100"),
+                new XAttribute("y", "100"),
+                new XAttribute("path", "RC8"),
+                new XAttribute("moveSpeed", "8")));
+
+            LevelBounds authored = (LevelBounds)method.Invoke(null, [star, 1.0, HitboxModel.Desktop, null])!;
+            LevelBounds preview = (LevelBounds)method.Invoke(null, [star, 1.0, HitboxModel.Desktop, 0.0])!;
+
+            Assert.Equal(authored.X + 8.0, preview.X, 6);
+            Assert.Equal(authored.Y, preview.Y, 6);
+            Assert.Equal(authored.W, preview.W, 6);
+            Assert.Equal(authored.H, preview.H, 6);
+        }
+
+        /// <summary>The orbit path overlay is a circle centered on the authored object position.</summary>
+        [Fact]
+        public void OrbitPathPointsCircleAuthoredCenter()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "ComputeOrbitPathPoints",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject star = new(new XElement(
+                "star",
+                new XAttribute("x", "100"),
+                new XAttribute("y", "200"),
+                new XAttribute("path", "RC30"),
+                new XAttribute("moveSpeed", "70")));
+
+            Point[] points = (Point[])method.Invoke(null, [ViewTransform.Identity, star])!;
+
+            Assert.True(points.Length > 12);
+            Assert.Equal(130.0, points[0].X, 6);
+            Assert.Equal(200.0, points[0].Y, 6);
+            Assert.All(points, p =>
+            {
+                double dx = p.X - 100.0;
+                double dy = p.Y - 200.0;
+                Assert.Equal(30.0, Math.Sqrt((dx * dx) + (dy * dy)), 6);
+            });
+        }
+
+        /// <summary>The orbit direction arrow sits on the circle tangent and follows RC/RW direction.</summary>
+        [Fact]
+        public void OrbitArrowDirectionFollowsPathPrefix()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "ComputeOrbitArrowPoints",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject clockwise = new(new XElement(
+                "star",
+                new XAttribute("x", "100"),
+                new XAttribute("y", "200"),
+                new XAttribute("path", "RC30"),
+                new XAttribute("moveSpeed", "70")));
+            LevelObject counterClockwise = new(new XElement(
+                "star",
+                new XAttribute("x", "100"),
+                new XAttribute("y", "200"),
+                new XAttribute("path", "RW30"),
+                new XAttribute("moveSpeed", "70")));
+
+            Point[] cw = (Point[])method.Invoke(null, [ViewTransform.Identity, clockwise])!;
+            Point[] ccw = (Point[])method.Invoke(null, [ViewTransform.Identity, counterClockwise])!;
+
+            Assert.Equal(4, cw.Length);
+            Assert.Equal(4, ccw.Length);
+            Assert.True(cw[1].X > cw[0].X);
+            Assert.Equal(cw[0].Y, cw[1].Y, 6);
+            Assert.True(ccw[1].X < ccw[0].X);
+            Assert.Equal(ccw[0].Y, ccw[1].Y, 6);
+        }
+
+        /// <summary>The orbit path overlay uses dots, not the longer shared overlay dash pattern.</summary>
+        [Fact]
+        public void OrbitPathPenUsesDottedPattern()
+        {
+            Type paletteType = typeof(LevelCanvas).Assembly.GetType("CtrDxEditor.Rendering.CanvasPalette")!;
+            object palette = Activator.CreateInstance(paletteType, nonPublic: true)!;
+            Pen pen = (Pen)paletteType.GetProperty("OrbitPath")!.GetValue(palette)!;
+
+            Assert.NotNull(pen.DashStyle);
+            Assert.Equal([1.0, 3.0], pen.DashStyle!.Dashes);
+        }
+
+        /// <summary>The orbit direction arrow is solid so its small head remains legible over the dotted path.</summary>
+        [Fact]
+        public void OrbitPathArrowPenIsSolid()
+        {
+            Type paletteType = typeof(LevelCanvas).Assembly.GetType("CtrDxEditor.Rendering.CanvasPalette")!;
+            object palette = Activator.CreateInstance(paletteType, nonPublic: true)!;
+            Pen pen = (Pen)paletteType.GetProperty("OrbitPathArrow")!.GetValue(palette)!;
+
+            Assert.Null(pen.DashStyle);
+            Assert.True(pen.Thickness > 1.5);
         }
 
         private static SpriteCache SeedStarAtlases()

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -203,6 +203,26 @@ namespace CtrDxEditor.Tests
             Assert.Equal(318.167, points[1].Y, 3);
         }
 
+        /// <summary>Spin arrows use the rotateSpeed sign: positive sweeps clockwise, negative counter-clockwise.</summary>
+        [Fact]
+        public void SpinArrowDirectionFollowsRotateSpeedSign()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "ComputeSpinArrowPoints",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject clockwise = new(new XElement("star", new XAttribute("x", "100"), new XAttribute("y", "200"), new XAttribute("rotateSpeed", "70")));
+            LevelObject counterClockwise = new(new XElement("star", new XAttribute("x", "100"), new XAttribute("y", "200"), new XAttribute("rotateSpeed", "-70")));
+
+            Point[] cw = (Point[])method.Invoke(null, [ViewTransform.Identity, clockwise, 20.0])!;
+            Point[] ccw = (Point[])method.Invoke(null, [ViewTransform.Identity, counterClockwise, 20.0])!;
+
+            Assert.Equal(cw[0].X, ccw[0].X, 3);
+            Assert.Equal(cw[0].Y, ccw[0].Y, 3);
+            Assert.True(cw[1].Y < cw[0].Y);
+            Assert.True(ccw[1].Y > ccw[0].Y);
+        }
+
         private static SpriteCache SeedStarAtlases()
         {
             SpriteCache cache = new(new FakeStore());

--- a/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
@@ -19,6 +19,19 @@ namespace CtrDxEditor.Tests
             Assert.Contains("CompleteDocumentEdit?.Invoke();", source, StringComparison.Ordinal);
         }
 
+        /// <summary>Movement path visibility is exposed through the View menu and bound into the canvas.</summary>
+        [Fact]
+        public void ViewMenuWiresMovementPathToggleToCanvas()
+        {
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+            string codeBehind = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml.cs"));
+
+            Assert.Contains("ShowMovementPathsToggle_Click", view, StringComparison.Ordinal);
+            Assert.Contains("Menu.View.ShowMovementPaths", view, StringComparison.Ordinal);
+            Assert.Contains("ShowMovementPaths=\"{Binding ShowMovementPaths}\"", view, StringComparison.Ordinal);
+            Assert.Contains("vm.ShowMovementPaths = !vm.ShowMovementPaths;", codeBehind, StringComparison.Ordinal);
+        }
+
         private static string SourcePath(params string[] parts)
         {
             string path = AppContext.BaseDirectory;

--- a/src/CtrDxEditor.Tests/SpikeFieldTests.cs
+++ b/src/CtrDxEditor.Tests/SpikeFieldTests.cs
@@ -130,5 +130,60 @@ namespace CtrDxEditor.Tests
             Assert.Null(spike.GetAttr("rotateSpeed"));
             Assert.Equal("0,0", spike.GetAttr("path"));
         }
+
+        /// <summary>Toggled spikes expose spin as unavailable so button rotation and continuous spin do not combine.</summary>
+        [Fact]
+        public void ToggledSpikeDisablesSpinField()
+        {
+            const string toggledLevel = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <map>
+                <layer name="settings">
+                    <map gridSize="32" width="640" height="480" />
+                </layer>
+                <layer name="Objects">
+                    <spike2 x="344" y="257" angle="0" size="2" toggled="1" />
+                </layer>
+            </map>
+            """;
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(toggledLevel);
+            vm.SelectedObject = vm.Document!.Objects[0];
+
+            AttributeFieldViewModel spin = vm.Fields.Single(f => f.Name == "spin");
+
+            Assert.False(spin.BoolValue);
+            Assert.False(spin.IsEnabled);
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "spinSpeed");
+        }
+
+        /// <summary>Enabling spin on a spike clears toggled state and preserves the existing path attribute.</summary>
+        [Fact]
+        public void EnablingSpikeSpinClearsToggledState()
+        {
+            const string level = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <map>
+                <layer name="settings">
+                    <map gridSize="32" width="640" height="480" />
+                </layer>
+                <layer name="Objects">
+                    <spike2 x="344" y="257" angle="0" size="2" path="0,0" toggled="1" />
+                </layer>
+            </map>
+            """;
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(level);
+            LevelObject spike = vm.Document!.Objects[0];
+            vm.SelectedObject = spike;
+
+            vm.Fields.Single(f => f.Name == "toggled").BoolValue = false;
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+
+            Assert.Equal("false", spike.GetAttr("toggled"));
+            Assert.Equal("70", spike.GetAttr("rotateSpeed"));
+            Assert.Equal("0,0", spike.GetAttr("path"));
+            Assert.False(vm.Fields.Single(f => f.Name == "toggled").IsEnabled);
+        }
     }
 }

--- a/src/CtrDxEditor.Tests/SpikeFieldTests.cs
+++ b/src/CtrDxEditor.Tests/SpikeFieldTests.cs
@@ -92,5 +92,43 @@ namespace CtrDxEditor.Tests
             Assert.Equal("spike4", spike.Type);
             Assert.Equal("4", spike.GetAttr("size"));
         }
+
+        /// <summary>Spike spin fields expose rotateSpeed as enabled, positive speed, and sign-backed direction.</summary>
+        [Fact]
+        public void SpikeSpinFieldsMapRotateSpeedSign()
+        {
+            const string spinningLevel = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <map>
+                <layer name="settings">
+                    <map gridSize="32" width="640" height="480" />
+                </layer>
+                <layer name="Objects">
+                    <spike2 x="344" y="257" angle="0" size="2" path="0,0" rotateSpeed="-130" />
+                </layer>
+            </map>
+            """;
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(spinningLevel);
+            LevelObject spike = vm.Document!.Objects[0];
+            vm.SelectedObject = spike;
+
+            Assert.True(vm.Fields.Single(f => f.Name == "spin").BoolValue);
+            AttributeFieldViewModel speed = vm.Fields.Single(f => f.Name == "spinSpeed");
+            Assert.True(speed.IsNumeric);
+            Assert.False(speed.AllowsDecimal);
+            Assert.Equal(1, speed.NumericMinimum);
+            Assert.Equal("130", speed.Value);
+            Assert.False(vm.Fields.Single(f => f.Name == "spinClockwise").BoolValue);
+
+            vm.Fields.Single(f => f.Name == "spinClockwise").BoolValue = true;
+
+            Assert.Equal("130", spike.GetAttr("rotateSpeed"));
+
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = false;
+
+            Assert.Null(spike.GetAttr("rotateSpeed"));
+            Assert.Equal("0,0", spike.GetAttr("path"));
+        }
     }
 }

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests for star-specific property panel fields.</summary>
+    public class StarFieldTests
+    {
+        private sealed class EmptyStore : IContentStore
+        {
+            public Task<bool> ExistsAsync(string relPath)
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<byte[]> ReadBytesAsync(string relPath)
+            {
+                return Task.FromResult(Array.Empty<byte>());
+            }
+
+            public Task<string> ReadTextAsync(string relPath)
+            {
+                return Task.FromResult("");
+            }
+
+            public Task<bool> IsPopulatedAsync()
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        private const string Level = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <map>
+            <layer name="settings">
+                <map gridSize="32" width="640" height="480" />
+            </layer>
+            <layer name="Objects">
+                <star x="100" y="100" timeout="-1" />
+            </layer>
+        </map>
+        """;
+
+        /// <summary>Checking spin on a star writes a default positive whole rotateSpeed and reveals controls.</summary>
+        [Fact]
+        public void CheckingStarSpinWritesDefaultRotateSpeed()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+
+            Assert.Equal("70", star.GetAttr("rotateSpeed"));
+            Assert.Equal("70", vm.Fields.Single(f => f.Name == "spinSpeed").Value);
+            Assert.True(vm.Fields.Single(f => f.Name == "spinClockwise").BoolValue);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -95,6 +95,57 @@ namespace CtrDxEditor.Tests
             Assert.Equal("70", star.GetAttr("moveSpeed"));
         }
 
+        /// <summary>Clearing orbit radius behaves like timed-star duration: it stays visible while editing.</summary>
+        [Fact]
+        public void ClearingStarOrbitRadiusKeepsOrbitFieldsVisibleLikeTimedDuration()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            AttributeFieldViewModel radius = vm.Fields.Single(f => f.Name == "orbitRadius");
+
+            radius.Value = string.Empty;
+
+            Assert.Equal(string.Empty, radius.Value);
+            Assert.Equal("RC", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Contains(vm.Fields, f => f.Name == "orbitRadius");
+
+            radius.Value = "45";
+
+            Assert.Equal("RC45", star.GetAttr("path"));
+            Assert.Equal("45", radius.Value);
+            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+        }
+
+        /// <summary>Clearing spin speed behaves like timed-star duration: it stays visible while editing.</summary>
+        [Fact]
+        public void ClearingStarSpinSpeedKeepsSpinFieldsVisibleLikeTimedDuration()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+            AttributeFieldViewModel speed = vm.Fields.Single(f => f.Name == "spinSpeed");
+
+            speed.Value = string.Empty;
+
+            Assert.Equal(string.Empty, speed.Value);
+            Assert.Equal(string.Empty, star.GetAttr("rotateSpeed"));
+            Assert.True(vm.Fields.Single(f => f.Name == "spin").BoolValue);
+            Assert.Contains(vm.Fields, f => f.Name == "spinSpeed");
+
+            speed.Value = "130";
+
+            Assert.Equal("130", star.GetAttr("rotateSpeed"));
+            Assert.Equal("130", speed.Value);
+            Assert.True(vm.Fields.Single(f => f.Name == "spin").BoolValue);
+        }
+
         /// <summary>Spin and orbit can coexist, matching DX's separate rotateSpeed and moveSpeed handling.</summary>
         [Fact]
         public void CheckingStarSpinAndOrbitKeepsBothMoverAttributes()

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -64,6 +64,56 @@ namespace CtrDxEditor.Tests
             Assert.True(vm.Fields.Single(f => f.Name == "spinClockwise").BoolValue);
         }
 
+        /// <summary>Orbit can be enabled without rotateSpeed and exposes radius/direction separately.</summary>
+        [Fact]
+        public void CheckingStarOrbitWithoutSpinWritesCircularPathRadius()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+
+            Assert.False(vm.Fields.Single(f => f.Name == "spin").BoolValue);
+            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+
+            Assert.Null(star.GetAttr("rotateSpeed"));
+            Assert.Equal("RC30", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.False(vm.Fields.Single(f => f.Name == "spin").BoolValue);
+            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "spinSpeed");
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "spinClockwise");
+            AttributeFieldViewModel radius = vm.Fields.Single(f => f.Name == "orbitRadius");
+            Assert.Equal("30", radius.Value);
+            Assert.Equal(1, radius.NumericMinimum);
+            Assert.True(vm.Fields.Single(f => f.Name == "orbitClockwise").BoolValue);
+
+            radius.Value = "45";
+            vm.Fields.Single(f => f.Name == "orbitClockwise").BoolValue = false;
+
+            Assert.Equal("RW45", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+        }
+
+        /// <summary>Spin and orbit can coexist, matching DX's separate rotateSpeed and moveSpeed handling.</summary>
+        [Fact]
+        public void CheckingStarSpinAndOrbitKeepsBothMoverAttributes()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+
+            Assert.Equal("70", star.GetAttr("rotateSpeed"));
+            Assert.Equal("RC30", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.Equal("70", vm.Fields.Single(f => f.Name == "spinSpeed").Value);
+            Assert.Equal("30", vm.Fields.Single(f => f.Name == "orbitRadius").Value);
+        }
+
         /// <summary>Changing spin refreshes object-list bindings without clearing the selected object.</summary>
         [Fact]
         public void CheckingStarSpinRefreshesObjectListBindingsWithoutClearingSelection()

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -86,13 +86,17 @@ namespace CtrDxEditor.Tests
             AttributeFieldViewModel radius = vm.Fields.Single(f => f.Name == "orbitRadius");
             Assert.Equal("30", radius.Value);
             Assert.Equal(1, radius.NumericMinimum);
+            AttributeFieldViewModel speed = vm.Fields.Single(f => f.Name == "orbitSpeed");
+            Assert.Equal("70", speed.Value);
+            Assert.Equal(1, speed.NumericMinimum);
             Assert.True(vm.Fields.Single(f => f.Name == "orbitClockwise").BoolValue);
 
             radius.Value = "45";
+            speed.Value = "120";
             vm.Fields.Single(f => f.Name == "orbitClockwise").BoolValue = false;
 
             Assert.Equal("RW45", star.GetAttr("path"));
-            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.Equal("120", star.GetAttr("moveSpeed"));
         }
 
         /// <summary>Clearing orbit radius behaves like timed-star duration: it stays visible while editing.</summary>
@@ -113,11 +117,38 @@ namespace CtrDxEditor.Tests
             Assert.Equal("70", star.GetAttr("moveSpeed"));
             Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
             Assert.Contains(vm.Fields, f => f.Name == "orbitRadius");
+            Assert.Contains(vm.Fields, f => f.Name == "orbitSpeed");
 
             radius.Value = "45";
 
             Assert.Equal("RC45", star.GetAttr("path"));
             Assert.Equal("45", radius.Value);
+            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+        }
+
+        /// <summary>Clearing orbit speed behaves like timed-star duration and keeps orbit fields visible.</summary>
+        [Fact]
+        public void ClearingStarOrbitSpeedKeepsOrbitFieldsVisibleLikeTimedDuration()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            AttributeFieldViewModel speed = vm.Fields.Single(f => f.Name == "orbitSpeed");
+
+            speed.Value = string.Empty;
+
+            Assert.Equal(string.Empty, speed.Value);
+            Assert.Equal(string.Empty, star.GetAttr("moveSpeed"));
+            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Contains(vm.Fields, f => f.Name == "orbitRadius");
+            Assert.Contains(vm.Fields, f => f.Name == "orbitSpeed");
+
+            speed.Value = "130";
+
+            Assert.Equal("130", star.GetAttr("moveSpeed"));
+            Assert.Equal("130", speed.Value);
             Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
         }
 
@@ -163,6 +194,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal("70", star.GetAttr("moveSpeed"));
             Assert.Equal("70", vm.Fields.Single(f => f.Name == "spinSpeed").Value);
             Assert.Equal("30", vm.Fields.Single(f => f.Name == "orbitRadius").Value);
+            Assert.Equal("70", vm.Fields.Single(f => f.Name == "orbitSpeed").Value);
         }
 
         /// <summary>Changing spin refreshes object-list bindings without clearing the selected object.</summary>

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -63,5 +63,22 @@ namespace CtrDxEditor.Tests
             Assert.Equal("70", vm.Fields.Single(f => f.Name == "spinSpeed").Value);
             Assert.True(vm.Fields.Single(f => f.Name == "spinClockwise").BoolValue);
         }
+
+        /// <summary>Changing spin refreshes object-list bindings without clearing the selected object.</summary>
+        [Fact]
+        public void CheckingStarSpinRefreshesObjectListBindingsWithoutClearingSelection()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+            int version = vm.ObjectListVersion;
+
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+
+            Assert.True(vm.ObjectListVersion > version);
+            Assert.Same(star, vm.SelectedObject);
+            Assert.Contains(star, vm.ObjectList);
+        }
     }
 }


### PR DESCRIPTION
## Description

- Add support for `moveSpeed`, `rotateSpeed` and `path` with RC/RW types for circular movements and speed.
- Add animation playback support for live movement preview.
- Organize the lock layer and play/stop buttons.