### PR TITLE
feat: add movement modes and editable polyline paths

### DIFF
--- a/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
@@ -66,5 +66,119 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(MoverPath.MaxStoredPlainOffsetPoints * 2, path.Split(',').Length);
             Assert.EndsWith("99,0", path);
         }
+
+        /// <summary>Retrace paths expose only their outbound canonical points.</summary>
+        [Fact]
+        public void CanonicalPointsReturnsOutboundHalfForRetrace()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50,0,50,100,50,100,0";
+
+            Assert.True(MoverPath.IsRetrace(path));
+            Assert.Equal([start, new Vec2(100, 0), new Vec2(100, 50), new Vec2(0, 50)],
+                MoverPath.CanonicalPoints(start, path));
+        }
+
+        /// <summary>Moving and inserting canonical points preserve the path's retrace state.</summary>
+        [Fact]
+        public void CanonicalMoveAndInsertPreserveRetrace()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50,0,50,100,50,100,0";
+
+            string moved = MoverPath.MoveCanonicalPoint(start, path, 2, new Vec2(125, 50));
+            string inserted = MoverPath.InsertCanonicalPoint(start, moved, 1, new Vec2(110, 25));
+
+            Assert.True(MoverPath.IsRetrace(inserted));
+            Assert.Equal(
+                [start, new Vec2(100, 0), new Vec2(110, 25), new Vec2(125, 50), new Vec2(0, 50)],
+                MoverPath.CanonicalPoints(start, inserted));
+        }
+
+        /// <summary>Appending adds a new canonical endpoint and hit-testing skips the object point.</summary>
+        [Fact]
+        public void AppendAndHitCanonicalPointUseEditableWaypoints()
+        {
+            Vec2 start = new(0, 0);
+            string edited = MoverPath.AppendCanonicalPoint(start, "100,0", new Vec2(100, 50));
+
+            Assert.Equal([start, new Vec2(100, 0), new Vec2(100, 50)],
+                MoverPath.CanonicalPoints(start, edited));
+            Assert.Equal(2, MoverPath.HitCanonicalPoint(start, edited, new Vec2(101, 49), tolerance: 5));
+            Assert.Equal(-1, MoverPath.HitCanonicalPoint(start, edited, new Vec2(1, 1), tolerance: 5));
+        }
+
+        /// <summary>Deleting an interior canonical waypoint reconnects its neighbors on a circuit.</summary>
+        [Fact]
+        public void DeleteCanonicalPointRemovesInteriorVertexOnCircuit()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50,0,50";
+
+            string edited = MoverPath.DeleteCanonicalPoint(start, path, 2);
+
+            Assert.Equal([start, new Vec2(100, 0), new Vec2(0, 50)],
+                MoverPath.CanonicalPoints(start, edited));
+        }
+
+        /// <summary>Deleting a canonical waypoint on a retrace keeps the path a retrace.</summary>
+        [Fact]
+        public void DeleteCanonicalPointPreservesRetrace()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50,0,50,100,50,100,0";
+
+            string edited = MoverPath.DeleteCanonicalPoint(start, path, 2);
+
+            Assert.True(MoverPath.IsRetrace(edited));
+            Assert.Equal([start, new Vec2(100, 0), new Vec2(0, 50)],
+                MoverPath.CanonicalPoints(start, edited));
+        }
+
+        /// <summary>Deleting the object point (index 0) or an out-of-range index is a no-op.</summary>
+        [Fact]
+        public void DeleteCanonicalPointIgnoresObjectPointAndOutOfRange()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50";
+
+            Assert.Equal(path, MoverPath.DeleteCanonicalPoint(start, path, 0));
+            Assert.Equal(path, MoverPath.DeleteCanonicalPoint(start, path, 9));
+        }
+
+        /// <summary>SetRetrace(true) expands the outbound shape to an out-and-back palindrome.</summary>
+        [Fact]
+        public void SetRetraceTrueProducesRetrace()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50";
+
+            string edited = MoverPath.SetRetrace(start, path, retrace: true);
+
+            Assert.True(MoverPath.IsRetrace(edited));
+            Assert.Equal([start, new Vec2(100, 0), new Vec2(100, 50)],
+                MoverPath.CanonicalPoints(start, edited));
+        }
+
+        /// <summary>SetRetrace(false) collapses a retrace back to a plain circuit of its outbound points.</summary>
+        [Fact]
+        public void SetRetraceFalseProducesCircuit()
+        {
+            Vec2 start = new(0, 0);
+            string path = "100,0,100,50,0,50,100,50,100,0";
+
+            string edited = MoverPath.SetRetrace(start, path, retrace: false);
+
+            Assert.False(MoverPath.IsRetrace(edited));
+            Assert.Equal("100,0,100,50,0,50", edited);
+        }
+
+        /// <summary>SetRetrace leaves circular and empty paths untouched.</summary>
+        [Fact]
+        public void SetRetraceIgnoresCircularAndEmpty()
+        {
+            Assert.Equal("RC120", MoverPath.SetRetrace(new Vec2(0, 0), "RC120", true));
+            Assert.Equal(string.Empty, MoverPath.SetRetrace(new Vec2(0, 0), "", true));
+        }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
@@ -1,0 +1,70 @@
+using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for DX mover path parsing, preview, and point serialization.</summary>
+    public class MoverPathTests
+    {
+        /// <summary>Plain DX paths store relative offsets and DX prepends the authored object point.</summary>
+        [Fact]
+        public void PlainPathPointsIncludeAuthoredStartAndRelativeOffsets()
+        {
+            Vec2[] points = MoverPath.Points(new Vec2(10, 20), "100,0,100,50");
+
+            Assert.Equal([new Vec2(10, 20), new Vec2(110, 20), new Vec2(110, 70)], points);
+        }
+
+        /// <summary>Previewing a plain path follows segment distance and wraps like DX's mover update loop.</summary>
+        [Fact]
+        public void PreviewPositionFollowsPlainPathSegments()
+        {
+            Vec2 position = MoverPath.PreviewPosition(new Vec2(10, 20), "100,0,100,50", moveSpeed: 75, elapsedSeconds: 2.0);
+
+            Assert.Equal(110.0, position.X, 6);
+            Assert.Equal(70.0, position.Y, 6);
+        }
+
+        /// <summary>Looped serialization writes just the authored shape points relative to the object.</summary>
+        [Fact]
+        public void SerializePlainLoopWritesDrawnPointsOnly()
+        {
+            string path = MoverPath.SerializePlain(
+                new Vec2(10, 20),
+                [new Vec2(10, 20), new Vec2(110, 20), new Vec2(110, 70)],
+                loop: true);
+
+            Assert.Equal("100,0,100,50", path);
+        }
+
+        /// <summary>Non-loop serialization mirrors the path back through intermediate points before DX wraps home.</summary>
+        [Fact]
+        public void SerializePlainNoLoopWritesPingPongReturnPoints()
+        {
+            string path = MoverPath.SerializePlain(
+                new Vec2(10, 20),
+                [new Vec2(10, 20), new Vec2(110, 20), new Vec2(110, 70), new Vec2(10, 70)],
+                loop: false);
+
+            Assert.Equal("100,0,100,50,0,50,100,50,100,0", path);
+        }
+
+        /// <summary>Generated plain paths are capped to DX's non-R capacity of 100 total points including start.</summary>
+        [Fact]
+        public void SerializePlainCapsStoredOffsetsToDxCapacity()
+        {
+            Vec2[] points = new Vec2[150];
+            for (int i = 0; i < points.Length; i++)
+            {
+                points[i] = new Vec2(i, 0);
+            }
+
+            string path = MoverPath.SerializePlain(new Vec2(0, 0), points, loop: true);
+
+            Assert.Equal(MoverPath.MaxStoredPlainOffsetPoints * 2, path.Split(',').Length);
+            Assert.EndsWith("99,0", path);
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
@@ -233,6 +233,88 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(retrace, MoverPath.AppendCanonicalPoint(start, retrace, new Vec2(51, 0)));
         }
 
+        /// <summary>Direction only applies to closed loops: not lines, retraces, or circular paths.</summary>
+        [Fact]
+        public void IsClosedLoopTrueForTriangleFalseForLineRetraceAndCircular()
+        {
+            Vec2 start = new(0, 0);
+
+            Assert.True(MoverPath.IsClosedLoop(start, "100,0,0,100"));
+            Assert.False(MoverPath.IsClosedLoop(start, "100,0"));
+            Assert.False(MoverPath.IsClosedLoop(start, "100,0,100,50,0,50,100,50,100,0"));
+            Assert.False(MoverPath.IsClosedLoop(start, "RC30"));
+        }
+
+        /// <summary>Winding reflects screen-space orientation (level Y is screen-down, so positive area is clockwise).</summary>
+        [Fact]
+        public void IsClockwiseReflectsScreenSpaceWinding()
+        {
+            Vec2 start = new(0, 0);
+
+            Assert.True(MoverPath.IsClockwise(start, "100,0,0,100"));
+            Assert.False(MoverPath.IsClockwise(start, "0,100,100,0"));
+        }
+
+        /// <summary>Flipping direction reverses the stored point order; matching the current winding is a no-op.</summary>
+        [Fact]
+        public void SetClockwiseReversesPointOrderWhenWindingDiffers()
+        {
+            Vec2 start = new(0, 0);
+            string clockwise = "100,0,0,100";
+
+            Assert.Equal(clockwise, MoverPath.SetClockwise(start, clockwise, clockwise: true));
+
+            string flipped = MoverPath.SetClockwise(start, clockwise, clockwise: false);
+            Assert.False(MoverPath.IsClockwise(start, flipped));
+            Assert.Equal(
+                [start, new Vec2(0, 100), new Vec2(100, 0)],
+                MoverPath.CanonicalPoints(start, flipped));
+        }
+
+        /// <summary>Direction is meaningless for non-loops, so setting it leaves the path untouched.</summary>
+        [Fact]
+        public void SetClockwiseNoOpForNonLoop()
+        {
+            Vec2 start = new(0, 0);
+
+            Assert.Equal("100,0", MoverPath.SetClockwise(start, "100,0", clockwise: false));
+        }
+
+        /// <summary>Retrace is only meaningful with two or more waypoints; a single straight segment cannot retrace.</summary>
+        [Fact]
+        public void CanRetraceRequiresAtLeastTwoWaypoints()
+        {
+            Vec2 start = new(0, 0);
+
+            Assert.False(MoverPath.CanRetrace(start, "100,0"));
+            Assert.True(MoverPath.CanRetrace(start, "100,0,100,50"));
+            Assert.True(MoverPath.CanRetrace(start, "100,0,100,50,0,50,100,50,100,0"));
+            Assert.False(MoverPath.CanRetrace(start, "RC30"));
+        }
+
+        /// <summary>The displayed direction stays put when toggling retrace, since the canonical order is preserved.</summary>
+        [Fact]
+        public void CanonicalClockwiseIsStableAcrossRetraceToggle()
+        {
+            Vec2 start = new(0, 0);
+            string counterClockwise = "0,100,100,0";
+
+            Assert.False(MoverPath.IsCanonicalClockwise(start, counterClockwise));
+
+            string asRetrace = MoverPath.SetRetrace(start, counterClockwise, retrace: true);
+            Assert.False(MoverPath.IsCanonicalClockwise(start, asRetrace));
+
+            string backToCircuit = MoverPath.SetRetrace(start, asRetrace, retrace: false);
+            Assert.False(MoverPath.IsCanonicalClockwise(start, backToCircuit));
+        }
+
+        /// <summary>A degenerate path (single line) defaults to clockwise for the disabled checkbox.</summary>
+        [Fact]
+        public void CanonicalClockwiseDefaultsClockwiseForSingleLine()
+        {
+            Assert.True(MoverPath.IsCanonicalClockwise(new Vec2(0, 0), "100,0"));
+        }
+
         private static Vec2[] PathPoints(int count)
         {
             Vec2[] points = new Vec2[count];

--- a/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
@@ -315,6 +315,18 @@ namespace CtrDxEditor.Core.Tests
             Assert.True(MoverPath.IsCanonicalClockwise(new Vec2(0, 0), "100,0"));
         }
 
+        /// <summary>The static "0,0" spin-carrier path is not polyline movement; a real segment or orbit is distinguished.</summary>
+        [Fact]
+        public void IsPolylineMovementIgnoresStaticSpinPath()
+        {
+            Assert.False(MoverPath.IsPolylineMovement("0,0"));
+            Assert.False(MoverPath.IsPolylineMovement(""));
+            Assert.False(MoverPath.IsPolylineMovement(null));
+            Assert.False(MoverPath.IsPolylineMovement("RC120"));
+            Assert.True(MoverPath.IsPolylineMovement("100,0"));
+            Assert.True(MoverPath.IsPolylineMovement("0,0,100,50"));
+        }
+
         private static Vec2[] PathPoints(int count)
         {
             Vec2[] points = new Vec2[count];

--- a/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MoverPathTests.cs
@@ -146,6 +146,19 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(path, MoverPath.DeleteCanonicalPoint(start, path, 9));
         }
 
+        /// <summary>Deleting the sole waypoint leaves no movement path instead of recreating a zero-offset waypoint.</summary>
+        [Fact]
+        public void DeleteCanonicalPointRemovesSoleWaypoint()
+        {
+            Vec2 start = new(0, 0);
+
+            string edited = MoverPath.DeleteCanonicalPoint(start, "100,0", 1);
+
+            Assert.Equal(string.Empty, edited);
+            Assert.Equal([start], MoverPath.CanonicalPoints(start, edited));
+            Assert.Equal(-1, MoverPath.HitCanonicalPoint(start, edited, start, tolerance: 5));
+        }
+
         /// <summary>SetRetrace(true) expands the outbound shape to an out-and-back palindrome.</summary>
         [Fact]
         public void SetRetraceTrueProducesRetrace()
@@ -179,6 +192,55 @@ namespace CtrDxEditor.Core.Tests
         {
             Assert.Equal("RC120", MoverPath.SetRetrace(new Vec2(0, 0), "RC120", true));
             Assert.Equal(string.Empty, MoverPath.SetRetrace(new Vec2(0, 0), "", true));
+        }
+
+        /// <summary>Retrace serialization caps canonical points before mirroring so the stored path stays symmetric.</summary>
+        [Fact]
+        public void SerializeRetracePreservesSymmetryAtDxCapacity()
+        {
+            Vec2 start = new(0, 0);
+
+            string path = MoverPath.Serialize(start, PathPoints(100), retrace: true);
+
+            Assert.True(MoverPath.IsRetrace(path));
+            Assert.Equal(51, MoverPath.CanonicalPoints(start, path).Length);
+            Assert.Equal(MoverPath.MaxStoredPlainOffsetPoints * 2, path.Split(',').Length);
+        }
+
+        /// <summary>Enabling retrace refuses to discard canonical points that cannot fit in a symmetric DX path.</summary>
+        [Fact]
+        public void SetRetraceRefusesDataLosingConversionAtCapacity()
+        {
+            Vec2 start = new(0, 0);
+            string path = MoverPath.Serialize(start, PathPoints(52), retrace: false);
+
+            Assert.Equal(path, MoverPath.SetRetrace(start, path, retrace: true));
+            Assert.False(MoverPath.IsRetrace(path));
+        }
+
+        /// <summary>Full circuit and retrace paths reject additional canonical points.</summary>
+        [Fact]
+        public void FullPathsHaveNoCanonicalAddCapacity()
+        {
+            Vec2 start = new(0, 0);
+            string circuit = MoverPath.Serialize(start, PathPoints(100), retrace: false);
+            string retrace = MoverPath.Serialize(start, PathPoints(51), retrace: true);
+
+            Assert.False(MoverPath.CanAddCanonicalPoint(start, circuit));
+            Assert.False(MoverPath.CanAddCanonicalPoint(start, retrace));
+            Assert.Equal(circuit, MoverPath.AppendCanonicalPoint(start, circuit, new Vec2(100, 0)));
+            Assert.Equal(circuit, MoverPath.InsertCanonicalPoint(start, circuit, 0, new Vec2(0.5, 0)));
+            Assert.Equal(retrace, MoverPath.AppendCanonicalPoint(start, retrace, new Vec2(51, 0)));
+        }
+
+        private static Vec2[] PathPoints(int count)
+        {
+            Vec2[] points = new Vec2[count];
+            for (int i = 0; i < count; i++)
+            {
+                points[i] = new Vec2(i, 0);
+            }
+            return points;
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/MoverPath.cs
+++ b/src/CtrDxEditor.Core/Editing/MoverPath.cs
@@ -33,6 +33,20 @@ namespace CtrDxEditor.Core.Editing
             return IsCircularPath(path) ? CircularPoints(start, path) : PlainPoints(start, path);
         }
 
+        /// <summary>Returns the object point plus editable canonical waypoints; retrace paths expose their outbound half.</summary>
+        public static Vec2[] CanonicalPoints(Vec2 start, string? path)
+        {
+            Vec2[] full = Points(start, path);
+            if (!IsRetrace(path))
+            {
+                return full;
+            }
+
+            int storedPointCount = full.Length - 1;
+            int outboundPointCount = (storedPointCount + 1) / 2;
+            return full[..(outboundPointCount + 1)];
+        }
+
         /// <summary>Computes the live-preview position for a DX mover path.</summary>
         public static Vec2 PreviewPosition(Vec2 start, string? path, int moveSpeed, double elapsedSeconds)
         {
@@ -86,20 +100,20 @@ namespace CtrDxEditor.Core.Editing
             return PreviewPosition(new Vec2(obj.X, obj.Y), obj.GetAttr("path"), RawMoveSpeed(obj), elapsedSeconds);
         }
 
-        /// <summary>Serializes absolute points to a plain DX offset path, optionally mirroring back home.</summary>
-        public static string SerializePlain(Vec2 start, IReadOnlyList<Vec2> absolutePoints, bool loop)
+        /// <summary>Serializes canonical absolute points to a plain DX offset path; retrace appends the reversed interior.</summary>
+        public static string Serialize(Vec2 start, IReadOnlyList<Vec2> canonicalAbsolutePoints, bool retrace)
         {
-            if (absolutePoints.Count <= 1)
+            if (canonicalAbsolutePoints.Count <= 1)
             {
                 return "0,0";
             }
 
-            List<Vec2> stored = [.. absolutePoints.Skip(1)];
-            if (!loop && absolutePoints.Count > 2)
+            List<Vec2> stored = [.. canonicalAbsolutePoints.Skip(1)];
+            if (retrace && canonicalAbsolutePoints.Count > 2)
             {
-                for (int i = absolutePoints.Count - 2; i >= 1; i--)
+                for (int i = canonicalAbsolutePoints.Count - 2; i >= 1; i--)
                 {
-                    stored.Add(absolutePoints[i]);
+                    stored.Add(canonicalAbsolutePoints[i]);
                 }
             }
 
@@ -113,6 +127,124 @@ namespace CtrDxEditor.Core.Editing
                 Vec2 offset = new(p.X - start.X, p.Y - start.Y);
                 return new[] { Format(offset.X), Format(offset.Y) };
             }));
+        }
+
+        /// <summary>Compatibility wrapper for serializing a looping or out-and-back plain path.</summary>
+        public static string SerializePlain(Vec2 start, IReadOnlyList<Vec2> absolutePoints, bool loop)
+        {
+            return Serialize(start, absolutePoints, retrace: !loop);
+        }
+
+        /// <summary>Returns true when a plain path stores an odd palindrome of out-and-back offsets.</summary>
+        public static bool IsRetrace(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || IsCircularPath(path))
+            {
+                return false;
+            }
+
+            Vec2[] points = Points(new Vec2(0, 0), path);
+            int storedPointCount = points.Length - 1;
+            if (storedPointCount < 3 || storedPointCount % 2 == 0)
+            {
+                return false;
+            }
+
+            for (int i = 1; i <= storedPointCount / 2; i++)
+            {
+                if (points[i] != points[^i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Returns the canonical waypoint index (>= 1) under the point, or -1.</summary>
+        public static int HitCanonicalPoint(Vec2 start, string? path, Vec2 point, double tolerance)
+        {
+            if (string.IsNullOrWhiteSpace(path) || IsCircularPath(path))
+            {
+                return -1;
+            }
+
+            Vec2[] pts = CanonicalPoints(start, path);
+            double toleranceSquared = tolerance * tolerance;
+            for (int i = 1; i < pts.Length; i++)
+            {
+                double dx = pts[i].X - point.X;
+                double dy = pts[i].Y - point.Y;
+                if ((dx * dx) + (dy * dy) <= toleranceSquared)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>Moves one canonical waypoint and re-serializes, preserving retrace/circuit state.</summary>
+        public static string MoveCanonicalPoint(Vec2 start, string? path, int index, Vec2 newPoint)
+        {
+            Vec2[] pts = CanonicalPoints(start, path);
+            if (index <= 0 || index >= pts.Length || IsCircularPath(path))
+            {
+                return path ?? string.Empty;
+            }
+
+            pts[index] = newPoint;
+            return Serialize(start, pts, IsRetrace(path));
+        }
+
+        /// <summary>Inserts a canonical waypoint after <paramref name="segmentIndex"/> and re-serializes.</summary>
+        public static string InsertCanonicalPoint(Vec2 start, string? path, int segmentIndex, Vec2 newPoint)
+        {
+            Vec2[] pts = CanonicalPoints(start, path);
+            if (segmentIndex < 0 || segmentIndex >= pts.Length - 1 || IsCircularPath(path))
+            {
+                return path ?? string.Empty;
+            }
+
+            List<Vec2> list = [.. pts];
+            list.Insert(segmentIndex + 1, newPoint);
+            return Serialize(start, list, IsRetrace(path));
+        }
+
+        /// <summary>Appends a canonical waypoint, preserving retrace/circuit state.</summary>
+        public static string AppendCanonicalPoint(Vec2 start, string? path, Vec2 newPoint)
+        {
+            if (IsCircularPath(path))
+            {
+                return path ?? string.Empty;
+            }
+
+            Vec2[] pts = CanonicalPoints(start, path);
+            List<Vec2> list = [.. pts];
+            list.Add(newPoint);
+            return Serialize(start, list, IsRetrace(path));
+        }
+
+        /// <summary>Removes a single canonical waypoint (index >= 1) and re-serializes, preserving retrace/circuit state.</summary>
+        public static string DeleteCanonicalPoint(Vec2 start, string? path, int index)
+        {
+            Vec2[] pts = CanonicalPoints(start, path);
+            if (index <= 0 || index >= pts.Length || IsCircularPath(path))
+            {
+                return path ?? string.Empty;
+            }
+
+            List<Vec2> list = [.. pts];
+            list.RemoveAt(index);
+            return Serialize(start, list, IsRetrace(path));
+        }
+
+        /// <summary>Re-serializes the canonical points as an out-and-back retrace or a plain circuit.</summary>
+        public static string SetRetrace(Vec2 start, string? path, bool retrace)
+        {
+            return string.IsNullOrWhiteSpace(path) || IsCircularPath(path)
+                ? path ?? string.Empty
+                : Serialize(start, CanonicalPoints(start, path), retrace);
         }
 
         /// <summary>Returns true when <paramref name="path"/> is DX circular movement syntax.</summary>

--- a/src/CtrDxEditor.Core/Editing/MoverPath.cs
+++ b/src/CtrDxEditor.Core/Editing/MoverPath.cs
@@ -157,6 +157,15 @@ namespace CtrDxEditor.Core.Editing
             return true;
         }
 
+        /// <summary>
+        /// True when out-and-back retrace produces a different path from a plain circuit — i.e. the path has at
+        /// least two waypoints. A single straight segment is inherently back-and-forth, so retrace is a no-op.
+        /// </summary>
+        public static bool CanRetrace(Vec2 start, string? path)
+        {
+            return !IsCircularPath(path) && CanonicalPoints(start, path).Length >= 3;
+        }
+
         /// <summary>Returns the canonical waypoint index (>= 1) under the point, or -1.</summary>
         public static int HitCanonicalPoint(Vec2 start, string? path, Vec2 point, double tolerance)
         {
@@ -258,6 +267,74 @@ namespace CtrDxEditor.Core.Editing
             return retrace && points.Length > MaxCanonicalPointCount(retrace: true)
                 ? path
                 : Serialize(start, points, retrace);
+        }
+
+        /// <summary>
+        /// Returns true when a plain path forms a closed loop with a defined winding: not circular, not an
+        /// out-and-back retrace, and at least three non-collinear canonical points (so it encloses an area).
+        /// Travel direction is only meaningful for such loops.
+        /// </summary>
+        public static bool IsClosedLoop(Vec2 start, string? path)
+        {
+            if (IsCircularPath(path) || IsRetrace(path))
+            {
+                return false;
+            }
+
+            Vec2[] points = CanonicalPoints(start, path);
+            return points.Length >= 3 && Math.Abs(SignedArea(points)) > 0.0001;
+        }
+
+        /// <summary>Returns true when the closed loop winds clockwise on screen (level Y is screen-down).</summary>
+        public static bool IsClockwise(Vec2 start, string? path)
+        {
+            return IsClosedLoop(start, path) && SignedArea(CanonicalPoints(start, path)) > 0;
+        }
+
+        /// <summary>
+        /// Reverses the loop's traversal direction (the stored point order) when needed so it winds the
+        /// requested way, and re-serializes. The game has no direction flag, so direction is the point order.
+        /// </summary>
+        public static string SetClockwise(Vec2 start, string? path, bool clockwise)
+        {
+            if (!IsClosedLoop(start, path) || IsClockwise(start, path) == clockwise)
+            {
+                return path ?? string.Empty;
+            }
+
+            Vec2[] points = CanonicalPoints(start, path);
+            List<Vec2> reversed = [points[0]];
+            for (int i = points.Length - 1; i >= 1; i--)
+            {
+                reversed.Add(points[i]);
+            }
+
+            return Serialize(start, reversed, retrace: false);
+        }
+
+        /// <summary>
+        /// Winding used for the direction checkbox's displayed value: the signed area of the canonical points,
+        /// computed whether or not the path is currently a loop or an out-and-back. Because the canonical order
+        /// is preserved across a retrace toggle, the shown check state stays stable instead of flipping. A
+        /// degenerate (collinear) path defaults to clockwise.
+        /// </summary>
+        public static bool IsCanonicalClockwise(Vec2 start, string? path)
+        {
+            return IsCircularPath(path) || SignedArea(CanonicalPoints(start, path)) >= 0;
+        }
+
+        /// <summary>Signed polygon area (shoelace) of a closed loop; positive is clockwise in screen space.</summary>
+        private static double SignedArea(Vec2[] points)
+        {
+            double sum = 0.0;
+            for (int i = 0; i < points.Length; i++)
+            {
+                Vec2 a = points[i];
+                Vec2 b = points[(i + 1) % points.Length];
+                sum += (a.X * b.Y) - (b.X * a.Y);
+            }
+
+            return sum / 2.0;
         }
 
         private static int MaxCanonicalPointCount(bool retrace)

--- a/src/CtrDxEditor.Core/Editing/MoverPath.cs
+++ b/src/CtrDxEditor.Core/Editing/MoverPath.cs
@@ -105,21 +105,17 @@ namespace CtrDxEditor.Core.Editing
         {
             if (canonicalAbsolutePoints.Count <= 1)
             {
-                return "0,0";
+                return string.Empty;
             }
 
-            List<Vec2> stored = [.. canonicalAbsolutePoints.Skip(1)];
-            if (retrace && canonicalAbsolutePoints.Count > 2)
+            int canonicalPointCount = Math.Min(canonicalAbsolutePoints.Count, MaxCanonicalPointCount(retrace));
+            List<Vec2> stored = [.. canonicalAbsolutePoints.Skip(1).Take(canonicalPointCount - 1)];
+            if (retrace && canonicalPointCount > 2)
             {
-                for (int i = canonicalAbsolutePoints.Count - 2; i >= 1; i--)
+                for (int i = canonicalPointCount - 2; i >= 1; i--)
                 {
                     stored.Add(canonicalAbsolutePoints[i]);
                 }
-            }
-
-            if (stored.Count > MaxStoredPlainOffsetPoints)
-            {
-                stored.RemoveRange(MaxStoredPlainOffsetPoints, stored.Count - MaxStoredPlainOffsetPoints);
             }
 
             return string.Join(",", stored.SelectMany(p =>
@@ -184,6 +180,13 @@ namespace CtrDxEditor.Core.Editing
             return -1;
         }
 
+        /// <summary>Whether one more canonical waypoint can fit without truncating the serialized DX path.</summary>
+        public static bool CanAddCanonicalPoint(Vec2 start, string? path)
+        {
+            return !IsCircularPath(path)
+                && CanonicalPoints(start, path).Length < MaxCanonicalPointCount(IsRetrace(path));
+        }
+
         /// <summary>Moves one canonical waypoint and re-serializes, preserving retrace/circuit state.</summary>
         public static string MoveCanonicalPoint(Vec2 start, string? path, int index, Vec2 newPoint)
         {
@@ -205,6 +208,10 @@ namespace CtrDxEditor.Core.Editing
             {
                 return path ?? string.Empty;
             }
+            if (!CanAddCanonicalPoint(start, path))
+            {
+                return path ?? string.Empty;
+            }
 
             List<Vec2> list = [.. pts];
             list.Insert(segmentIndex + 1, newPoint);
@@ -214,7 +221,7 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Appends a canonical waypoint, preserving retrace/circuit state.</summary>
         public static string AppendCanonicalPoint(Vec2 start, string? path, Vec2 newPoint)
         {
-            if (IsCircularPath(path))
+            if (IsCircularPath(path) || !CanAddCanonicalPoint(start, path))
             {
                 return path ?? string.Empty;
             }
@@ -242,9 +249,22 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Re-serializes the canonical points as an out-and-back retrace or a plain circuit.</summary>
         public static string SetRetrace(Vec2 start, string? path, bool retrace)
         {
-            return string.IsNullOrWhiteSpace(path) || IsCircularPath(path)
-                ? path ?? string.Empty
-                : Serialize(start, CanonicalPoints(start, path), retrace);
+            if (string.IsNullOrWhiteSpace(path) || IsCircularPath(path))
+            {
+                return path ?? string.Empty;
+            }
+
+            Vec2[] points = CanonicalPoints(start, path);
+            return retrace && points.Length > MaxCanonicalPointCount(retrace: true)
+                ? path
+                : Serialize(start, points, retrace);
+        }
+
+        private static int MaxCanonicalPointCount(bool retrace)
+        {
+            return retrace
+                ? (MaxStoredPlainOffsetPoints + 3) / 2
+                : MaxStoredPlainOffsetPoints + 1;
         }
 
         /// <summary>Returns true when <paramref name="path"/> is DX circular movement syntax.</summary>

--- a/src/CtrDxEditor.Core/Editing/MoverPath.cs
+++ b/src/CtrDxEditor.Core/Editing/MoverPath.cs
@@ -21,6 +21,31 @@ namespace CtrDxEditor.Core.Editing
                 && Points(new Vec2(obj.X, obj.Y), obj.GetAttr("path")).Length > 1;
         }
 
+        /// <summary>
+        /// True when a plain (non-circular) path actually translates the object — at least one stored point
+        /// differs from the start. The spin-carrier path (<c>"0,0"</c>) that hosts <c>rotateSpeed</c> does not, so
+        /// movement-mode detection can tell a real polyline apart from a bare spinner.
+        /// </summary>
+        public static bool IsPolylineMovement(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || IsCircularPath(path))
+            {
+                return false;
+            }
+
+            Vec2 origin = new(0, 0);
+            Vec2[] points = Points(origin, path);
+            for (int i = 1; i < points.Length; i++)
+            {
+                if (points[i] != origin)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>Computes absolute path points for a DX mover path.</summary>
         public static Vec2[] Points(Vec2 start, string? path)
         {

--- a/src/CtrDxEditor.Core/Editing/MoverPath.cs
+++ b/src/CtrDxEditor.Core/Editing/MoverPath.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>Parses, previews, and serializes DX mover path strings.</summary>
+    public static class MoverPath
+    {
+        /// <summary>DX allocates 100 points for non-R paths and prepends the authored start point.</summary>
+        public const int MaxStoredPlainOffsetPoints = 99;
+
+        /// <summary>Returns true when the object has a path with positive movement speed.</summary>
+        public static bool HasActiveMovement(LevelObject obj)
+        {
+            return RawMoveSpeed(obj) > 0
+                && Points(new Vec2(obj.X, obj.Y), obj.GetAttr("path")).Length > 1;
+        }
+
+        /// <summary>Computes absolute path points for a DX mover path.</summary>
+        public static Vec2[] Points(Vec2 start, string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return [start];
+            }
+
+            path = path.Trim();
+            return IsCircularPath(path) ? CircularPoints(start, path) : PlainPoints(start, path);
+        }
+
+        /// <summary>Computes the live-preview position for a DX mover path.</summary>
+        public static Vec2 PreviewPosition(Vec2 start, string? path, int moveSpeed, double elapsedSeconds)
+        {
+            if (moveSpeed <= 0)
+            {
+                return start;
+            }
+
+            Vec2[] points = Points(start, path);
+            if (points.Length == 0)
+            {
+                return start;
+            }
+
+            if (points.Length == 1 || elapsedSeconds <= 0)
+            {
+                return points[0];
+            }
+
+            double remaining = moveSpeed * elapsedSeconds;
+            int index = 0;
+            while (remaining > 0)
+            {
+                Vec2 point = points[index];
+                Vec2 target = points[(index + 1) % points.Length];
+                double dx = target.X - point.X;
+                double dy = target.Y - point.Y;
+                double distance = Math.Sqrt((dx * dx) + (dy * dy));
+                if (distance <= 0)
+                {
+                    index = (index + 1) % points.Length;
+                    continue;
+                }
+
+                if (remaining <= distance)
+                {
+                    double t = remaining / distance;
+                    return new Vec2(point.X + (dx * t), point.Y + (dy * t));
+                }
+
+                remaining -= distance;
+                index = (index + 1) % points.Length;
+            }
+
+            return points[index];
+        }
+
+        /// <summary>Computes the live-preview position for a level object's mover data.</summary>
+        public static Vec2 PreviewPosition(LevelObject obj, double elapsedSeconds)
+        {
+            return PreviewPosition(new Vec2(obj.X, obj.Y), obj.GetAttr("path"), RawMoveSpeed(obj), elapsedSeconds);
+        }
+
+        /// <summary>Serializes absolute points to a plain DX offset path, optionally mirroring back home.</summary>
+        public static string SerializePlain(Vec2 start, IReadOnlyList<Vec2> absolutePoints, bool loop)
+        {
+            if (absolutePoints.Count <= 1)
+            {
+                return "0,0";
+            }
+
+            List<Vec2> stored = [.. absolutePoints.Skip(1)];
+            if (!loop && absolutePoints.Count > 2)
+            {
+                for (int i = absolutePoints.Count - 2; i >= 1; i--)
+                {
+                    stored.Add(absolutePoints[i]);
+                }
+            }
+
+            if (stored.Count > MaxStoredPlainOffsetPoints)
+            {
+                stored.RemoveRange(MaxStoredPlainOffsetPoints, stored.Count - MaxStoredPlainOffsetPoints);
+            }
+
+            return string.Join(",", stored.SelectMany(p =>
+            {
+                Vec2 offset = new(p.X - start.X, p.Y - start.Y);
+                return new[] { Format(offset.X), Format(offset.Y) };
+            }));
+        }
+
+        /// <summary>Returns true when <paramref name="path"/> is DX circular movement syntax.</summary>
+        public static bool IsCircularPath(string? path)
+        {
+            return path is { Length: > 2 }
+                && path[0] == 'R'
+                && (path[1] == 'C' || path[1] == 'W')
+                && int.TryParse(path[2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius)
+                && radius > 0;
+        }
+
+        /// <summary>Returns true when the circular path traverses clockwise.</summary>
+        public static bool IsCircularClockwise(string? path)
+        {
+            return !IsCircularPath(path) || path![1] == 'C';
+        }
+
+        /// <summary>Returns the circular path radius, or <paramref name="fallback"/> when not circular.</summary>
+        public static int CircularRadius(string? path, int fallback)
+        {
+            return IsCircularPath(path) && int.TryParse(path![2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius)
+                ? radius
+                : fallback;
+        }
+
+        private static Vec2[] CircularPoints(Vec2 start, string path)
+        {
+            int radius = CircularRadius(path, fallback: 0);
+            int pointCount = radius / 2;
+            if (pointCount <= 0)
+            {
+                return [start];
+            }
+
+            Vec2[] points = new Vec2[pointCount];
+            double angleStep = Math.Tau / pointCount;
+            if (!IsCircularClockwise(path))
+            {
+                angleStep = -angleStep;
+            }
+
+            double theta = 0.0;
+            for (int i = 0; i < points.Length; i++)
+            {
+                points[i] = new Vec2(
+                    start.X + (radius * Math.Cos(theta)),
+                    start.Y + (radius * Math.Sin(theta)));
+                theta += angleStep;
+            }
+
+            return points;
+        }
+
+        private static Vec2[] PlainPoints(Vec2 start, string path)
+        {
+            if (path[^1] == ',')
+            {
+                path = path[..^1];
+            }
+
+            string[] parts = path.Split(',');
+            if (parts.Length % 2 != 0)
+            {
+                return [start];
+            }
+
+            List<Vec2> points = [start];
+            for (int i = 0; i < parts.Length; i += 2)
+            {
+                double x = ParseDoubleOrZero(parts[i]);
+                double y = ParseDoubleOrZero(parts[i + 1]);
+                points.Add(new Vec2(start.X + x, start.Y + y));
+            }
+
+            return [.. points];
+        }
+
+        private static int RawMoveSpeed(LevelObject obj)
+        {
+            return double.TryParse(obj.GetAttr("moveSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? Math.Abs((int)value)
+                : 0;
+        }
+
+        private static double ParseDoubleOrZero(string value)
+        {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+                ? parsed
+                : 0.0;
+        }
+
+        private static string Format(double value)
+        {
+            return Math.Abs(value) < 0.0000001
+                ? "0"
+                : value.ToString("0.###", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
+++ b/src/CtrDxEditor.Core/Editing/ObjectSpin.cs
@@ -39,7 +39,7 @@ namespace CtrDxEditor.Core.Editing
         /// <returns><see langword="true"/> when the object has a circular path and non-zero move speed.</returns>
         public static bool IsOrbital(LevelObject obj)
         {
-            return IsCircularPath(obj.GetAttr("path")) && RawMoveSpeed(obj) > 0;
+            return MoverPath.IsCircularPath(obj.GetAttr("path")) && RawMoveSpeed(obj) > 0;
         }
 
         /// <summary>The positive whole-number speed magnitude shown in the editor.</summary>
@@ -63,8 +63,7 @@ namespace CtrDxEditor.Core.Editing
         /// <returns><see langword="true"/> for <c>RC</c> paths, and as the default for new orbit paths.</returns>
         public static bool OrbitClockwise(LevelObject obj)
         {
-            string? path = obj.GetAttr("path");
-            return !IsCircularPath(path) || path![1] == 'C';
+            return MoverPath.IsCircularClockwise(obj.GetAttr("path"));
         }
 
         /// <summary>Writes or clears spin data, storing direction as the sign of <paramref name="speed"/>.</summary>
@@ -94,9 +93,7 @@ namespace CtrDxEditor.Core.Editing
         public static int OrbitRadius(LevelObject obj)
         {
             string? path = obj.GetAttr("path");
-            return IsCircularPath(path) && int.TryParse(path![2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0
-                ? radius
-                : DefaultOrbitRadius;
+            return MoverPath.CircularRadius(path, DefaultOrbitRadius);
         }
 
         /// <summary>The positive whole-number movement speed encoded in DX <c>moveSpeed</c>.</summary>
@@ -116,7 +113,7 @@ namespace CtrDxEditor.Core.Editing
         {
             if (!enabled || radius <= 0)
             {
-                if (IsCircularPath(obj.GetAttr("path")))
+                if (MoverPath.IsCircularPath(obj.GetAttr("path")))
                 {
                     obj.RemoveAttr("path");
                     obj.RemoveAttr("moveSpeed");
@@ -162,53 +159,7 @@ namespace CtrDxEditor.Core.Editing
         /// <returns>The preview position, or the authored position when no active orbit exists.</returns>
         public static Vec2 PreviewPosition(LevelObject obj, double elapsedSeconds)
         {
-            Vec2 authored = new(obj.X, obj.Y);
-            string? path = obj.GetAttr("path");
-            int moveSpeed = RawMoveSpeed(obj);
-            if (!IsCircularPath(path) || moveSpeed <= 0)
-            {
-                return authored;
-            }
-
-            int radius = OrbitRadius(obj);
-            int pointsCount = radius / 2;
-            if (pointsCount <= 0)
-            {
-                return authored;
-            }
-
-            Vec2[] points = BuildCircularPath(authored, radius, path![1] == 'C', pointsCount);
-            if (points.Length == 1 || elapsedSeconds <= 0)
-            {
-                return points[0];
-            }
-
-            double remaining = moveSpeed * elapsedSeconds;
-            int index = 0;
-            while (remaining > 0)
-            {
-                Vec2 start = points[index];
-                Vec2 end = points[(index + 1) % points.Length];
-                double dx = end.X - start.X;
-                double dy = end.Y - start.Y;
-                double distance = Math.Sqrt((dx * dx) + (dy * dy));
-                if (distance <= 0)
-                {
-                    index = (index + 1) % points.Length;
-                    continue;
-                }
-
-                if (remaining <= distance)
-                {
-                    double t = remaining / distance;
-                    return new Vec2(start.X + (dx * t), start.Y + (dy * t));
-                }
-
-                remaining -= distance;
-                index = (index + 1) % points.Length;
-            }
-
-            return points[index];
+            return MoverPath.PreviewPosition(obj, elapsedSeconds);
         }
 
         private static int RawSpeed(LevelObject obj)
@@ -223,36 +174,6 @@ namespace CtrDxEditor.Core.Editing
             return double.TryParse(obj.GetAttr("moveSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
                 ? Math.Abs((int)value)
                 : 0;
-        }
-
-        private static Vec2[] BuildCircularPath(Vec2 start, int radius, bool clockwise, int pointsCount)
-        {
-            Vec2[] points = new Vec2[pointsCount];
-            double angleStep = Math.Tau / pointsCount;
-            if (!clockwise)
-            {
-                angleStep = -angleStep;
-            }
-
-            double theta = 0.0;
-            for (int i = 0; i < points.Length; i++)
-            {
-                points[i] = new Vec2(
-                    start.X + (radius * Math.Cos(theta)),
-                    start.Y + (radius * Math.Sin(theta)));
-                theta += angleStep;
-            }
-
-            return points;
-        }
-
-        private static bool IsCircularPath(string? path)
-        {
-            return path is { Length: > 2 }
-                && path[0] == 'R'
-                && (path[1] == 'C' || path[1] == 'W')
-                && int.TryParse(path[2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius)
-                && radius > 0;
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
+++ b/src/CtrDxEditor.Shared/Converters/SpinPreviewConverters.cs
@@ -48,7 +48,7 @@ namespace CtrDxEditor.Converters
 
         private static bool HasPreviewAnimation(LevelObject obj)
         {
-            return ElectroAnimation.IsElectro(obj.Type) || ObjectSpin.IsRotatingInPlace(obj) || ObjectSpin.IsOrbital(obj);
+            return ElectroAnimation.IsElectro(obj.Type) || ObjectSpin.IsRotatingInPlace(obj) || MoverPath.HasActiveMovement(obj);
         }
 
         private sealed class ObjectAnimationPreviewingConverter : IMultiValueConverter

--- a/src/CtrDxEditor.Shared/Localization/Localizer.cs
+++ b/src/CtrDxEditor.Shared/Localization/Localizer.cs
@@ -85,5 +85,11 @@ namespace CtrDxEditor.Localization
         {
             return Strings.TryGetValue($"Attr.{name}", out string? value) ? value : name;
         }
+
+        /// <summary>Display label for an enum option value; falls back to the raw value when no string is defined.</summary>
+        public static string AttributeOption(string attribute, string value)
+        {
+            return Strings.TryGetValue($"Attr.{attribute}.{value}", out string? label) ? label : value;
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -130,8 +130,8 @@
 
     "Object.target": "Om Nom",
     "Object.candy": "Candy",
-    "Object.candyL": "Candy (Left)",
-    "Object.candyR": "Candy (Right)",
+    "Object.candyL": "Candy (left)",
+    "Object.candyR": "Candy (right)",
     "Object.star": "Star",
     "Object.grab": "Rope hook",
     "Object.bubble": "Bubble",
@@ -176,11 +176,13 @@
     "Attr.spin": "Spin object",
     "Attr.spinSpeed": "Spin speed",
     "Attr.spinClockwise": "Spin clockwise",
-    "Attr.spinOrbital": "Orbit object",
     "Attr.movementMode": "Movement",
+    "Attr.movementMode.none": "None",
+    "Attr.movementMode.orbit": "Orbit",
+    "Attr.movementMode.polyline": "Polyline",
     "Attr.orbitRadius": "Orbit radius",
     "Attr.orbitSpeed": "Orbit speed",
     "Attr.orbitClockwise": "Orbit clockwise",
     "Attr.polylineSpeed": "Polyline speed",
-    "Attr.polylineRetrace": "Bounce (out and back)"
+    "Attr.polylineRetrace": "Back and forth"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -185,5 +185,7 @@
     "Attr.orbitClockwise": "Orbit clockwise",
     "Attr.polylineSpeed": "Polyline speed",
     "Attr.polylineRetrace": "Back and forth",
-    "Attr.polylineClockwise": "Clockwise"
+    "Attr.polylineClockwise": "Clockwise",
+
+    "Hint.PolylinePointLimit": "Movement path is at its 99-point limit"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -182,5 +182,5 @@
     "Attr.orbitSpeed": "Orbit speed",
     "Attr.orbitClockwise": "Orbit clockwise",
     "Attr.polylineSpeed": "Polyline speed",
-    "Attr.polylineLoop": "Loop path"
+    "Attr.polylineRetrace": "Bounce (out and back)"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -184,5 +184,6 @@
     "Attr.orbitSpeed": "Orbit speed",
     "Attr.orbitClockwise": "Orbit clockwise",
     "Attr.polylineSpeed": "Polyline speed",
-    "Attr.polylineRetrace": "Back and forth"
+    "Attr.polylineRetrace": "Back and forth",
+    "Attr.polylineClockwise": "Clockwise"
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -177,7 +177,10 @@
     "Attr.spinSpeed": "Spin speed",
     "Attr.spinClockwise": "Spin clockwise",
     "Attr.spinOrbital": "Orbit object",
+    "Attr.movementMode": "Movement",
     "Attr.orbitRadius": "Orbit radius",
     "Attr.orbitSpeed": "Orbit speed",
-    "Attr.orbitClockwise": "Orbit clockwise"
+    "Attr.orbitClockwise": "Orbit clockwise",
+    "Attr.polylineSpeed": "Polyline speed",
+    "Attr.polylineLoop": "Loop path"
 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
@@ -227,7 +227,8 @@ namespace CtrDxEditor.Rendering
         /// <summary>Returns the segment whose midpoint insert handle is under a level point, or -1.</summary>
         private int HitPolylineSegment(Vec2 levelPt)
         {
-            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj))
+            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj)
+                || !MoverPath.CanAddCanonicalPoint(new Vec2(obj.X, obj.Y), obj.GetAttr("path")))
             {
                 return -1;
             }
@@ -275,7 +276,8 @@ namespace CtrDxEditor.Rendering
         /// <summary>True when the pointer is over the append nub for the selected editable polyline.</summary>
         private bool HitPolylineNub(Vec2 levelPt)
         {
-            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj))
+            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj)
+                || !MoverPath.CanAddCanonicalPoint(new Vec2(obj.X, obj.Y), obj.GetAttr("path")))
             {
                 return false;
             }
@@ -725,12 +727,7 @@ namespace CtrDxEditor.Rendering
             base.OnPointerExited(e);
             SetHookHovered(false); // don't leave the hook lit when the cursor leaves the canvas
             SetDialKnobHovered(false); // nor the rotation knob
-            if (_polylineHoverPoint != -1 || _polylineNubHot)
-            {
-                _polylineHoverPoint = -1;
-                _polylineNubHot = false;
-                InvalidateVisual();
-            }
+            ResetPolylineHover();
         }
 
         /// <inheritdoc />

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
@@ -357,7 +357,10 @@ namespace CtrDxEditor.Rendering
 
         private bool HitBoundContains(LevelObject obj, LevelBounds bounds, Vec2 point)
         {
-            return LevelSceneRenderer.SelectionContains(obj, bounds, point, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
+            // An animating object (moving or spinning) is a moving target whose hit box no longer matches where it's
+            // drawn, so it can't be picked until the preview stops. Static objects stay editable.
+            return !IsAnimatingInPreview(obj)
+                && LevelSceneRenderer.SelectionContains(obj, bounds, point, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
         }
 
         private int TopmostHit(IReadOnlyList<LevelObject> objects, List<LevelBounds> bounds, Vec2 point, int afterIndex = -1)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
@@ -208,6 +208,119 @@ namespace CtrDxEditor.Rendering
             }
         }
 
+        /// <summary>Whether an object has a non-circular path that supports direct polyline editing.</summary>
+        private static bool IsEditablePolyline(LevelObject obj)
+        {
+            string? path = obj.GetAttr("path");
+            return !string.IsNullOrWhiteSpace(path) && !MoverPath.IsCircularPath(path);
+        }
+
+        /// <summary>Returns the selected canonical waypoint under a level point, or -1.</summary>
+        private int HitPolylinePoint(Vec2 levelPt)
+        {
+            return SelectedObject is { } obj && View.Zoom > 0 && IsEditablePolyline(obj)
+                ? MoverPath.HitCanonicalPoint(
+                    new Vec2(obj.X, obj.Y), obj.GetAttr("path"), levelPt, tolerance: 9 / View.Zoom)
+                : -1;
+        }
+
+        /// <summary>Returns the segment whose midpoint insert handle is under a level point, or -1.</summary>
+        private int HitPolylineSegment(Vec2 levelPt)
+        {
+            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj))
+            {
+                return -1;
+            }
+
+            Vec2[] points = MoverPath.CanonicalPoints(new Vec2(obj.X, obj.Y), obj.GetAttr("path"));
+            double tolerance = 7 / View.Zoom;
+            double toleranceSquared = tolerance * tolerance;
+            for (int i = 0; i < points.Length - 1; i++)
+            {
+                Vec2 midpoint = new(
+                    (points[i].X + points[i + 1].X) / 2,
+                    (points[i].Y + points[i + 1].Y) / 2);
+                double dx = midpoint.X - levelPt.X;
+                double dy = midpoint.Y - levelPt.Y;
+                if ((dx * dx) + (dy * dy) <= toleranceSquared)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>Level-space position of the append "+" nub: ~24 px past the last waypoint along the last segment.</summary>
+        private Vec2 PolylineNubPoint(LevelObject obj)
+        {
+            Vec2[] points = MoverPath.CanonicalPoints(new Vec2(obj.X, obj.Y), obj.GetAttr("path"));
+            Vec2 tip = points[^1];
+            Vec2 direction = points.Length >= 2
+                ? new Vec2(tip.X - points[^2].X, tip.Y - points[^2].Y)
+                : new Vec2(1, 0);
+            double length = Math.Sqrt((direction.X * direction.X) + (direction.Y * direction.Y));
+            if (length < 0.0001)
+            {
+                direction = new Vec2(1, 0);
+                length = 1;
+            }
+
+            double offset = 24 / View.Zoom;
+            return new Vec2(
+                tip.X + (direction.X / length * offset),
+                tip.Y + (direction.Y / length * offset));
+        }
+
+        /// <summary>True when the pointer is over the append nub for the selected editable polyline.</summary>
+        private bool HitPolylineNub(Vec2 levelPt)
+        {
+            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj))
+            {
+                return false;
+            }
+
+            Vec2 nub = PolylineNubPoint(obj);
+            double tolerance = 9 / View.Zoom;
+            double dx = nub.X - levelPt.X;
+            double dy = nub.Y - levelPt.Y;
+            return (dx * dx) + (dy * dy) <= tolerance * tolerance;
+        }
+
+        /// <summary>Rounds a point to whole units after snapping its direction from an anchor to 45-degree increments.</summary>
+        private static (int X, int Y) SnapAngle(Vec2 anchor, Vec2 point)
+        {
+            double dx = point.X - anchor.X;
+            double dy = point.Y - anchor.Y;
+            double length = Math.Sqrt((dx * dx) + (dy * dy));
+            if (length < 0.0001)
+            {
+                return ((int)Math.Round(point.X), (int)Math.Round(point.Y));
+            }
+
+            double angle = Math.Round(Math.Atan2(dy, dx) / (Math.PI / 4)) * (Math.PI / 4);
+            return (
+                (int)Math.Round(anchor.X + (Math.Cos(angle) * length)),
+                (int)Math.Round(anchor.Y + (Math.Sin(angle) * length)));
+        }
+
+        /// <summary>Deletes a single canonical waypoint from the selected polyline, reconnecting neighbors.</summary>
+        private void DeleteSelectedPolylineVertex(int index)
+        {
+            if (index <= 0 || SelectedObject is not { } obj)
+            {
+                return;
+            }
+
+            BeginDocumentEdit?.Invoke();
+            obj.SetAttr("path", MoverPath.DeleteCanonicalPoint(
+                new Vec2(obj.X, obj.Y), obj.GetAttr("path"), index));
+            _polylineHoverPoint = -1;
+            SelectedObjectMoved?.Invoke();
+            CompleteDocumentEdit?.Invoke();
+            InvalidateVisual();
+        }
+
         /// <summary>Finds the index of an object within the list by reference/value equality.</summary>
         /// <param name="objects">The object list to search.</param>
         /// <param name="target">The object to locate.</param>
@@ -283,13 +396,23 @@ namespace CtrDxEditor.Rendering
                 e.Pointer.Capture(this);
                 return;
             }
+
+            Point p = e.GetPosition(this);
+            Vec2 levelPt = View.ScreenToLevel(new Vec2(p.X, p.Y));
+            if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            {
+                int rightHit = HitPolylinePoint(levelPt);
+                if (rightHit > 0)
+                {
+                    DeleteSelectedPolylineVertex(rightHit);
+                    e.Handled = true;
+                }
+                return;
+            }
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;
             }
-
-            Point p = e.GetPosition(this);
-            Vec2 levelPt = View.ScreenToLevel(new Vec2(p.X, p.Y));
 
             // Grabbing the auto-catch ring resizes the radius; it takes priority over object hit-testing
             // (the ring can sit over other objects) but not over a middle-button pan.
@@ -346,6 +469,53 @@ namespace CtrDxEditor.Rendering
                 ApplyRotation(rotObj, rotSpec, levelPt, e.KeyModifiers);
                 SelectedObjectMoved?.Invoke();
                 InvalidateVisual();
+                e.Pointer.Capture(this);
+                return;
+            }
+
+            int pointHit = HitPolylinePoint(levelPt);
+            if (pointHit > 0 && SelectedObject is not null)
+            {
+                BeginDocumentEdit?.Invoke();
+                _polylinePointDrag = pointHit;
+                e.Handled = true;
+                e.Pointer.Capture(this);
+                return;
+            }
+
+            int segmentHit = HitPolylineSegment(levelPt);
+            if (segmentHit >= 0 && SelectedObject is { } segmentObj)
+            {
+                Vec2 start = new(segmentObj.X, segmentObj.Y);
+                Vec2[] points = MoverPath.CanonicalPoints(start, segmentObj.GetAttr("path"));
+                (int x, int y) = e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+                    ? SnapAngle(points[segmentHit], levelPt)
+                    : Snap(levelPt);
+                BeginDocumentEdit?.Invoke();
+                segmentObj.SetAttr("path", MoverPath.InsertCanonicalPoint(
+                    start, segmentObj.GetAttr("path"), segmentHit, new Vec2(x, y)));
+                SelectedObjectMoved?.Invoke();
+                _polylinePointDrag = segmentHit + 1;
+                InvalidateVisual();
+                e.Handled = true;
+                e.Pointer.Capture(this);
+                return;
+            }
+
+            if (HitPolylineNub(levelPt) && SelectedObject is { } nubObj)
+            {
+                Vec2 start = new(nubObj.X, nubObj.Y);
+                Vec2[] points = MoverPath.CanonicalPoints(start, nubObj.GetAttr("path"));
+                (int x, int y) = e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+                    ? SnapAngle(points[^1], levelPt)
+                    : Snap(levelPt);
+                BeginDocumentEdit?.Invoke();
+                nubObj.SetAttr("path", MoverPath.AppendCanonicalPoint(
+                    start, nubObj.GetAttr("path"), new Vec2(x, y)));
+                SelectedObjectMoved?.Invoke();
+                _polylinePointDrag = MoverPath.CanonicalPoints(start, nubObj.GetAttr("path")).Length - 1;
+                InvalidateVisual();
+                e.Handled = true;
                 e.Pointer.Capture(this);
                 return;
             }
@@ -444,6 +614,23 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
+            if (_polylinePointDrag > 0 && SelectedObject is { } pathObj)
+            {
+                Vec2 start = new(pathObj.X, pathObj.Y);
+                Vec2[] points = MoverPath.CanonicalPoints(start, pathObj.GetAttr("path"));
+                if (_polylinePointDrag < points.Length)
+                {
+                    (int x, int y) = e.KeyModifiers.HasFlag(KeyModifiers.Shift)
+                        ? SnapAngle(points[_polylinePointDrag - 1], levelPt)
+                        : Snap(levelPt);
+                    pathObj.SetAttr("path", MoverPath.MoveCanonicalPoint(
+                        start, pathObj.GetAttr("path"), _polylinePointDrag, new Vec2(x, y)));
+                    SelectedObjectMoved?.Invoke();
+                    InvalidateVisual();
+                }
+                return;
+            }
+
             if (_panning)
             {
                 ScrollBy(_panLast.X - p.X, _panLast.Y - p.Y);
@@ -460,7 +647,18 @@ namespace CtrDxEditor.Rendering
                 ObjectRotation.Handle dial = HitRotationDial(levelPt);
                 SetDialKnobHovered(dial == ObjectRotation.Handle.Knob);
                 SpikeResize.Handle spikeHandle = HitSpikeResize(levelPt);
-                Cursor = dial != ObjectRotation.Handle.None ? new Cursor(StandardCursorType.Hand)
+                int oldHoverPoint = _polylineHoverPoint;
+                bool oldNubHot = _polylineNubHot;
+                _polylineHoverPoint = HitPolylinePoint(levelPt);
+                _polylineNubHot = HitPolylineNub(levelPt);
+                bool overPolylineInsert = HitPolylineSegment(levelPt) >= 0;
+                if (oldHoverPoint != _polylineHoverPoint || oldNubHot != _polylineNubHot)
+                {
+                    InvalidateVisual();
+                }
+                Cursor = _polylineNubHot || _polylineHoverPoint > 0 || overPolylineInsert
+                    ? new Cursor(StandardCursorType.Hand)
+                    : dial != ObjectRotation.Handle.None ? new Cursor(StandardCursorType.Hand)
                     : spikeHandle != SpikeResize.Handle.None ? CursorForSpikeResize()
                     : OnRadiusEdge(levelPt) ? ResizeCursor : CursorForHandle(handle);
                 return;
@@ -496,7 +694,7 @@ namespace CtrDxEditor.Rendering
         {
             // Capture loss (including the release path's own Capture(null)) can fire with nothing in
             // progress; skip the resets and completion callback unless a gesture is actually active.
-            bool gestureActive = _dragging || _panning || _resizingRadius
+            bool gestureActive = _dragging || _panning || _resizingRadius || _polylinePointDrag > 0
                 || _railDrag != GrabRail.Handle.None || _spikeResizeDrag != SpikeResize.Handle.None
                 || _rotating || _hookHovered;
             if (!gestureActive)
@@ -504,7 +702,7 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
-            bool editedDocument = _dragging || _resizingRadius
+            bool editedDocument = _dragging || _resizingRadius || _polylinePointDrag > 0
                 || _railDrag != GrabRail.Handle.None || _spikeResizeDrag != SpikeResize.Handle.None || _rotating;
             _dragging = false;
             _panning = false;
@@ -512,6 +710,7 @@ namespace CtrDxEditor.Rendering
             _railDrag = GrabRail.Handle.None;
             _spikeResizeDrag = SpikeResize.Handle.None;
             _rotating = false;
+            _polylinePointDrag = -1;
             if (editedDocument)
             {
                 CompleteDocumentEdit?.Invoke();
@@ -526,6 +725,25 @@ namespace CtrDxEditor.Rendering
             base.OnPointerExited(e);
             SetHookHovered(false); // don't leave the hook lit when the cursor leaves the canvas
             SetDialKnobHovered(false); // nor the rotation knob
+            if (_polylineHoverPoint != -1 || _polylineNubHot)
+            {
+                _polylineHoverPoint = -1;
+                _polylineNubHot = false;
+                InvalidateVisual();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if ((e.Key == Key.Delete || e.Key == Key.Back) && _polylineHoverPoint > 0)
+            {
+                DeleteSelectedPolylineVertex(_polylineHoverPoint);
+                e.Handled = true;
+                return;
+            }
+
+            base.OnKeyDown(e);
         }
 
         /// <inheritdoc />

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Input.cs
@@ -289,6 +289,26 @@ namespace CtrDxEditor.Rendering
             return (dx * dx) + (dy * dy) <= tolerance * tolerance;
         }
 
+        /// <summary>
+        /// True when hovering the end of a selected editable polyline that has hit its point cap, so the missing
+        /// append nub gets an explanatory hint instead of just silently vanishing.
+        /// </summary>
+        private bool HoveringPolylineLimit(Vec2 levelPt)
+        {
+            if (SelectedObject is not { } obj || View.Zoom <= 0 || !IsEditablePolyline(obj)
+                || IsAnimatingInPreview(obj)
+                || MoverPath.CanAddCanonicalPoint(new Vec2(obj.X, obj.Y), obj.GetAttr("path")))
+            {
+                return false;
+            }
+
+            Vec2 nub = PolylineNubPoint(obj);
+            double tolerance = 22 / View.Zoom;
+            double dx = nub.X - levelPt.X;
+            double dy = nub.Y - levelPt.Y;
+            return (dx * dx) + (dy * dy) <= tolerance * tolerance;
+        }
+
         /// <summary>Rounds a point to whole units after snapping its direction from an anchor to 45-degree increments.</summary>
         private static (int X, int Y) SnapAngle(Vec2 anchor, Vec2 point)
         {
@@ -654,10 +674,12 @@ namespace CtrDxEditor.Rendering
                 SpikeResize.Handle spikeHandle = HitSpikeResize(levelPt);
                 int oldHoverPoint = _polylineHoverPoint;
                 bool oldNubHot = _polylineNubHot;
+                bool oldLimitHint = _polylineAtLimitHint;
                 _polylineHoverPoint = HitPolylinePoint(levelPt);
                 _polylineNubHot = HitPolylineNub(levelPt);
+                _polylineAtLimitHint = HoveringPolylineLimit(levelPt);
                 bool overPolylineInsert = HitPolylineSegment(levelPt) >= 0;
-                if (oldHoverPoint != _polylineHoverPoint || oldNubHot != _polylineNubHot)
+                if (oldHoverPoint != _polylineHoverPoint || oldNubHot != _polylineNubHot || oldLimitHint != _polylineAtLimitHint)
                 {
                     InvalidateVisual();
                 }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -173,17 +173,22 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
+            bool canAddPoint = MoverPath.CanAddCanonicalPoint(new Vec2(obj.X, obj.Y), path);
+
             // Segment midpoint insert dots use fuller opacity so they read as interactive handles.
-            using (context.PushOpacity(0.6))
+            if (canAddPoint)
             {
-                for (int i = 0; i < points.Length - 1; i++)
+                using (context.PushOpacity(0.6))
                 {
-                    Vec2 midpoint = new(
-                        (points[i].X + points[i + 1].X) / 2,
-                        (points[i].Y + points[i + 1].Y) / 2);
-                    Vec2 screen = v.LevelToScreen(midpoint);
-                    context.DrawEllipse(Brushes.White, _palette.OrbitPathArrow,
-                        new Point(screen.X, screen.Y), 3, 3);
+                    for (int i = 0; i < points.Length - 1; i++)
+                    {
+                        Vec2 midpoint = new(
+                            (points[i].X + points[i + 1].X) / 2,
+                            (points[i].Y + points[i + 1].Y) / 2);
+                        Vec2 screen = v.LevelToScreen(midpoint);
+                        context.DrawEllipse(Brushes.White, _palette.OrbitPathArrow,
+                            new Point(screen.X, screen.Y), 3, 3);
+                    }
                 }
             }
 
@@ -197,6 +202,11 @@ namespace CtrDxEditor.Rendering
                 {
                     context.DrawEllipse(null, _palette.OrbitPathArrow, center, 8, 8);
                 }
+            }
+
+            if (!canAddPoint)
+            {
+                return;
             }
 
             // The append nub follows the tip and fills when hovered.

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -139,6 +139,7 @@ namespace CtrDxEditor.Rendering
                 {
                     context.DrawLine(pen, points[i], points[(i + 1) % points.Length]);
                 }
+                DrawPolylinePointHandles(context, v, selected);
             }
 
             if (selected is not null && RotationTable.For(selected.Type) is { } rotSpec)
@@ -155,6 +156,63 @@ namespace CtrDxEditor.Rendering
                     LevelSceneRenderer.DrawSpritePreview(context, v, ghostSprite, ghostElement, _ghostLevel.X, _ghostLevel.Y);
                 }
             }
+        }
+
+        /// <summary>Draws editable handles, segment inserts, and the append nub for the selected polyline path.</summary>
+        private void DrawPolylinePointHandles(DrawingContext context, ViewTransform v, LevelObject obj)
+        {
+            string? path = obj.GetAttr("path");
+            if (string.IsNullOrWhiteSpace(path) || MoverPath.IsCircularPath(path))
+            {
+                return;
+            }
+
+            Vec2[] points = MoverPath.CanonicalPoints(new Vec2(obj.X, obj.Y), path);
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            // Segment midpoint insert dots use fuller opacity so they read as interactive handles.
+            using (context.PushOpacity(0.6))
+            {
+                for (int i = 0; i < points.Length - 1; i++)
+                {
+                    Vec2 midpoint = new(
+                        (points[i].X + points[i + 1].X) / 2,
+                        (points[i].Y + points[i + 1].Y) / 2);
+                    Vec2 screen = v.LevelToScreen(midpoint);
+                    context.DrawEllipse(Brushes.White, _palette.OrbitPathArrow,
+                        new Point(screen.X, screen.Y), 3, 3);
+                }
+            }
+
+            // Waypoint handles are solid, with an outer ring when hovered or dragged.
+            for (int i = 1; i < points.Length; i++)
+            {
+                Vec2 screen = v.LevelToScreen(points[i]);
+                Point center = new(screen.X, screen.Y);
+                context.DrawEllipse(Brushes.White, _palette.OrbitPathArrow, center, 5, 5);
+                if (i == _polylineHoverPoint || i == _polylinePointDrag)
+                {
+                    context.DrawEllipse(null, _palette.OrbitPathArrow, center, 8, 8);
+                }
+            }
+
+            // The append nub follows the tip and fills when hovered.
+            Vec2 nub = PolylineNubPoint(obj);
+            Vec2 nubScreen = v.LevelToScreen(nub);
+            Point nubCenter = new(nubScreen.X, nubScreen.Y);
+            context.DrawEllipse(
+                _polylineNubHot ? Brushes.White : Brushes.Transparent,
+                _palette.OrbitPathArrow,
+                nubCenter,
+                7,
+                7);
+            context.DrawLine(_palette.OrbitPathArrow,
+                new Point(nubScreen.X - 3, nubScreen.Y), new Point(nubScreen.X + 3, nubScreen.Y));
+            context.DrawLine(_palette.OrbitPathArrow,
+                new Point(nubScreen.X, nubScreen.Y - 3), new Point(nubScreen.X, nubScreen.Y + 3));
         }
 
         /// <summary>

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 using Avalonia;
@@ -10,6 +11,7 @@ using CtrDxEditor.Content;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
+using CtrDxEditor.Localization;
 
 namespace CtrDxEditor.Rendering
 {
@@ -158,6 +160,32 @@ namespace CtrDxEditor.Rendering
                     LevelSceneRenderer.DrawSpritePreview(context, v, ghostSprite, ghostElement, _ghostLevel.X, _ghostLevel.Y);
                 }
             }
+
+            if (_polylineAtLimitHint && SelectedObject is { } limitObj)
+            {
+                DrawPolylineLimitHint(context, v, limitObj);
+            }
+        }
+
+        /// <summary>
+        /// Draws a small labelled hint at the end of a full polyline, explaining why the append nub is gone once
+        /// the path has hit its stored-point cap.
+        /// </summary>
+        private void DrawPolylineLimitHint(DrawingContext context, ViewTransform v, LevelObject obj)
+        {
+            Vec2 nub = v.LevelToScreen(PolylineNubPoint(obj));
+            FormattedText text = new(
+                Localizer.Get("Hint.PolylinePointLimit"),
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily.DefaultFontFamilyName),
+                12.0,
+                Brushes.White);
+
+            Point origin = new(nub.X + 12.0, nub.Y - (text.Height / 2.0));
+            Rect box = new(origin.X - 6.0, origin.Y - 3.0, text.Width + 12.0, text.Height + 6.0);
+            context.FillRectangle(new SolidColorBrush(Color.FromArgb(220, 0, 0, 0)), box, 4.0f);
+            context.DrawText(text, origin);
         }
 
         /// <summary>Draws editable handles, segment inserts, and the append nub for the selected polyline path.</summary>

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -128,7 +128,9 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            LevelObject? selected = SelectedObject;
+            // Selection chrome (outline, edit handles, rotation dial) is hidden while the selected object is a
+            // moving preview target — it isn't pickable, and drawing chrome at its stale home position would mislead.
+            LevelObject? selected = SelectedObject is { } s && !IsAnimatingInPreview(s) ? s : null;
             if (selected is not null)
             {
                 LevelBounds sb = LevelSceneRenderer.SelectionBounds(sprites, selected, ActiveCandySkin, ActiveOmNomSupport, doc.NightLevel);
@@ -395,6 +397,16 @@ namespace CtrDxEditor.Rendering
         {
             return AnimationPreviewMode == CtrDxEditor.ViewModels.AnimationPreviewMode.All
                 || (AnimationPreviewMode == CtrDxEditor.ViewModels.AnimationPreviewMode.Focused && Equals(AnimationPreviewObject, obj));
+        }
+
+        /// <summary>
+        /// True when the object is animating during preview — moving along a path/orbit or spinning in place — so
+        /// its drawn transform no longer matches its authored one. Such an object can't be picked and its selection
+        /// chrome (outline, handles, rotation ring) is hidden until the preview stops.
+        /// </summary>
+        private bool IsAnimatingInPreview(LevelObject obj)
+        {
+            return IsAnimationPreviewing(obj) && (MoverPath.HasActiveMovement(obj) || ObjectSpin.IsSpinning(obj));
         }
 
         private double PreviewSpinDegrees(LevelObject obj)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -79,7 +79,7 @@ namespace CtrDxEditor.Rendering
             {
                 if (ShowMovementPaths)
                 {
-                    LevelSceneRenderer.DrawOrbitPath(context, v, obj, _palette.OrbitPath, _palette.OrbitPathArrow);
+                    LevelSceneRenderer.DrawMovementPath(context, v, obj, _palette.OrbitPath, _palette.OrbitPathArrow);
                 }
                 if (!IsAnimationPreviewing(obj))
                 {

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -342,6 +342,23 @@ namespace CtrDxEditor.Rendering
             {
                 ScrollTo(HorizontalScrollValue, VerticalScrollValue);
             }
+            else if (change.Property == SelectedObjectProperty)
+            {
+                _polylinePointDrag = -1;
+                ResetPolylineHover();
+            }
+        }
+
+        /// <summary>Clears selected-polyline hover chrome and repaints when it was visible.</summary>
+        private void ResetPolylineHover()
+        {
+            bool changed = _polylineHoverPoint != -1 || _polylineNubHot;
+            _polylineHoverPoint = -1;
+            _polylineNubHot = false;
+            if (changed)
+            {
+                InvalidateVisual();
+            }
         }
 
     }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -235,6 +235,15 @@ namespace CtrDxEditor.Rendering
         /// <summary>True while the cursor hovers the selected object's rotation knob (lights it up).</summary>
         private bool _dialKnobHovered;
 
+        /// <summary>Canonical waypoint currently being dragged, or -1 when no path point drag is active.</summary>
+        private int _polylinePointDrag = -1;
+
+        /// <summary>Canonical waypoint currently under the pointer, or -1.</summary>
+        private int _polylineHoverPoint = -1;
+
+        /// <summary>True while the pointer is over the append nub of the selected polyline.</summary>
+        private bool _polylineNubHot;
+
         /// <summary>Level-space offset from the dragged object's origin to the pointer, held constant during a drag.</summary>
         private Vec2 _dragOffset;
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -244,6 +244,9 @@ namespace CtrDxEditor.Rendering
         /// <summary>True while the pointer is over the append nub of the selected polyline.</summary>
         private bool _polylineNubHot;
 
+        /// <summary>True while hovering the end of a selected polyline that has hit its point cap (shows the limit hint).</summary>
+        private bool _polylineAtLimitHint;
+
         /// <summary>Level-space offset from the dragged object's origin to the pointer, held constant during a drag.</summary>
         private Vec2 _dragOffset;
 
@@ -352,9 +355,10 @@ namespace CtrDxEditor.Rendering
         /// <summary>Clears selected-polyline hover chrome and repaints when it was visible.</summary>
         private void ResetPolylineHover()
         {
-            bool changed = _polylineHoverPoint != -1 || _polylineNubHot;
+            bool changed = _polylineHoverPoint != -1 || _polylineNubHot || _polylineAtLimitHint;
             _polylineHoverPoint = -1;
             _polylineNubHot = false;
+            _polylineAtLimitHint = false;
             if (changed)
             {
                 InvalidateVisual();

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -861,6 +861,51 @@ namespace CtrDxEditor.Rendering
             }
         }
 
+        /// <summary>Draws the movement path used by active DX mover data.</summary>
+        public static void DrawMovementPath(DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pathPen, Pen arrowPen)
+        {
+            if (ObjectSpin.IsOrbital(obj))
+            {
+                DrawOrbitPath(ctx, v, obj, pathPen, arrowPen);
+                return;
+            }
+
+            Point[] points = ComputeMovementPathPoints(v, obj);
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            for (int i = 0; i < points.Length; i++)
+            {
+                ctx.DrawLine(pathPen, points[i], points[(i + 1) % points.Length]);
+            }
+        }
+
+        /// <summary>Computes screen-space points for the active DX movement path.</summary>
+        public static Point[] ComputeMovementPathPoints(ViewTransform v, LevelObject obj)
+        {
+            if (!MoverPath.HasActiveMovement(obj))
+            {
+                return [];
+            }
+
+            if (ObjectSpin.IsOrbital(obj))
+            {
+                return ComputeOrbitPathPoints(v, obj);
+            }
+
+            Vec2[] points = MoverPath.Points(new Vec2(obj.X, obj.Y), obj.GetAttr("path"));
+            Point[] screenPoints = new Point[points.Length];
+            for (int i = 0; i < points.Length; i++)
+            {
+                Vec2 screen = v.LevelToScreen(points[i]);
+                screenPoints[i] = new Point(screen.X, screen.Y);
+            }
+
+            return screenPoints;
+        }
+
         /// <summary>Computes screen-space points for the circular orbit path centered on authored object coordinates.</summary>
         public static Point[] ComputeOrbitPathPoints(ViewTransform v, LevelObject obj)
         {

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -876,10 +876,41 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
+            // Draw each traversal segment with a mid-segment chevron pointing the way the object travels,
+            // so the loop's winding (and the back-and-forth of a retrace) is legible like the orbit arrow.
             for (int i = 0; i < points.Length; i++)
             {
-                ctx.DrawLine(pathPen, points[i], points[(i + 1) % points.Length]);
+                Point a = points[i];
+                Point b = points[(i + 1) % points.Length];
+                ctx.DrawLine(pathPen, a, b);
+                DrawSegmentArrow(ctx, arrowPen, a, b);
             }
+        }
+
+        /// <summary>Draws a small chevron at the midpoint of <paramref name="a"/>→<paramref name="b"/> pointing toward b.</summary>
+        private static void DrawSegmentArrow(DrawingContext ctx, Pen arrowPen, Point a, Point b)
+        {
+            double dx = b.X - a.X;
+            double dy = b.Y - a.Y;
+            double length = Math.Sqrt((dx * dx) + (dy * dy));
+            if (length < 12.0)
+            {
+                return;
+            }
+
+            double ux = dx / length;
+            double uy = dy / length;
+            Point mid = new((a.X + b.X) / 2.0, (a.Y + b.Y) / 2.0);
+
+            const double barb = 6.0;
+            const double cos = 0.866; // 30° barb spread
+            const double sin = 0.5;
+            double rx = -ux;
+            double ry = -uy;
+            Point left = new(mid.X + (barb * ((rx * cos) - (ry * sin))), mid.Y + (barb * ((rx * sin) + (ry * cos))));
+            Point right = new(mid.X + (barb * ((rx * cos) + (ry * sin))), mid.Y + (barb * ((-rx * sin) + (ry * cos))));
+            ctx.DrawLine(arrowPen, mid, left);
+            ctx.DrawLine(arrowPen, mid, right);
         }
 
         /// <summary>Computes screen-space points for the active DX movement path.</summary>

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -876,14 +876,28 @@ namespace CtrDxEditor.Rendering
                 return;
             }
 
-            // Draw each traversal segment with a mid-segment chevron pointing the way the object travels,
-            // so the loop's winding (and the back-and-forth of a retrace) is legible like the orbit arrow.
             for (int i = 0; i < points.Length; i++)
             {
-                Point a = points[i];
-                Point b = points[(i + 1) % points.Length];
-                ctx.DrawLine(pathPen, a, b);
-                DrawSegmentArrow(ctx, arrowPen, a, b);
+                ctx.DrawLine(pathPen, points[i], points[(i + 1) % points.Length]);
+            }
+
+            // A loop reads one way all the way round, so arrow every segment. A back-and-forth (retrace) path is
+            // stored as an out-and-back palindrome whose return segments overlap the outbound ones — arrowing all
+            // of them would draw contradictory '><' chevrons, so only arrow the outbound half (first length/2).
+            if (MoverPath.IsRetrace(obj.GetAttr("path")))
+            {
+                int outboundSegments = points.Length / 2;
+                for (int i = 0; i < outboundSegments; i++)
+                {
+                    DrawSegmentArrow(ctx, arrowPen, points[i], points[i + 1]);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < points.Length; i++)
+                {
+                    DrawSegmentArrow(ctx, arrowPen, points[i], points[(i + 1) % points.Length]);
+                }
             }
         }
 

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -35,7 +35,7 @@ namespace CtrDxEditor.ViewModels
             IsNumeric = type is AttrType.Whole or AttrType.Number;
             AllowsDecimal = type == AttrType.Number;
             EnumValues = enumValues;
-            EnumOptions = enumValues?.Select(v => new AttributeOptionViewModel(v, LabelForOption(name, v))).ToArray();
+            EnumOptions = enumValues?.Select(v => new AttributeOptionViewModel(v, Localizer.AttributeOption(name, v))).ToArray();
             _get = () => target.GetAttr(name);
             _set = v => target.SetAttr(name, v ?? string.Empty);
             _onChanging = onChanging ?? (() => { });
@@ -167,18 +167,6 @@ namespace CtrDxEditor.ViewModels
             OnPropertyChanged(nameof(Value));
             OnPropertyChanged(nameof(SelectedOption));
             OnPropertyChanged(nameof(BoolValue));
-        }
-
-        private static string LabelForOption(string attribute, string value)
-        {
-            return attribute == "part"
-                ? value switch
-                {
-                    "L" => "left",
-                    "R" => "right",
-                    _ => value,
-                }
-                : value;
         }
 
         private string? DisplayValue(string? value)

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -110,7 +110,7 @@ namespace CtrDxEditor.ViewModels
         public int NumericMinimum => Name switch
         {
             "timeout" => 1,
-            "spinSpeed" or "orbitRadius" or "orbitSpeed" => 1,
+            "spinSpeed" or "orbitRadius" or "orbitSpeed" or "polylineSpeed" => 1,
             "length" or "radius" or "moveLength" or "moveOffset" or "litRadius" => 0,
             _ => -9999,
         };

--- a/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/AttributeFieldViewModel.cs
@@ -19,6 +19,7 @@ namespace CtrDxEditor.ViewModels
         private readonly Action<string?> _set;
         private readonly Action _onChanging;
         private readonly Action _onChanged;
+        private readonly Func<bool>? _isEnabledFn;
 
         /// <summary>Attribute-backed field (text, number, bool, or fixed enum).</summary>
         public AttributeFieldViewModel(
@@ -61,14 +62,19 @@ namespace CtrDxEditor.ViewModels
             _onChanged = onChanged;
         }
 
-        /// <summary>Delegate-backed simple field (bool/text/number) with no fixed option list.</summary>
+        /// <summary>
+        /// Delegate-backed simple field (bool/text/number) with no fixed option list. The optional
+        /// <paramref name="isEnabled"/> predicate greys the field out when it returns false (re-evaluated on
+        /// <see cref="Refresh"/>).
+        /// </summary>
         public AttributeFieldViewModel(
             string name,
             AttrType type,
             Func<string?> get,
             Action<string?> set,
             Action onChanged,
-            Action? onChanging = null)
+            Action? onChanging = null,
+            Func<bool>? isEnabled = null)
         {
             Name = name;
             Label = Localizer.AttributeName(name);
@@ -79,6 +85,11 @@ namespace CtrDxEditor.ViewModels
             _set = set;
             _onChanging = onChanging ?? (() => { });
             _onChanged = onChanged;
+            _isEnabledFn = isEnabled;
+            if (isEnabled is not null)
+            {
+                IsEnabled = isEnabled();
+            }
         }
 
         /// <summary>The raw attribute id / field key (never localized).</summary>
@@ -167,6 +178,10 @@ namespace CtrDxEditor.ViewModels
             OnPropertyChanged(nameof(Value));
             OnPropertyChanged(nameof(SelectedOption));
             OnPropertyChanged(nameof(BoolValue));
+            if (_isEnabledFn is not null)
+            {
+                IsEnabled = _isEnabledFn();
+            }
         }
 
         private string? DisplayValue(string? value)

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -74,6 +74,11 @@ namespace CtrDxEditor.ViewModels
         /// <summary>True when a level is open and editor-only commands can run.</summary>
         public bool HasDocument => Document is not null;
 
+        /// <summary>Whether the selected object has a non-circular polyline path with direct-edit handles.</summary>
+        public bool CanEditPolyline => SelectedObject is { } obj
+            && !string.IsNullOrWhiteSpace(obj.GetAttr("path"))
+            && !MoverPath.IsCircularPath(obj.GetAttr("path"));
+
         /// <summary>True when an undo snapshot is available.</summary>
         public bool CanUndo => _undoStack.Count > 0;
 
@@ -407,6 +412,7 @@ namespace CtrDxEditor.ViewModels
 
         partial void OnSelectedObjectChanged(LevelObject? value)
         {
+            OnPropertyChanged(nameof(CanEditPolyline));
             PopulateFields(value);
         }
 

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -176,8 +176,17 @@ namespace CtrDxEditor.ViewModels
                             SetPolyline(value);
                             break;
                         default:
-                            value.RemoveAttr("path");
                             value.RemoveAttr("moveSpeed");
+                            // Keep the static spin-carrier path if the object still spins; only a non-spinner
+                            // clears the path entirely.
+                            if (ObjectSpin.IsSpinning(value))
+                            {
+                                value.SetAttr("path", ObjectSpin.StaticPath);
+                            }
+                            else
+                            {
+                                value.RemoveAttr("path");
+                            }
                             break;
                     }
 
@@ -387,7 +396,17 @@ namespace CtrDxEditor.ViewModels
         private static string MovementMode(LevelObject value)
         {
             string? path = value.GetAttr("path");
-            return string.IsNullOrWhiteSpace(path) ? "none" : IsOrbitEditingPath(path) ? "orbit" : "polyline";
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return "none";
+            }
+            if (IsOrbitEditingPath(path))
+            {
+                return "orbit";
+            }
+
+            // A bare spinner stores the static "0,0" path to host rotateSpeed; that is not polyline movement.
+            return MoverPath.IsPolylineMovement(path) ? "polyline" : "none";
         }
 
         private static bool IsOrbitEditingPath(string path)
@@ -397,7 +416,9 @@ namespace CtrDxEditor.ViewModels
 
         private static void SetPolyline(LevelObject value)
         {
-            if (string.IsNullOrWhiteSpace(value.GetAttr("path")) || IsOrbitEditingPath(value.GetAttr("path")!))
+            // Seed a real segment unless the object already has one — covers empty, orbit, and the static "0,0"
+            // spin-carrier path (so enabling polyline while spinning still gives it a movement path).
+            if (!MoverPath.IsPolylineMovement(value.GetAttr("path")))
             {
                 value.SetAttr("path", "100,0");
             }

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -192,7 +192,7 @@ namespace CtrDxEditor.ViewModels
             }
             else if (movementMode == "polyline")
             {
-                BuildPolyline(fields, value, onChanged, onChanging);
+                BuildPolyline(fields, value, onChanged, onChanging, Structural);
             }
         }
 
@@ -295,7 +295,8 @@ namespace CtrDxEditor.ViewModels
             IList<AttributeFieldViewModel> fields,
             LevelObject value,
             Action onChanged,
-            Action onChanging)
+            Action onChanging,
+            Action structural)
         {
             fields.Add(new AttributeFieldViewModel(
                 "polylineSpeed",
@@ -322,6 +323,8 @@ namespace CtrDxEditor.ViewModels
                 onChanged,
                 onChanging));
 
+            // A single straight segment is inherently back-and-forth, so the retrace toggle is a no-op there
+            // and shows disabled; it becomes meaningful once the path has at least two waypoints.
             fields.Add(new AttributeFieldViewModel(
                 "polylineRetrace",
                 AttrType.Bool,
@@ -331,8 +334,25 @@ namespace CtrDxEditor.ViewModels
                     Vec2 start = new(value.X, value.Y);
                     value.SetAttr("path", MoverPath.SetRetrace(start, value.GetAttr("path"), v == "true"));
                 },
+                structural,
+                onChanging,
+                isEnabled: () => MoverPath.CanRetrace(new Vec2(value.X, value.Y), value.GetAttr("path"))));
+
+            // Direction is only meaningful for a closed loop; for lines/retraces the checkbox is greyed out
+            // (shown checked as the clockwise default). The game has no direction flag, so flipping it just
+            // reverses the stored point order.
+            fields.Add(new AttributeFieldViewModel(
+                "polylineClockwise",
+                AttrType.Bool,
+                () => MoverPath.IsCanonicalClockwise(new Vec2(value.X, value.Y), value.GetAttr("path")) ? "true" : "false",
+                v =>
+                {
+                    Vec2 start = new(value.X, value.Y);
+                    value.SetAttr("path", MoverPath.SetClockwise(start, value.GetAttr("path"), v == "true"));
+                },
                 onChanged,
-                onChanging));
+                onChanging,
+                isEnabled: () => MoverPath.IsClosedLoop(new Vec2(value.X, value.Y), value.GetAttr("path"))));
         }
 
         private static string SpinSpeedValue(LevelObject value)

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using CtrDxEditor.Core.Descriptors;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
+using CtrDxEditor.Core.Geometry;
 
 namespace CtrDxEditor.ViewModels
 {
@@ -41,8 +42,6 @@ namespace CtrDxEditor.ViewModels
 
             bool spinning = ObjectSpin.IsSpinning(value);
             bool spinClockwise = ObjectSpin.SpinClockwise(value);
-            bool orbital = ObjectSpin.IsOrbital(value);
-            bool orbitClockwise = ObjectSpin.OrbitClockwise(value);
 
             AttributeFieldViewModel spin = new(
                 "spin",
@@ -134,120 +133,211 @@ namespace CtrDxEditor.ViewModels
                     onChanging));
             }
 
+            BuildMovement(fields, value, onChanged, onChanging, rebuild);
+        }
+
+        private static void BuildMovement(
+            IList<AttributeFieldViewModel> fields,
+            LevelObject value,
+            Action onChanged,
+            Action onChanging,
+            Action rebuild)
+        {
+            void Structural()
+            {
+                onChanged();
+                rebuild();
+            }
+
+            string movementMode = MovementMode(value);
+            bool orbitClockwise = ObjectSpin.OrbitClockwise(value);
+
             fields.Add(new AttributeFieldViewModel(
-                "spinOrbital",
-                AttrType.Bool,
-                () => orbital ? "true" : "false",
+                "movementMode",
+                [
+                    new AttributeOptionViewModel("none", "none"),
+                    new AttributeOptionViewModel("orbit", "orbit"),
+                    new AttributeOptionViewModel("polyline", "polyline"),
+                ],
+                () => movementMode,
                 v =>
                 {
-                    bool enabled = v == "true";
-
-                    int orbitRadius = ObjectSpin.OrbitRadius(value);
-                    if (enabled && orbitRadius <= 0)
+                    switch (v)
                     {
-                        orbitRadius = ObjectSpin.DefaultOrbitRadius;
+                        case "orbit":
+                            ObjectSpin.SetOrbital(
+                                value,
+                                enabled: true,
+                                ObjectSpin.OrbitRadius(value),
+                                ObjectSpin.OrbitClockwise(value));
+                            break;
+                        case "polyline":
+                            SetPolyline(value);
+                            break;
+                        default:
+                            value.RemoveAttr("path");
+                            value.RemoveAttr("moveSpeed");
+                            break;
                     }
-
-                    ObjectSpin.SetOrbital(
-                        value,
-                        enabled,
-                        orbitRadius,
-                        orbitClockwise);
 
                     Structural();
                 },
                 Structural,
                 onChanging));
 
-            if (orbital)
+            if (movementMode == "orbit")
             {
-                fields.Add(new AttributeFieldViewModel(
-                    "orbitRadius",
-                    AttrType.Whole,
-                    () => OrbitRadiusValue(value),
-                    v =>
+                BuildOrbit(fields, value, onChanged, onChanging, orbitClockwise);
+            }
+            else if (movementMode == "polyline")
+            {
+                BuildPolyline(fields, value, onChanged, onChanging);
+            }
+        }
+
+        private static void BuildOrbit(
+            IList<AttributeFieldViewModel> fields,
+            LevelObject value,
+            Action onChanged,
+            Action onChanging,
+            bool orbitClockwise)
+        {
+            fields.Add(new AttributeFieldViewModel(
+                "orbitRadius",
+                AttrType.Whole,
+                () => OrbitRadiusValue(value),
+                v =>
+                {
+                    int radius = int.TryParse(
+                        v,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out int parsed)
+                            ? parsed
+                            : 0;
+
+                    if (radius <= 0)
                     {
-                        int radius = int.TryParse(
-                            v,
-                            NumberStyles.Integer,
-                            CultureInfo.InvariantCulture,
-                            out int parsed)
-                                ? parsed
-                                : 0;
+                        value.SetAttr("path", OrbitPrefix(orbitClockwise) + (v ?? string.Empty));
+                        return;
+                    }
 
-                        if (radius <= 0)
-                        {
-                            value.SetAttr("path", OrbitPrefix(orbitClockwise) + (v ?? string.Empty));
-                            return;
-                        }
+                    ObjectSpin.SetOrbital(
+                        value,
+                        enabled: true,
+                        radius,
+                        orbitClockwise);
+                },
+                onChanged,
+                onChanging));
 
+            fields.Add(new AttributeFieldViewModel(
+                "orbitSpeed",
+                AttrType.Whole,
+                () => MoveSpeedValue(value),
+                v =>
+                {
+                    int speed = int.TryParse(
+                        v,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out int parsed)
+                            ? parsed
+                            : 0;
+
+                    if (speed <= 0)
+                    {
+                        value.SetAttr("moveSpeed", v ?? string.Empty);
+                        return;
+                    }
+
+                    ObjectSpin.SetOrbitSpeed(value, speed);
+                },
+                onChanged,
+                onChanging));
+
+            fields.Add(new AttributeFieldViewModel(
+                "orbitClockwise",
+                AttrType.Bool,
+                () => orbitClockwise ? "true" : "false",
+                v =>
+                {
+                    orbitClockwise = v == "true";
+                    string radiusValue = OrbitRadiusValue(value);
+                    string speedValue = MoveSpeedValue(value);
+                    if (int.TryParse(radiusValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0)
+                    {
                         ObjectSpin.SetOrbital(
                             value,
                             enabled: true,
                             radius,
-                            orbitClockwise);
-                    },
-                    onChanged,
-                    onChanging));
-
-                fields.Add(new AttributeFieldViewModel(
-                    "orbitSpeed",
-                    AttrType.Whole,
-                    () => OrbitSpeedValue(value),
-                    v =>
-                    {
-                        int speed = int.TryParse(
-                            v,
-                            NumberStyles.Integer,
-                            CultureInfo.InvariantCulture,
-                            out int parsed)
-                                ? parsed
-                                : 0;
-
-                        if (speed <= 0)
+                            clockwise: orbitClockwise);
+                        if (int.TryParse(speedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int speed) && speed > 0)
                         {
-                            value.SetAttr("moveSpeed", v ?? string.Empty);
-                            return;
-                        }
-
-                        ObjectSpin.SetOrbitSpeed(value, speed);
-                    },
-                    onChanged,
-                    onChanging));
-
-                fields.Add(new AttributeFieldViewModel(
-                    "orbitClockwise",
-                    AttrType.Bool,
-                    () => orbitClockwise ? "true" : "false",
-                    v =>
-                    {
-                        orbitClockwise = v == "true";
-                        string radiusValue = OrbitRadiusValue(value);
-                        string speedValue = OrbitSpeedValue(value);
-                        if (int.TryParse(radiusValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius) && radius > 0)
-                        {
-                            ObjectSpin.SetOrbital(
-                                value,
-                                enabled: true,
-                                radius,
-                                clockwise: orbitClockwise);
-                            if (int.TryParse(speedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int speed) && speed > 0)
-                            {
-                                ObjectSpin.SetOrbitSpeed(value, speed);
-                            }
-                            else
-                            {
-                                value.SetAttr("moveSpeed", speedValue);
-                            }
+                            ObjectSpin.SetOrbitSpeed(value, speed);
                         }
                         else
                         {
-                            value.SetAttr("path", OrbitPrefix(orbitClockwise) + radiusValue);
+                            value.SetAttr("moveSpeed", speedValue);
                         }
-                    },
-                    onChanged,
-                    onChanging));
-            }
+                    }
+                    else
+                    {
+                        value.SetAttr("path", OrbitPrefix(orbitClockwise) + radiusValue);
+                    }
+                },
+                onChanged,
+                onChanging));
+        }
+
+        private static void BuildPolyline(
+            IList<AttributeFieldViewModel> fields,
+            LevelObject value,
+            Action onChanged,
+            Action onChanging)
+        {
+            fields.Add(new AttributeFieldViewModel(
+                "polylineSpeed",
+                AttrType.Whole,
+                () => MoveSpeedValue(value),
+                v =>
+                {
+                    int speed = int.TryParse(
+                        v,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out int parsed)
+                            ? parsed
+                            : 0;
+
+                    if (speed <= 0)
+                    {
+                        value.SetAttr("moveSpeed", v ?? string.Empty);
+                        return;
+                    }
+
+                    ObjectSpin.SetOrbitSpeed(value, speed);
+                },
+                onChanged,
+                onChanging));
+
+            fields.Add(new AttributeFieldViewModel(
+                "polylineLoop",
+                AttrType.Bool,
+                () => "true",
+                v =>
+                {
+                    if (v != "false")
+                    {
+                        return;
+                    }
+
+                    Vec2 start = new(value.X, value.Y);
+                    Vec2[] points = MoverPath.Points(start, value.GetAttr("path"));
+                    value.SetAttr("path", MoverPath.SerializePlain(start, points, loop: false));
+                },
+                onChanged,
+                onChanging));
         }
 
         private static string SpinSpeedValue(LevelObject value)
@@ -266,7 +356,7 @@ namespace CtrDxEditor.ViewModels
                 : ObjectSpin.OrbitRadius(value).ToString(CultureInfo.InvariantCulture);
         }
 
-        private static string OrbitSpeedValue(LevelObject value)
+        private static string MoveSpeedValue(LevelObject value)
         {
             string? raw = value.GetAttr("moveSpeed");
             return double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double speed) && speed != 0
@@ -277,6 +367,39 @@ namespace CtrDxEditor.ViewModels
         private static string OrbitPrefix(bool clockwise)
         {
             return clockwise ? "RC" : "RW";
+        }
+
+        private static string MovementMode(LevelObject value)
+        {
+            string? path = value.GetAttr("path");
+            return string.IsNullOrWhiteSpace(path) ? "none" : IsOrbitEditingPath(path) ? "orbit" : "polyline";
+        }
+
+        private static bool IsOrbitEditingPath(string path)
+        {
+            return path.Length >= 2 && path[0] == 'R' && (path[1] == 'C' || path[1] == 'W');
+        }
+
+        private static void SetPolyline(LevelObject value)
+        {
+            if (string.IsNullOrWhiteSpace(value.GetAttr("path")) || IsOrbitEditingPath(value.GetAttr("path")!))
+            {
+                value.SetAttr("path", "100,0");
+            }
+
+            int moveSpeed = MoveSpeed(value);
+            if (moveSpeed == 0)
+            {
+                moveSpeed = ObjectSpin.SpinSpeed(value);
+            }
+            value.SetAttr("moveSpeed", (moveSpeed > 0 ? moveSpeed : ObjectSpin.DefaultSpeed).ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static int MoveSpeed(LevelObject value)
+        {
+            return double.TryParse(value.GetAttr("moveSpeed"), NumberStyles.Float, CultureInfo.InvariantCulture, out double speed)
+                ? Math.Abs((int)speed)
+                : 0;
         }
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -6,6 +6,7 @@ using CtrDxEditor.Core.Descriptors;
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
+using CtrDxEditor.Localization;
 
 namespace CtrDxEditor.ViewModels
 {
@@ -155,9 +156,9 @@ namespace CtrDxEditor.ViewModels
             fields.Add(new AttributeFieldViewModel(
                 "movementMode",
                 [
-                    new AttributeOptionViewModel("none", "none"),
-                    new AttributeOptionViewModel("orbit", "orbit"),
-                    new AttributeOptionViewModel("polyline", "polyline"),
+                    new AttributeOptionViewModel("none", Localizer.Get("Attr.movementMode.none")),
+                    new AttributeOptionViewModel("orbit", Localizer.Get("Attr.movementMode.orbit")),
+                    new AttributeOptionViewModel("polyline", Localizer.Get("Attr.movementMode.polyline")),
                 ],
                 () => movementMode,
                 v =>

--- a/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/SpinFieldBuilder.cs
@@ -322,19 +322,13 @@ namespace CtrDxEditor.ViewModels
                 onChanging));
 
             fields.Add(new AttributeFieldViewModel(
-                "polylineLoop",
+                "polylineRetrace",
                 AttrType.Bool,
-                () => "true",
+                () => MoverPath.IsRetrace(value.GetAttr("path")) ? "true" : "false",
                 v =>
                 {
-                    if (v != "false")
-                    {
-                        return;
-                    }
-
                     Vec2 start = new(value.X, value.Y);
-                    Vec2[] points = MoverPath.Points(start, value.GetAttr("path"));
-                    value.SetAttr("path", MoverPath.SerializePlain(start, points, loop: false));
+                    value.SetAttr("path", MoverPath.SetRetrace(start, value.GetAttr("path"), v == "true"));
                 },
                 onChanged,
                 onChanging));

--- a/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
+++ b/src/CtrDxEditor.Tests/EditorAnimationPreviewTests.cs
@@ -135,6 +135,25 @@ namespace CtrDxEditor.Tests
             Assert.True(available is true);
         }
 
+        /// <summary>Plain point mover paths expose the same row preview affordance as RC/RW orbit paths.</summary>
+        [Fact]
+        public void PlainPathObjectHasAnimationPreviewAvailable()
+        {
+            LevelObject star = new(new XElement("star",
+                new XAttribute("x", "20"),
+                new XAttribute("y", "30"),
+                new XAttribute("path", "100,0,100,50"),
+                new XAttribute("moveSpeed", "70")));
+
+            object? available = SpinPreviewConverters.Available.Convert(
+                star,
+                typeof(bool),
+                parameter: null,
+                CultureInfo.InvariantCulture);
+
+            Assert.True(available is true);
+        }
+
         /// <summary>Electro timing can be previewed even without spin or orbit mover attributes.</summary>
         [Fact]
         public void ElectroTimingHasAnimationPreviewAvailable()

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -277,6 +277,29 @@ namespace CtrDxEditor.Tests
             });
         }
 
+        /// <summary>Plain movement path overlays follow DX's authored start plus relative point offsets.</summary>
+        [Fact]
+        public void MovementPathPointsFollowPlainDxOffsets()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "ComputeMovementPathPoints",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject star = new(new XElement(
+                "star",
+                new XAttribute("x", "100"),
+                new XAttribute("y", "200"),
+                new XAttribute("path", "100,0,100,50"),
+                new XAttribute("moveSpeed", "70")));
+
+            Point[] points = (Point[])method.Invoke(null, [ViewTransform.Identity, star])!;
+
+            Assert.Equal(3, points.Length);
+            Assert.Equal(new Point(100, 200), points[0]);
+            Assert.Equal(new Point(200, 200), points[1]);
+            Assert.Equal(new Point(200, 250), points[2]);
+        }
+
         /// <summary>The orbit direction arrow sits on the circle tangent and follows RC/RW direction.</summary>
         [Fact]
         public void OrbitArrowDirectionFollowsPathPrefix()

--- a/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
@@ -32,6 +32,18 @@ namespace CtrDxEditor.Tests
             Assert.Contains("vm.ShowMovementPaths = !vm.ShowMovementPaths;", codeBehind, StringComparison.Ordinal);
         }
 
+        /// <summary>Retrace is exposed as a polyline property field driven by SetRetrace.</summary>
+        [Fact]
+        public void RetraceIsExposedAsPolylineField()
+        {
+            string builder = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "ViewModels", "SpinFieldBuilder.cs"));
+
+            Assert.Contains("polylineRetrace", builder, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.SetRetrace", builder, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.IsRetrace", builder, StringComparison.Ordinal);
+            Assert.DoesNotContain("polylineLoop", builder, StringComparison.Ordinal);
+        }
+
         private static string SourcePath(params string[] parts)
         {
             string path = AppContext.BaseDirectory;

--- a/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
@@ -50,11 +50,14 @@ namespace CtrDxEditor.Tests
         {
             string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
             string vm = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "ViewModels", "EditorViewModel.cs"));
+            string canvas = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Rendering", "LevelCanvas.cs"));
 
             Assert.DoesNotContain("PolylineEditMode", view, StringComparison.Ordinal);
             Assert.DoesNotContain("PolylineEditMode", vm, StringComparison.Ordinal);
             Assert.DoesNotContain("Menu.Edit.PolylineEditPoints", view, StringComparison.Ordinal);
             Assert.Contains("CanEditPolyline", vm, StringComparison.Ordinal);
+            Assert.Contains("change.Property == SelectedObjectProperty", canvas, StringComparison.Ordinal);
+            Assert.Contains("ResetPolylineHover();", canvas, StringComparison.Ordinal);
         }
 
         /// <summary>Polyline gestures append via the nub and delete single vertices; the old mode/truncate paths are gone.</summary>
@@ -69,6 +72,7 @@ namespace CtrDxEditor.Tests
             Assert.Contains("MoverPath.DeleteCanonicalPoint", input, StringComparison.Ordinal);
             Assert.Contains("MoverPath.MoveCanonicalPoint", input, StringComparison.Ordinal);
             Assert.Contains("MoverPath.InsertCanonicalPoint", input, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.CanAddCanonicalPoint", input, StringComparison.Ordinal);
             Assert.DoesNotContain("PolylineEditMode", input, StringComparison.Ordinal);
             Assert.DoesNotContain("MoverPath.TruncateCanonicalFrom", input, StringComparison.Ordinal);
             Assert.DoesNotContain("_altCloseHot", rendering, StringComparison.Ordinal);

--- a/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasTransactionTests.cs
@@ -44,6 +44,37 @@ namespace CtrDxEditor.Tests
             Assert.DoesNotContain("polylineLoop", builder, StringComparison.Ordinal);
         }
 
+        /// <summary>The polyline editor has no mode toggle anywhere in the view or view model.</summary>
+        [Fact]
+        public void PolylineEditingHasNoModeToggle()
+        {
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+            string vm = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "ViewModels", "EditorViewModel.cs"));
+
+            Assert.DoesNotContain("PolylineEditMode", view, StringComparison.Ordinal);
+            Assert.DoesNotContain("PolylineEditMode", vm, StringComparison.Ordinal);
+            Assert.DoesNotContain("Menu.Edit.PolylineEditPoints", view, StringComparison.Ordinal);
+            Assert.Contains("CanEditPolyline", vm, StringComparison.Ordinal);
+        }
+
+        /// <summary>Polyline gestures append via the nub and delete single vertices; the old mode/truncate paths are gone.</summary>
+        [Fact]
+        public void PolylineGesturesUseNubAppendAndSingleVertexDelete()
+        {
+            string input = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Rendering", "LevelCanvas.Input.cs"));
+            string rendering = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Rendering", "LevelCanvas.Rendering.cs"));
+
+            Assert.Contains("HitPolylineNub", input, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.AppendCanonicalPoint", input, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.DeleteCanonicalPoint", input, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.MoveCanonicalPoint", input, StringComparison.Ordinal);
+            Assert.Contains("MoverPath.InsertCanonicalPoint", input, StringComparison.Ordinal);
+            Assert.DoesNotContain("PolylineEditMode", input, StringComparison.Ordinal);
+            Assert.DoesNotContain("MoverPath.TruncateCanonicalFrom", input, StringComparison.Ordinal);
+            Assert.DoesNotContain("_altCloseHot", rendering, StringComparison.Ordinal);
+            Assert.Contains("DrawPolylinePointHandles", rendering, StringComparison.Ordinal);
+        }
+
         private static string SourcePath(params string[] parts)
         {
             string path = AppContext.BaseDirectory;

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -238,7 +238,9 @@ namespace CtrDxEditor.Tests
             vm.Fields.Single(f => f.Name == "movementMode").Value = "none";
 
             Assert.Equal("70", star.GetAttr("rotateSpeed"));
-            Assert.Null(star.GetAttr("path"));
+            // The game only spins an object that has a path (its mover carries rotateSpeed), so clearing movement
+            // keeps the static "0,0" spin-carrier rather than removing the path and silently breaking spin.
+            Assert.Equal("0,0", star.GetAttr("path"));
             Assert.Null(star.GetAttr("moveSpeed"));
             Assert.Equal("none", vm.Fields.Single(f => f.Name == "movementMode").Value);
         }

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -74,13 +74,13 @@ namespace CtrDxEditor.Tests
             vm.SelectedObject = star;
 
             Assert.False(vm.Fields.Single(f => f.Name == "spin").BoolValue);
-            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "orbit";
 
             Assert.Null(star.GetAttr("rotateSpeed"));
             Assert.Equal("RC30", star.GetAttr("path"));
             Assert.Equal("70", star.GetAttr("moveSpeed"));
             Assert.False(vm.Fields.Single(f => f.Name == "spin").BoolValue);
-            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Equal("orbit", vm.Fields.Single(f => f.Name == "movementMode").Value);
             Assert.DoesNotContain(vm.Fields, f => f.Name == "spinSpeed");
             Assert.DoesNotContain(vm.Fields, f => f.Name == "spinClockwise");
             AttributeFieldViewModel radius = vm.Fields.Single(f => f.Name == "orbitRadius");
@@ -107,7 +107,7 @@ namespace CtrDxEditor.Tests
             vm.LoadLevelXml(Level);
             LevelObject star = vm.Document!.Objects[0];
             vm.SelectedObject = star;
-            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "orbit";
             AttributeFieldViewModel radius = vm.Fields.Single(f => f.Name == "orbitRadius");
 
             radius.Value = string.Empty;
@@ -115,7 +115,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal(string.Empty, radius.Value);
             Assert.Equal("RC", star.GetAttr("path"));
             Assert.Equal("70", star.GetAttr("moveSpeed"));
-            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Equal("orbit", vm.Fields.Single(f => f.Name == "movementMode").Value);
             Assert.Contains(vm.Fields, f => f.Name == "orbitRadius");
             Assert.Contains(vm.Fields, f => f.Name == "orbitSpeed");
 
@@ -123,7 +123,7 @@ namespace CtrDxEditor.Tests
 
             Assert.Equal("RC45", star.GetAttr("path"));
             Assert.Equal("45", radius.Value);
-            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Equal("orbit", vm.Fields.Single(f => f.Name == "movementMode").Value);
         }
 
         /// <summary>Clearing orbit speed behaves like timed-star duration and keeps orbit fields visible.</summary>
@@ -134,14 +134,14 @@ namespace CtrDxEditor.Tests
             vm.LoadLevelXml(Level);
             LevelObject star = vm.Document!.Objects[0];
             vm.SelectedObject = star;
-            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "orbit";
             AttributeFieldViewModel speed = vm.Fields.Single(f => f.Name == "orbitSpeed");
 
             speed.Value = string.Empty;
 
             Assert.Equal(string.Empty, speed.Value);
             Assert.Equal(string.Empty, star.GetAttr("moveSpeed"));
-            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Equal("orbit", vm.Fields.Single(f => f.Name == "movementMode").Value);
             Assert.Contains(vm.Fields, f => f.Name == "orbitRadius");
             Assert.Contains(vm.Fields, f => f.Name == "orbitSpeed");
 
@@ -149,7 +149,7 @@ namespace CtrDxEditor.Tests
 
             Assert.Equal("130", star.GetAttr("moveSpeed"));
             Assert.Equal("130", speed.Value);
-            Assert.True(vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue);
+            Assert.Equal("orbit", vm.Fields.Single(f => f.Name == "movementMode").Value);
         }
 
         /// <summary>Clearing spin speed behaves like timed-star duration: it stays visible while editing.</summary>
@@ -187,7 +187,7 @@ namespace CtrDxEditor.Tests
             vm.SelectedObject = star;
 
             vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
-            vm.Fields.Single(f => f.Name == "spinOrbital").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "orbit";
 
             Assert.Equal("70", star.GetAttr("rotateSpeed"));
             Assert.Equal("RC30", star.GetAttr("path"));
@@ -212,6 +212,35 @@ namespace CtrDxEditor.Tests
             Assert.True(vm.ObjectListVersion > version);
             Assert.Same(star, vm.SelectedObject);
             Assert.Contains(star, vm.ObjectList);
+        }
+
+        /// <summary>Polyline movement is mutually exclusive with orbit but preserves independent spin.</summary>
+        [Fact]
+        public void SwitchingStarMovementModeBetweenOrbitAndPolylinePreservesSpin()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyStore()));
+            vm.LoadLevelXml(Level);
+            LevelObject star = vm.Document!.Objects[0];
+            vm.SelectedObject = star;
+
+            vm.Fields.Single(f => f.Name == "spin").BoolValue = true;
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "orbit";
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "polyline";
+
+            Assert.Equal("70", star.GetAttr("rotateSpeed"));
+            Assert.Equal("100,0", star.GetAttr("path"));
+            Assert.Equal("70", star.GetAttr("moveSpeed"));
+            Assert.Equal("polyline", vm.Fields.Single(f => f.Name == "movementMode").Value);
+            Assert.Contains(vm.Fields, f => f.Name == "polylineSpeed");
+            Assert.Contains(vm.Fields, f => f.Name == "polylineLoop");
+            Assert.DoesNotContain(vm.Fields, f => f.Name == "orbitRadius");
+
+            vm.Fields.Single(f => f.Name == "movementMode").Value = "none";
+
+            Assert.Equal("70", star.GetAttr("rotateSpeed"));
+            Assert.Null(star.GetAttr("path"));
+            Assert.Null(star.GetAttr("moveSpeed"));
+            Assert.Equal("none", vm.Fields.Single(f => f.Name == "movementMode").Value);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/StarFieldTests.cs
+++ b/src/CtrDxEditor.Tests/StarFieldTests.cs
@@ -232,7 +232,7 @@ namespace CtrDxEditor.Tests
             Assert.Equal("70", star.GetAttr("moveSpeed"));
             Assert.Equal("polyline", vm.Fields.Single(f => f.Name == "movementMode").Value);
             Assert.Contains(vm.Fields, f => f.Name == "polylineSpeed");
-            Assert.Contains(vm.Fields, f => f.Name == "polylineLoop");
+            Assert.Contains(vm.Fields, f => f.Name == "polylineRetrace");
             Assert.DoesNotContain(vm.Fields, f => f.Name == "orbitRadius");
 
             vm.Fields.Single(f => f.Name == "movementMode").Value = "none";


### PR DESCRIPTION
## Description

- Add a movement selector, with None, Orbit, and Polyline modes
- Support direct polyline editing on the canvas:
  - drag waypoints to reposition them
  - click segment handles to insert points
  - use the endpoint handle to append points
  - right-click or press Delete/Backspace to remove hovered points
  - hold Shift to snap segments to 45-degree angles
- Add controls for movement speed, back-and-forth retracing, and loop direction
- Render polyline paths and direction arrows in the editor and animation preview
- Preview object movement along both orbit and polyline paths
- Keep object spin independent from the selected movement mode
- Prevent moving objects from being selected or edited during animation preview
- Enforce Cut the Rope: DX path capacity and endpoint invariants, with a hint at the 99-point limit
- Add coverage for path parsing, serialization, editing, preview animation, and canvas transactions