### PR TITLE
feat: object palette with search, game header, and marquee for long names

### DIFF
--- a/src/CtrDxEditor.Shared/Controls/MarqueeMath.cs
+++ b/src/CtrDxEditor.Shared/Controls/MarqueeMath.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace CtrDxEditor.Controls
+{
+    /// <summary>Provides pure geometry calculations for marquee scrolling.</summary>
+    public static class MarqueeMath
+    {
+        /// <summary>Calculates how many pixels the text exceeds its viewport.</summary>
+        /// <param name="textWidth">The measured width of the text in pixels.</param>
+        /// <param name="availableWidth">The available viewport width in pixels.</param>
+        /// <returns>The excess width in pixels, clamped to zero when the text fits.</returns>
+        public static double Overflow(double textWidth, double availableWidth)
+        {
+            return Math.Max(0, textWidth - availableWidth);
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Controls/MarqueeTextBlock.cs
+++ b/src/CtrDxEditor.Shared/Controls/MarqueeTextBlock.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+using Avalonia.Styling;
+
+namespace CtrDxEditor.Controls
+{
+    /// <summary>
+    /// Displays clipped, single-line text that bounces horizontally while active when the text overflows.
+    /// </summary>
+    public sealed class MarqueeTextBlock : Control, IDisposable
+    {
+        private const double Speed = 40;
+        private static readonly TimeSpan MinLeg = TimeSpan.FromSeconds(0.6);
+
+        /// <summary>Identifies the <see cref="Text"/> styled property.</summary>
+        public static readonly StyledProperty<string?> TextProperty =
+            AvaloniaProperty.Register<MarqueeTextBlock, string?>(nameof(Text));
+
+        /// <summary>Identifies the <see cref="ForceActive"/> styled property.</summary>
+        public static readonly StyledProperty<bool> ForceActiveProperty =
+            AvaloniaProperty.Register<MarqueeTextBlock, bool>(nameof(ForceActive));
+
+        private readonly TextBlock _label;
+        private readonly TranslateTransform _translate = new();
+        private CancellationTokenSource? _animCts;
+        private double _overflow;
+
+        /// <summary>Initializes a new instance of the <see cref="MarqueeTextBlock"/> class.</summary>
+        public MarqueeTextBlock()
+        {
+            ClipToBounds = true;
+            _label = new TextBlock
+            {
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+                TextWrapping = TextWrapping.NoWrap,
+                RenderTransform = _translate,
+            };
+            _label[!TextBlock.TextProperty] = this[!TextProperty];
+            _label[!TextBlock.ForegroundProperty] = this[!TextElement.ForegroundProperty];
+            VisualChildren.Add(_label);
+            LogicalChildren.Add(_label);
+        }
+
+        /// <summary>Gets or sets the text displayed by the control.</summary>
+        public string? Text
+        {
+            get => GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        /// <summary>Gets or sets whether the marquee remains active when the pointer is not over it.</summary>
+        public bool ForceActive
+        {
+            get => GetValue(ForceActiveProperty);
+            set => SetValue(ForceActiveProperty, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (change.Property == IsPointerOverProperty
+                || change.Property == ForceActiveProperty)
+            {
+                UpdateAnimation();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            _label.Measure(new Size(double.PositiveInfinity, availableSize.Height));
+            return new Size(0, _label.DesiredSize.Height);
+        }
+
+        /// <inheritdoc/>
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            double textWidth = _label.DesiredSize.Width;
+            _label.Arrange(new Rect(0, 0, textWidth, finalSize.Height));
+            _overflow = MarqueeMath.Overflow(textWidth, finalSize.Width);
+            UpdateAnimation();
+            return finalSize;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            StopAnimation();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>Releases animation cancellation resources owned by this control.</summary>
+        public void Dispose()
+        {
+            StopAnimation();
+        }
+
+        private bool IsActive => IsPointerOver || ForceActive;
+
+        private void UpdateAnimation()
+        {
+            StopAnimation();
+            if (!IsActive || _overflow <= 0)
+            {
+                _translate.X = 0;
+                return;
+            }
+
+            TimeSpan leg = TimeSpan.FromSeconds(Math.Max(_overflow / Speed, MinLeg.TotalSeconds));
+            Animation anim = new()
+            {
+                Duration = leg,
+                IterationCount = IterationCount.Infinite,
+                PlaybackDirection = PlaybackDirection.Alternate,
+                Easing = new LinearEasing(),
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        Cue = new Cue(0d),
+                        Setters = { new Setter(TranslateTransform.XProperty, 0d) },
+                    },
+                    new KeyFrame
+                    {
+                        Cue = new Cue(1d),
+                        Setters = { new Setter(TranslateTransform.XProperty, -_overflow) },
+                    },
+                },
+            };
+
+            _animCts = new CancellationTokenSource();
+            _ = anim.RunAsync(_translate, _animCts.Token);
+        }
+
+        private void StopAnimation()
+        {
+            _animCts?.Cancel();
+            _animCts?.Dispose();
+            _animCts = null;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -29,6 +29,7 @@
 
     "Panel.Objects": "Objects",
     "Panel.Properties": "Properties",
+    "Palette.SearchPlaceholder": "Search objects…",
 
     "Dialog.Open.Title": "Open level XML",
     "Dialog.Save.Title": "Save level XML",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -29,7 +29,7 @@
 
     "Panel.Objects": "Objects",
     "Panel.Properties": "Properties",
-    "Palette.SearchPlaceholder": "Search objects…",
+    "Palette.SearchPlaceholder": "Search…",
 
     "Dialog.Open.Title": "Open level XML",
     "Dialog.Save.Title": "Save level XML",

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -49,12 +49,19 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial LevelObject? AnimationPreviewObject { get; set; }
         [ObservableProperty] public partial double AnimationPreviewElapsedSeconds { get; set; }
         [ObservableProperty] public partial int ObjectListVersion { get; set; }
+        [ObservableProperty] public partial string PaletteSearchText { get; set; } = "";
 
         /// <summary>Sprite cache for the active content.</summary>
         public SpriteCache Sprites { get; } = sprites;
 
         /// <summary>Palette items available for placement.</summary>
         public ObservableCollection<PaletteItemViewModel> Palette { get; } = [];
+
+        /// <summary>Display name of the game whose objects fill the palette.</summary>
+        public string CurrentGameName { get; } = "Cut the Rope";
+
+        /// <summary>Palette items after applying <see cref="PaletteSearchText"/>.</summary>
+        public ObservableCollection<PaletteItemViewModel> PaletteView { get; } = [];
 
         /// <summary>Attribute fields for the selected object.</summary>
         public ObservableCollection<AttributeFieldViewModel> Fields { get; } = [];
@@ -295,6 +302,27 @@ namespace CtrDxEditor.ViewModels
                 Palette.Add(new PaletteItemViewModel(
                     d.ElementName, Localizer.ObjectName(d.ElementName), enabled,
                     Sprites.GetThumbnail(PaletteSpriteKey(d.ElementName), ActiveCandySkin, ActiveOmNomSupport)));
+            }
+            RebuildPaletteView();
+        }
+
+        partial void OnPaletteSearchTextChanged(string value)
+        {
+            RebuildPaletteView();
+        }
+
+        /// <summary>Repopulates <see cref="PaletteView"/> from <see cref="Palette"/> and the search text.</summary>
+        public void RebuildPaletteView()
+        {
+            PaletteView.Clear();
+            string needle = PaletteSearchText?.Trim() ?? "";
+            foreach (PaletteItemViewModel item in Palette)
+            {
+                if (needle.Length == 0
+                    || item.DisplayName.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                {
+                    PaletteView.Add(item);
+                }
             }
         }
 

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -81,6 +81,12 @@ namespace CtrDxEditor.ViewModels
         /// <summary>True when a level is open and editor-only commands can run.</summary>
         public bool HasDocument => Document is not null;
 
+        /// <summary>
+        /// True when the palette's game-name header should show: a level is open and no
+        /// search is active (the header is hidden while searching to reduce clutter).
+        /// </summary>
+        public bool ShowGameName => HasDocument && string.IsNullOrWhiteSpace(PaletteSearchText);
+
         /// <summary>Whether the selected object has real polyline movement with direct-edit handles.</summary>
         public bool CanEditPolyline => SelectedObject is { } obj
             && MoverPath.IsPolylineMovement(obj.GetAttr("path"));
@@ -310,6 +316,7 @@ namespace CtrDxEditor.ViewModels
         partial void OnPaletteSearchTextChanged(string value)
         {
             RebuildPaletteView();
+            OnPropertyChanged(nameof(ShowGameName));
         }
 
         /// <summary>Repopulates <see cref="PaletteView"/> from <see cref="Palette"/> and the search text.</summary>
@@ -452,6 +459,7 @@ namespace CtrDxEditor.ViewModels
         partial void OnDocumentChanged(LevelDocument? value)
         {
             OnPropertyChanged(nameof(HasDocument));
+            OnPropertyChanged(nameof(ShowGameName));
         }
 
         partial void OnAnimationPreviewModeChanged(AnimationPreviewMode value)

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -122,6 +122,7 @@ namespace CtrDxEditor.ViewModels
             LockedObject = null;
             ClearHistory();
             Palette.Clear();
+            RebuildPaletteView();
             ObjectList.Clear();
             Fields.Clear();
         }

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -319,7 +319,10 @@ namespace CtrDxEditor.ViewModels
             OnPropertyChanged(nameof(ShowGameName));
         }
 
-        /// <summary>Repopulates <see cref="PaletteView"/> from <see cref="Palette"/> and the search text.</summary>
+        /// <summary>
+        /// Repopulates <see cref="PaletteView"/> from <see cref="Palette"/> and the search text,
+        /// matching against both the display name and the raw XML element name.
+        /// </summary>
         public void RebuildPaletteView()
         {
             PaletteView.Clear();
@@ -327,7 +330,8 @@ namespace CtrDxEditor.ViewModels
             foreach (PaletteItemViewModel item in Palette)
             {
                 if (needle.Length == 0
-                    || item.DisplayName.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                    || item.DisplayName.Contains(needle, StringComparison.OrdinalIgnoreCase)
+                    || item.Element.Contains(needle, StringComparison.OrdinalIgnoreCase))
                 {
                     PaletteView.Add(item);
                 }

--- a/src/CtrDxEditor.Shared/ViewModels/PaletteItemViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/PaletteItemViewModel.cs
@@ -21,5 +21,12 @@ namespace CtrDxEditor.ViewModels
             get;
             set => SetProperty(ref field, value);
         } = enabled;
+
+        /// <summary>True while this item is the one being dragged from the palette.</summary>
+        public bool IsDragging
+        {
+            get;
+            set => SetProperty(ref field, value);
+        }
     }
 }

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -234,6 +234,7 @@
               <ItemsControl.ItemTemplate>
                 <DataTemplate>
                   <Button Margin="0,3" Padding="8,6" HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
                           IsEnabled="{Binding Enabled}"
                           Tag="{Binding Element}">
                     <Grid ColumnDefinitions="*,Auto">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -219,6 +219,7 @@
       <Border Grid.Column="0" Background="{DynamicResource EditorBrush.Surface.Panel}">
         <Grid RowDefinitions="Auto,Auto,*">
           <TextBox Grid.Row="0" Margin="6,6,6,4"
+                   IsVisible="{Binding HasDocument, FallbackValue=False}"
                    Text="{Binding PaletteSearchText, Mode=TwoWay}"
                    PlaceholderText="{loc:Tr Palette.SearchPlaceholder}">
             <TextBox.InnerLeftContent>
@@ -227,6 +228,7 @@
             </TextBox.InnerLeftContent>
           </TextBox>
           <TextBlock Grid.Row="1" Text="{Binding CurrentGameName}" FontWeight="Bold"
+                     IsVisible="{Binding ShowGameName, FallbackValue=False}"
                      Margin="8,6,8,4" />
           <ScrollViewer Grid.Row="2" HorizontalScrollBarVisibility="Disabled"
                         VerticalScrollBarVisibility="Auto">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -229,7 +229,8 @@
           </TextBox>
           <TextBlock Grid.Row="1" Text="{Binding CurrentGameName}" FontWeight="Bold"
                      IsVisible="{Binding ShowGameName, FallbackValue=False}"
-                     Margin="8,6,8,4" />
+                     TextWrapping="Wrap"
+                     Margin="8,6,8,8" />
           <ScrollViewer Grid.Row="2" HorizontalScrollBarVisibility="Disabled"
                         VerticalScrollBarVisibility="Auto">
             <ItemsControl x:Name="PaletteList" ItemsSource="{Binding PaletteView}" Margin="6,0,6,10">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -6,6 +6,7 @@
         xmlns:core="using:CtrDxEditor.Core.Document"
         xmlns:conv="using:CtrDxEditor.Converters"
         xmlns:loc="using:CtrDxEditor.Localization"
+        xmlns:ctl="using:CtrDxEditor.Controls"
         xmlns:icons="using:Material.Icons.Avalonia"
         xmlns:dialogs="using:AvaloniaDialogs.Views"
         x:Class="CtrDxEditor.Views.MainView"
@@ -216,21 +217,38 @@
     </Menu>
     <Grid ColumnDefinitions="160,1,*,1,280">
       <Border Grid.Column="0" Background="{DynamicResource EditorBrush.Surface.Panel}">
-        <ItemsControl x:Name="PaletteList" ItemsSource="{Binding Palette}" Margin="6,6,6,10">
-          <ItemsControl.ItemTemplate>
-            <DataTemplate>
-              <Button Margin="0,3" Padding="8,6" HorizontalAlignment="Stretch"
-                      IsEnabled="{Binding Enabled}"
-                      Tag="{Binding Element}">
-                <Grid ColumnDefinitions="*,Auto">
-                  <TextBlock Grid.Column="0" Text="{Binding DisplayName}" VerticalAlignment="Center" />
-                  <Image Grid.Column="1" Source="{Binding Icon}" Width="28" Height="28"
-                         Stretch="Uniform" Margin="6,0,0,0" />
-                </Grid>
-              </Button>
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <Grid RowDefinitions="Auto,Auto,*">
+          <TextBox Grid.Row="0" Margin="6,6,6,4"
+                   Text="{Binding PaletteSearchText, Mode=TwoWay}"
+                   PlaceholderText="{loc:Tr Palette.SearchPlaceholder}">
+            <TextBox.InnerLeftContent>
+              <icons:MaterialIcon Kind="Magnify" Width="16" Height="16" Margin="6,0,0,0"
+                                  Foreground="{DynamicResource EditorBrush.Text.Subtle}" />
+            </TextBox.InnerLeftContent>
+          </TextBox>
+          <TextBlock Grid.Row="1" Text="{Binding CurrentGameName}" FontWeight="Bold"
+                     Margin="8,6,8,4" />
+          <ScrollViewer Grid.Row="2" HorizontalScrollBarVisibility="Disabled"
+                        VerticalScrollBarVisibility="Auto">
+            <ItemsControl x:Name="PaletteList" ItemsSource="{Binding PaletteView}" Margin="6,0,6,10">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Button Margin="0,3" Padding="8,6" HorizontalAlignment="Stretch"
+                          IsEnabled="{Binding Enabled}"
+                          Tag="{Binding Element}">
+                    <Grid ColumnDefinitions="*,Auto">
+                      <ctl:MarqueeTextBlock Grid.Column="0" Text="{Binding DisplayName}"
+                                            ForceActive="{Binding IsDragging}"
+                                            VerticalAlignment="Center" />
+                      <Image Grid.Column="1" Source="{Binding Icon}" Width="28" Height="28"
+                             Stretch="Uniform" Margin="6,0,0,0" />
+                    </Grid>
+                  </Button>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+        </Grid>
       </Border>
       <Border Grid.Column="1" Background="{DynamicResource EditorBrush.Surface.Divider}" />
       <Grid Grid.Column="2" RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -215,7 +215,7 @@
         </MenuItem>
       </MenuItem>
     </Menu>
-    <Grid ColumnDefinitions="160,1,*,1,280">
+    <Grid ColumnDefinitions="200,1,*,1,280">
       <Border Grid.Column="0" Background="{DynamicResource EditorBrush.Surface.Panel}">
         <Grid RowDefinitions="Auto,Auto,*">
           <TextBox Grid.Row="0" Margin="6,6,6,4"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -66,6 +66,8 @@ namespace CtrDxEditor.Views
                 PointerMovedEvent, PaletteItem_PointerMoved, RoutingStrategies.Bubble, handledEventsToo: true);
             paletteList.AddHandler(
                 PointerReleasedEvent, PaletteItem_PointerReleased, RoutingStrategies.Bubble, handledEventsToo: true);
+            paletteList.AddHandler(
+                PointerCaptureLostEvent, PaletteItem_PointerCaptureLost, RoutingStrategies.Bubble, handledEventsToo: true);
             // Menu hint text (⌘/Ctrl) is bound in XAML via ShortcutHint; here we only handle the keys.
             // MenuItem.InputGesture only renders text and wouldn't trigger Click-driven items anyway.
             KeyModifiers cmdModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
@@ -241,8 +243,7 @@ namespace CtrDxEditor.Views
         private void PaletteItem_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
             // Arm a placement on left-press and capture the pointer; the gesture resolves on release.
-            _palettePendingElement = null;
-            _paletteDragging = false;
+            CancelPaletteDrag();
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 return;
@@ -321,6 +322,17 @@ namespace CtrDxEditor.Views
             }
 
             e.Pointer.Capture(null);
+            CancelPaletteDrag();
+        }
+
+        private void PaletteItem_PointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            CancelPaletteDrag();
+        }
+
+        private void CancelPaletteDrag()
+        {
+            this.FindControl<LevelCanvas>("Canvas")?.HideGhost();
             _palettePendingElement = null;
             _paletteDragging = false;
             if (_draggingItem is { } draggingItem)
@@ -701,6 +713,7 @@ namespace CtrDxEditor.Views
         /// <inheritdoc />
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            CancelPaletteDrag();
             _animationPreviewTimer.Stop();
             if (_mutatedSubscription is not null)
             {

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -236,6 +236,7 @@ namespace CtrDxEditor.Views
         private string? _palettePendingElement;
         private Point _palettePressPos;
         private bool _paletteDragging;
+        private PaletteItemViewModel? _draggingItem;
 
         private void PaletteItem_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
@@ -251,6 +252,11 @@ namespace CtrDxEditor.Views
             if (button is { Tag: string element, IsEnabled: true })
             {
                 _palettePendingElement = element;
+                if (button.DataContext is PaletteItemViewModel pressed)
+                {
+                    _draggingItem = pressed;
+                    pressed.IsDragging = true;
+                }
                 _palettePressPos = e.GetPosition(this);
                 e.Pointer.Capture(sender as IInputElement);
             }
@@ -317,6 +323,11 @@ namespace CtrDxEditor.Views
             e.Pointer.Capture(null);
             _palettePendingElement = null;
             _paletteDragging = false;
+            if (_draggingItem is { } draggingItem)
+            {
+                draggingItem.IsDragging = false;
+            }
+            _draggingItem = null;
         }
 
         private void WireObjectMutated()

--- a/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests object-palette filtering and game identity exposed by the editor view model.</summary>
+    public class EditorPaletteSearchTests
+    {
+        private static EditorViewModel Vm()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyContentStore()));
+            vm.NewLevel(new LevelSettings(640, 480, 1.0f, 0, TwoParts: false, NightLevel: false));
+            return vm;
+        }
+
+        /// <summary>An empty search leaves every source palette item visible.</summary>
+        [Fact]
+        public void EmptySearchShowsEveryPaletteItem()
+        {
+            EditorViewModel vm = Vm();
+            Assert.Equal(vm.Palette.Count, vm.PaletteView.Count);
+        }
+
+        /// <summary>Search matches display-name substrings without regard to case.</summary>
+        [Fact]
+        public void SearchFiltersByDisplayNameCaseInsensitively()
+        {
+            EditorViewModel vm = Vm();
+            string sample = vm.Palette.First().DisplayName;
+            string needle = sample[..2].ToUpperInvariant();
+
+            vm.PaletteSearchText = needle;
+
+            Assert.NotEmpty(vm.PaletteView);
+            Assert.All(vm.PaletteView, i =>
+                Assert.Contains(needle, i.DisplayName, System.StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>A search with no display-name match produces an empty view.</summary>
+        [Fact]
+        public void NonMatchingSearchYieldsEmptyView()
+        {
+            EditorViewModel vm = Vm();
+            vm.PaletteSearchText = "zzz-no-such-object";
+            Assert.Empty(vm.PaletteView);
+        }
+
+        /// <summary>Refreshing the source palette reapplies the current search filter.</summary>
+        [Fact]
+        public void RefreshPaletteKeepsActiveFilterApplied()
+        {
+            EditorViewModel vm = Vm();
+            string needle = vm.Palette.First().DisplayName;
+            vm.PaletteSearchText = needle;
+
+            vm.RefreshPalette();
+
+            Assert.All(vm.PaletteView, i =>
+                Assert.Contains(needle, i.DisplayName, System.StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>The palette reports the game whose object catalog it displays.</summary>
+        [Fact]
+        public void CurrentGameNameIsCutTheRope()
+        {
+            Assert.Equal("Cut the Rope", Vm().CurrentGameName);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
@@ -26,6 +26,17 @@ namespace CtrDxEditor.Tests
             Assert.Equal(vm.Palette.Count, vm.PaletteView.Count);
         }
 
+        /// <summary>A whitespace-only search leaves every source palette item visible.</summary>
+        [Fact]
+        public void WhitespaceSearchShowsEveryPaletteItem()
+        {
+            EditorViewModel vm = Vm();
+
+            vm.PaletteSearchText = " \t ";
+
+            Assert.Equal(vm.Palette.Count, vm.PaletteView.Count);
+        }
+
         /// <summary>Search matches display-name substrings without regard to case.</summary>
         [Fact]
         public void SearchFiltersByDisplayNameCaseInsensitively()
@@ -60,6 +71,7 @@ namespace CtrDxEditor.Tests
 
             vm.RefreshPalette();
 
+            Assert.NotEmpty(vm.PaletteView);
             Assert.All(vm.PaletteView, i =>
                 Assert.Contains(needle, i.DisplayName, System.StringComparison.OrdinalIgnoreCase));
         }
@@ -69,6 +81,19 @@ namespace CtrDxEditor.Tests
         public void CurrentGameNameIsCutTheRope()
         {
             Assert.Equal("Cut the Rope", Vm().CurrentGameName);
+        }
+
+        /// <summary>Closing a level clears both the source palette and its filtered view.</summary>
+        [Fact]
+        public void CloseLevelClearsPaletteView()
+        {
+            EditorViewModel vm = Vm();
+            Assert.NotEmpty(vm.PaletteView);
+
+            vm.CloseLevel();
+
+            Assert.Empty(vm.Palette);
+            Assert.Empty(vm.PaletteView);
         }
     }
 }

--- a/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
@@ -83,6 +83,32 @@ namespace CtrDxEditor.Tests
             Assert.Equal("Cut the Rope", Vm().CurrentGameName);
         }
 
+        /// <summary>With no level open, the game-name header stays hidden.</summary>
+        [Fact]
+        public void GameNameHiddenWithoutDocument()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyContentStore()));
+            Assert.False(vm.ShowGameName);
+        }
+
+        /// <summary>With a level open and no search, the game-name header shows.</summary>
+        [Fact]
+        public void GameNameShownWithDocumentAndEmptySearch()
+        {
+            Assert.True(Vm().ShowGameName);
+        }
+
+        /// <summary>An active search hides the game-name header to reduce clutter.</summary>
+        [Fact]
+        public void GameNameHiddenWhileSearching()
+        {
+            EditorViewModel vm = Vm();
+
+            vm.PaletteSearchText = "candy";
+
+            Assert.False(vm.ShowGameName);
+        }
+
         /// <summary>Closing a level clears both the source palette and its filtered view.</summary>
         [Fact]
         public void CloseLevelClearsPaletteView()

--- a/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
+++ b/src/CtrDxEditor.Tests/EditorPaletteSearchTests.cs
@@ -52,6 +52,21 @@ namespace CtrDxEditor.Tests
                 Assert.Contains(needle, i.DisplayName, System.StringComparison.OrdinalIgnoreCase));
         }
 
+        /// <summary>Search also matches the raw XML element name, not just the display name.</summary>
+        [Fact]
+        public void SearchMatchesXmlElementName()
+        {
+            EditorViewModel vm = Vm();
+
+            // "bouncer1" is the element name; its display name has no digit, so a match here
+            // can only come from the element-name comparison.
+            vm.PaletteSearchText = "bouncer1";
+
+            Assert.Contains(vm.PaletteView, i => i.Element == "bouncer1");
+            Assert.All(vm.PaletteView, i =>
+                Assert.Contains("bouncer1", i.Element, System.StringComparison.OrdinalIgnoreCase));
+        }
+
         /// <summary>A search with no display-name match produces an empty view.</summary>
         [Fact]
         public void NonMatchingSearchYieldsEmptyView()

--- a/src/CtrDxEditor.Tests/EmptyContentStore.cs
+++ b/src/CtrDxEditor.Tests/EmptyContentStore.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+
+using CtrDxEditor.Content;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>A content store that reports nothing populated — for VM tests without assets.</summary>
+    public sealed class EmptyContentStore : IContentStore
+    {
+        /// <summary>Reports that a relative content path does not exist.</summary>
+        /// <param name="relPath">The relative content path to inspect.</param>
+        /// <returns>A completed task whose result is <see langword="false"/>.</returns>
+        public Task<bool> ExistsAsync(string relPath)
+        {
+            return Task.FromResult(false);
+        }
+
+        /// <summary>Returns empty binary content for a relative path.</summary>
+        /// <param name="relPath">The relative content path to read.</param>
+        /// <returns>A completed task containing an empty byte array.</returns>
+        public Task<byte[]> ReadBytesAsync(string relPath)
+        {
+            return Task.FromResult(Array.Empty<byte>());
+        }
+
+        /// <summary>Returns empty text content for a relative path.</summary>
+        /// <param name="relPath">The relative content path to read.</param>
+        /// <returns>A completed task containing an empty string.</returns>
+        public Task<string> ReadTextAsync(string relPath)
+        {
+            return Task.FromResult("");
+        }
+
+        /// <summary>Reports that the store has no installed content.</summary>
+        /// <returns>A completed task whose result is <see langword="false"/>.</returns>
+        public Task<bool> IsPopulatedAsync()
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/MainViewPaletteTests.cs
+++ b/src/CtrDxEditor.Tests/MainViewPaletteTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests palette view wiring that is difficult to exercise through headless pointer input.</summary>
+    public class MainViewPaletteTests
+    {
+        /// <summary>The palette button stretches its content so the marquee receives a usable viewport.</summary>
+        [Fact]
+        public void PaletteButtonStretchesMarqueeContent()
+        {
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+
+            Assert.Contains("HorizontalContentAlignment=\"Stretch\"", view, StringComparison.Ordinal);
+        }
+
+        /// <summary>Lost pointer capture and view detachment cancel palette drag state through shared cleanup.</summary>
+        [Fact]
+        public void InterruptedPaletteDragUsesSharedCleanup()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml.cs"));
+
+            Assert.Contains("PointerCaptureLostEvent, PaletteItem_PointerCaptureLost", source, StringComparison.Ordinal);
+            Assert.Contains("private void CancelPaletteDrag()", source, StringComparison.Ordinal);
+            Assert.Contains("private void PaletteItem_PointerCaptureLost", source, StringComparison.Ordinal);
+            Assert.Contains("CancelPaletteDrag();", source, StringComparison.Ordinal);
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string path = AppContext.BaseDirectory;
+            while (Path.GetFileName(path) != "src")
+            {
+                path = Directory.GetParent(path)?.FullName
+                       ?? throw new InvalidOperationException("Could not locate src directory.");
+            }
+
+            return Path.Combine([path, .. parts]);
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/MarqueeMathTests.cs
+++ b/src/CtrDxEditor.Tests/MarqueeMathTests.cs
@@ -1,0 +1,31 @@
+using CtrDxEditor.Controls;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests overflow geometry used by the palette marquee.</summary>
+    public class MarqueeMathTests
+    {
+        /// <summary>Text narrower than the viewport has no overflow.</summary>
+        [Fact]
+        public void NoOverflowWhenTextFits()
+        {
+            Assert.Equal(0d, MarqueeMath.Overflow(textWidth: 80, availableWidth: 120));
+        }
+
+        /// <summary>Text exactly as wide as the viewport has no overflow.</summary>
+        [Fact]
+        public void NoOverflowAtExactFit()
+        {
+            Assert.Equal(0d, MarqueeMath.Overflow(textWidth: 120, availableWidth: 120));
+        }
+
+        /// <summary>Overflow equals the text width beyond the viewport width.</summary>
+        [Fact]
+        public void OverflowIsTheExcessWidth()
+        {
+            Assert.Equal(30d, MarqueeMath.Overflow(textWidth: 150, availableWidth: 120));
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/PaletteItemViewModelTests.cs
+++ b/src/CtrDxEditor.Tests/PaletteItemViewModelTests.cs
@@ -1,0 +1,26 @@
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests observable state exposed by palette items.</summary>
+    public class PaletteItemViewModelTests
+    {
+        /// <summary>Setting drag state updates the value and raises its property-change notification.</summary>
+        [Fact]
+        public void IsDraggingRaisesPropertyChangedAndUpdatesValue()
+        {
+            PaletteItemViewModel item = new("candy", "Candy", enabled: true, icon: null);
+            string? changed = null;
+            item.PropertyChanged += (_, e) => changed = e.PropertyName;
+
+            Assert.False(item.IsDragging);
+
+            item.IsDragging = true;
+
+            Assert.True(item.IsDragging);
+            Assert.Equal(nameof(PaletteItemViewModel.IsDragging), changed);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Redesigns the left object palette to make objects easier to find and to read long names, and lays groundwork for supporting objects from other Cut the Rope games.

The palette (now 200px) gains, top to bottom: a search box, a game-name header, a scrollable object list, and a ping-pong marquee that animates long names on hover or drag.


## Changes

- Search bar: filters the palette live by both the display name and the raw XML element name (e.g. "Bouncer" or "bouncer1"), case-insensitively.
- Game-name header: a bold "Cut the Rope" label (`CurrentGameName` on the VM) above the list, wired as data so a future game switcher is a data swap, not a rewrite. Wraps for long names.
- Ping-pong marquee: new standalone `MarqueeTextBlock` control (+ pure `MarqueeMath` helper): long names bounce left↔right while the row is hovered or being dragged; short names stay still.
- Scrollbar: the object list is now wrapped in a `ScrollViewer`.
- Visibility rules: the search box and header stay hidden until a level is open (with `FallbackValue=False` to avoid a startup flash), and the header also hides while searching so results read as one flat, game-agnostic list.
