### PR TITLE
refactor: Simplify candy object ID binding

### DIFF
--- a/src/CtrDxEditor.Core.Tests/SplitCandyAndBulbDescriptorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/SplitCandyAndBulbDescriptorTests.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 using CtrDxEditor.Core.Descriptors;
 
 using Xunit;
@@ -26,20 +24,27 @@ namespace CtrDxEditor.Core.Tests
             Assert.Empty(right.Attributes);
         }
 
-        /// <summary>Light bulbs expose litRadius and an editable bulbNumber with no load-time default.</summary>
+        /// <summary>Light bulbs expose litRadius only; bulb ids are assigned internally.</summary>
         [Fact]
-        public void LightBulbHasLitRadiusAndBulbNumber()
+        public void LightBulbHasOnlyLitRadius()
         {
             ObjectDescriptor? bulb = DescriptorTable.Default.For("lightBulb");
             Assert.NotNull(bulb);
 
-            AttributeSpec litRadius = bulb.Attributes.Single(a => a.Name == "litRadius");
+            AttributeSpec litRadius = Assert.Single(bulb.Attributes);
+            Assert.Equal("litRadius", litRadius.Name);
             Assert.Equal(AttrType.Whole, litRadius.Type);
             Assert.Equal("50", litRadius.Default);
+        }
 
-            AttributeSpec bulbNumber = bulb.Attributes.Single(a => a.Name == "bulbNumber");
-            Assert.Equal(AttrType.Text, bulbNumber.Type);
-            Assert.Null(bulbNumber.Default);
+        /// <summary>Plain candy ids are assigned internally and are not editable descriptor fields.</summary>
+        [Fact]
+        public void PlainCandyHasNoEditableAttributes()
+        {
+            ObjectDescriptor? candy = DescriptorTable.Default.For("candy");
+            Assert.NotNull(candy);
+
+            Assert.Empty(candy.Attributes);
         }
     }
 }

--- a/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
+++ b/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
@@ -29,10 +29,7 @@ namespace CtrDxEditor.Core.Descriptors
             new ObjectDescriptor("target", "Om Nom", [], MaxCount: int.MaxValue),
 
             // Candy
-            new ObjectDescriptor("candy", "Candy",
-            [
-                new AttributeSpec("candyNumber", AttrType.Text, null),
-            ], MaxCount: int.MaxValue),
+            new ObjectDescriptor("candy", "Candy", [], MaxCount: int.MaxValue),
             new ObjectDescriptor("candyL", "Candy (Left)", [], MaxCount: 1),
             new ObjectDescriptor("candyR", "Candy (Right)", [], MaxCount: 1),
 
@@ -101,7 +98,6 @@ namespace CtrDxEditor.Core.Descriptors
                 new AttributeSpec("offTime", AttrType.Number, "2.0"),
                 new AttributeSpec("onTime", AttrType.Number, "2.0"),
                 new AttributeSpec("angle", AttrType.Number, "0"),
-                new AttributeSpec("size", AttrType.Whole, "5"),
             ], MaxCount: int.MaxValue),
 
             // Gravity button
@@ -111,7 +107,6 @@ namespace CtrDxEditor.Core.Descriptors
             new ObjectDescriptor("lightBulb", "Light Bulb",
             [
                 new AttributeSpec("litRadius", AttrType.Whole, "50"),
-                new AttributeSpec("bulbNumber", AttrType.Text, null),
             ], MaxCount: int.MaxValue),
         ]);
     }

--- a/src/CtrDxEditor.Core/Editing/LevelObjectPolicy.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelObjectPolicy.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 using CtrDxEditor.Core.Document;
@@ -40,9 +41,38 @@ namespace CtrDxEditor.Core.Editing
             }
         }
 
+        /// <summary>
+        /// Reassigns hidden candy and bulb ids from zero in object order, updating grab references
+        /// that pointed at matching legacy keys.
+        /// </summary>
+        public static void NormalizeBindingKeys(LevelDocument document)
+        {
+            IReadOnlyList<LevelObject> objects = document.Objects;
+            Dictionary<string, string> candyMap = NormalizeObjects(
+                objects.Where(o => o.Type == "candy"),
+                "candyNumber");
+            Dictionary<string, string> bulbMap = NormalizeObjects(
+                objects.Where(o => o.Type is "lightBulb" or "lightbulb"),
+                "bulbNumber");
+
+            foreach (LevelObject grab in objects.Where(o => o.Type == "grab"))
+            {
+                if (IsTrue(grab.GetAttr("bindBulb")))
+                {
+                    Retarget(grab, "bulbNumber", bulbMap);
+                }
+                else if (!document.TwoParts)
+                {
+                    Retarget(grab, "candyNumber", candyMap);
+                }
+            }
+        }
+
         /// <summary>Returns whether an object attribute should be exposed for editing in this level.</summary>
         public static bool IsAttributeVisible(string element, string attribute, LevelDocument document)
         {
+            _ = document;
+
             // `part` is subsumed by the grab "Attach to" binding control.
             if (element == "grab" && attribute == "part")
             {
@@ -55,8 +85,39 @@ namespace CtrDxEditor.Core.Editing
                 return false;
             }
 
-            // The candyNumber key is only meaningful outside split-candy levels.
-            return element != "candy" || attribute != "candyNumber" || !document.TwoParts;
+            // Binding keys are authored internally and selected through grab "Attach to".
+            return (element != "candy" || attribute != "candyNumber")
+                && (element is not ("lightBulb" or "lightbulb") || attribute != "bulbNumber");
+        }
+
+        private static Dictionary<string, string> NormalizeObjects(IEnumerable<LevelObject> objects, string attribute)
+        {
+            Dictionary<string, string> map = [];
+            int key = 0;
+            foreach (LevelObject obj in objects)
+            {
+                string next = key.ToString(CultureInfo.InvariantCulture);
+                if (obj.GetAttr(attribute) is { } old)
+                {
+                    _ = map.TryAdd(old.Trim(), next);
+                }
+                obj.SetAttr(attribute, next);
+                key++;
+            }
+            return map;
+        }
+
+        private static void Retarget(LevelObject grab, string attribute, Dictionary<string, string> keyMap)
+        {
+            if (grab.GetAttr(attribute) is { } old && keyMap.TryGetValue(old.Trim(), out string? next))
+            {
+                grab.SetAttr(attribute, next);
+            }
+        }
+
+        private static bool IsTrue(string? v)
+        {
+            return bool.TryParse(v, out bool b) && b;
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/Placement.cs
+++ b/src/CtrDxEditor.Core/Editing/Placement.cs
@@ -22,6 +22,10 @@ namespace CtrDxEditor.Core.Editing
                     element.SetAttributeValue(spec.Name, spec.Default);
                 }
             }
+            if (descriptor.ElementName == "electro")
+            {
+                element.SetAttributeValue("size", "5");
+            }
 
             return new LevelObject(element);
         }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -287,6 +287,7 @@ namespace CtrDxEditor.Rendering
                 {
                     LevelSceneRenderer.DrawObject(context, v, sprites, obj, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel,
                         ActiveBackground > 0 ? Brushes.Black : _palette.StarDurationText,
+                        objects,
                         useAnimationPreview && IsAnimationPreviewing(obj) ? AnimationPreviewElapsedSeconds : null);
                 }
             }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 using Avalonia;
 using Avalonia.Media;
@@ -120,6 +121,7 @@ namespace CtrDxEditor.Rendering
         /// <param name="omNomSupport">Active Om Nom support index.</param>
         /// <param name="nightLevel">Whether night sprite variants apply.</param>
         /// <param name="starDurationText">Brush for the timed-star duration label.</param>
+        /// <param name="objects">All level objects, used to decide whether binding id labels are needed.</param>
         /// <param name="animationPreviewSeconds">Elapsed live-preview seconds, or null for authored static rendering.</param>
         public static void DrawObject(
             DrawingContext ctx,
@@ -130,6 +132,7 @@ namespace CtrDxEditor.Rendering
             int omNomSupport,
             bool nightLevel,
             IBrush starDurationText,
+            IReadOnlyList<LevelObject> objects,
             double? animationPreviewSeconds = null)
         {
             Vec2 previewPosition = PreviewPosition(obj, animationPreviewSeconds);
@@ -148,6 +151,7 @@ namespace CtrDxEditor.Rendering
                     DrawStarDuration(ctx, v, star, x, y, timeout, starDurationText);
                 }
                 DrawOverlays(ctx, v, sprites, obj, x, y);
+                DrawBindingIdLabel(ctx, v, obj, objects, x, y);
                 return;
             }
 
@@ -163,6 +167,7 @@ namespace CtrDxEditor.Rendering
                     }
                 }
                 DrawOverlays(ctx, v, sprites, obj, x, y);
+                DrawBindingIdLabel(ctx, v, obj, objects, x, y);
                 return;
             }
 
@@ -177,6 +182,21 @@ namespace CtrDxEditor.Rendering
                 DrawSprite(ctx, v, sprite, x, y, spinRotation);
             }
             DrawOverlays(ctx, v, sprites, obj, x, y);
+            DrawBindingIdLabel(ctx, v, obj, objects, x, y);
+        }
+
+        /// <summary>Returns the hidden binding id to show on a candy or bulb, or null when no label is needed.</summary>
+        /// <param name="obj">The object being drawn.</param>
+        /// <param name="objects">All level objects.</param>
+        /// <returns>The id label for multi-object candy/bulb groups, otherwise null.</returns>
+        internal static string? BindingIdLabel(LevelObject obj, IReadOnlyList<LevelObject> objects)
+        {
+            return obj.Type switch
+            {
+                "candy" => LabelForGroup(obj, objects, "candy", "candyNumber"),
+                "lightBulb" or "lightbulb" => LabelForGroup(obj, objects, obj.Type, "bulbNumber"),
+                _ => null,
+            };
         }
 
         internal static string PreviewSpriteKey(LevelObject obj, double? animationPreviewSeconds)
@@ -356,6 +376,63 @@ namespace CtrDxEditor.Rendering
         {
             Vec2 point = v.LevelToScreen(new Vec2(x, y));
             return new Point(point.X, point.Y);
+        }
+
+        private static string? LabelForGroup(
+            LevelObject obj,
+            IReadOnlyList<LevelObject> objects,
+            string element,
+            string attribute)
+        {
+            List<LevelObject> group = [.. objects.Where(o => o.Type == element)];
+            if (group.Count <= 1)
+            {
+                return null;
+            }
+
+            if (obj.GetAttr(attribute) is { Length: > 0 } key)
+            {
+                return key;
+            }
+
+            int index = group.IndexOf(obj);
+            return index >= 0 ? index.ToString(CultureInfo.InvariantCulture) : null;
+        }
+
+        private static void DrawBindingIdLabel(
+            DrawingContext ctx,
+            ViewTransform v,
+            LevelObject obj,
+            IReadOnlyList<LevelObject> objects,
+            double x,
+            double y)
+        {
+            string? label = BindingIdLabel(obj, objects);
+            if (label is null)
+            {
+                return;
+            }
+
+            FormattedText shadow = CreateBindingIdText(label, v.Zoom, Brushes.Black);
+            FormattedText text = CreateBindingIdText(label, v.Zoom, Brushes.White);
+            Vec2 center = v.LevelToScreen(new Vec2(x, y));
+            Point origin = new(
+                center.X - (text.Width / 2.0),
+                center.Y - (text.Height / 2.0));
+            double shadowOffset = Math.Max(1.0, 1.5 * v.Zoom);
+            ctx.DrawText(shadow, new Point(origin.X + shadowOffset, origin.Y + shadowOffset));
+            ctx.DrawText(text, origin);
+        }
+
+        private static FormattedText CreateBindingIdText(string text, double zoom, IBrush foreground)
+        {
+            return new FormattedText(
+                text,
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily.DefaultFontFamilyName, FontStyle.Normal, FontWeight.Bold),
+                Math.Max(10.0, 16.0 * zoom),
+                foreground);
         }
 
         /// <summary>Draws the countdown label above a timed star.</summary>

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -92,6 +92,7 @@ namespace CtrDxEditor.ViewModels
         {
             StopAnimationPreview();
             Document = LevelDocument.Parse(xml);
+            LevelObjectPolicy.NormalizeBindingKeys(Document);
             SelectedObject = null;
             LockedObject = null;
             ClearHistory();
@@ -153,6 +154,7 @@ namespace CtrDxEditor.ViewModels
             StopAnimationPreview();
             CaptureUndoSnapshot();
             Document.UpdateSettings(settings);
+            LevelObjectPolicy.NormalizeBindingKeys(Document);
             RefreshPalette();
             RefreshObjectList();
             if (SelectedObject is not null && !Document.Objects.Contains(SelectedObject))
@@ -183,6 +185,7 @@ namespace CtrDxEditor.ViewModels
             }
             CaptureUndoSnapshot();
             LevelDocument.Remove(removed);
+            LevelObjectPolicy.NormalizeBindingKeys(Document);
             if (Equals(LockedObject, removed))
             {
                 LockedObject = null;
@@ -322,6 +325,7 @@ namespace CtrDxEditor.ViewModels
             LevelObject obj = Placement.CreateObject(d, levelX, levelY);
             LevelObjectPolicy.ApplyDefaults(obj, Document);
             Document.Add(obj);
+            LevelObjectPolicy.NormalizeBindingKeys(Document);
             RefreshPalette();
             RefreshObjectList();
             SelectedObject = obj;
@@ -331,6 +335,10 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Serializes the current level to XML text, or null when no document is loaded.</summary>
         public string? ToXml()
         {
+            if (Document is not null)
+            {
+                LevelObjectPolicy.NormalizeBindingKeys(Document);
+            }
             return Document?.Save();
         }
 

--- a/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
+++ b/src/CtrDxEditor.Tests/EditorLevelIoTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 
 using CtrDxEditor.Content;
 using CtrDxEditor.ViewModels;
@@ -91,6 +93,41 @@ namespace CtrDxEditor.Tests
             vm.LoadLevelXml(xml);
 
             Assert.True(raised);
+        }
+
+        /// <summary>Legacy candy and bulb keys are normalized to 0-based ids while preserving grab targets.</summary>
+        [Fact]
+        public void LoadLevelXmlNormalizesBindingKeysAndRetargetsGrabs()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            const string xml = """
+                <map>
+                  <layer name="settings">
+                    <map gridSize="32" width="640" height="480" />
+                    <gameDesign twoParts="false" nightLevel="true" />
+                  </layer>
+                  <layer name="Objects">
+                    <candy x="10" y="10" candyNumber="7" />
+                    <candy x="20" y="20" candyNumber="9" />
+                    <lightBulb x="30" y="30" bulbNumber="4" />
+                    <lightBulb x="40" y="40" bulbNumber="8" />
+                    <grab x="5" y="5" candyNumber="9" />
+                    <grab x="6" y="6" bindBulb="true" bulbNumber="4" />
+                  </layer>
+                </map>
+                """;
+
+            vm.LoadLevelXml(xml);
+
+            XDocument saved = XDocument.Parse(vm.ToXml()!);
+            XElement[] objects = [.. saved.Descendants("layer")
+                .Single(l => (string?)l.Attribute("name") == "Objects")
+                .Elements()];
+
+            Assert.Equal(["0", "1"], objects.Where(e => e.Name == "candy").Attributes("candyNumber").Select(a => a.Value));
+            Assert.Equal(["0", "1"], objects.Where(e => e.Name == "lightBulb").Attributes("bulbNumber").Select(a => a.Value));
+            Assert.Equal("1", objects.First(e => e.Name == "grab").Attribute("candyNumber")?.Value);
+            Assert.Equal("0", objects.Last(e => e.Name == "grab").Attribute("bulbNumber")?.Value);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/GrabPropertyTests.cs
+++ b/src/CtrDxEditor.Tests/GrabPropertyTests.cs
@@ -98,6 +98,22 @@ namespace CtrDxEditor.Tests
             Assert.Equal("1", grab.GetAttr("candyNumber"));
         }
 
+        /// <summary>Candy and bulb binding keys stay internal instead of becoming property fields.</summary>
+        [Theory]
+        [InlineData("candy", "candyNumber")]
+        [InlineData("lightBulb", "bulbNumber")]
+        public void CandyAndBulbIdsAreNotEditablePropertyFields(string element, string attribute)
+        {
+            EditorViewModel vm = Vm();
+            vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: true));
+
+            LevelObject obj = vm.PlaceObject(element, 100, 120)!;
+            vm.SelectedObject = obj;
+
+            Assert.NotNull(obj.GetAttr(attribute));
+            Assert.DoesNotContain(vm.Fields, f => f.Name == attribute);
+        }
+
         /// <summary>Grab attribute should be a checkbox in the UI.</summary>
         [Fact]
         public void GrabBoolAttributeSurfacesAsCheckbox()
@@ -348,9 +364,9 @@ namespace CtrDxEditor.Tests
             Assert.True(vm.Fields.Single(f => f.Name == "gun").IsEnabled);
         }
 
-        /// <summary>Selected single-candy objects expose the editable candyNumber field.</summary>
+        /// <summary>Selected single-candy objects keep their internal id without exposing an input.</summary>
         [Fact]
-        public void SelectedCandyShowsCandyNumberField()
+        public void SelectedCandyHidesCandyNumberField()
         {
             EditorViewModel vm = Vm();
             vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: false));
@@ -358,8 +374,8 @@ namespace CtrDxEditor.Tests
             LevelObject candy = vm.PlaceObject("candy", 100, 120)!;
             vm.SelectedObject = candy;
 
-            AttributeFieldViewModel field = vm.Fields.Single(f => f.Name == "candyNumber");
-            Assert.Equal("0", field.Value);
+            Assert.Equal("0", candy.GetAttr("candyNumber"));
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "candyNumber");
         }
 
         /// <summary>Length and radius are magnitudes: their numeric box refuses negatives; x/y still allow them.</summary>


### PR DESCRIPTION
## Description

- Make candy object ID binding internal. Editor now no longer exposes ID binding to users. This streamlines rope hook binding.
- Add binding ID text when there are more than one of the candy objects.