### PR TITLE
fix: normalize spike/bouncer tag names to their size attribute on load

### DIFF
--- a/src/CtrDxEditor.Core/Document/LevelDocument.cs
+++ b/src/CtrDxEditor.Core/Document/LevelDocument.cs
@@ -5,11 +5,15 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
+using CtrDxEditor.Core.Editing;
+
 namespace CtrDxEditor.Core.Document
 {
     /// <summary>
     /// Owns the parsed level XML tree. Unknown layers, elements, and attributes are retained
-    /// verbatim on the underlying XDocument so a no-edit save round-trips losslessly.
+    /// verbatim on the underlying XDocument so a no-edit save round-trips losslessly. The one
+    /// exception is that spike/bouncer tags are normalized on load to match their authoritative
+    /// size attribute (e.g. spike2 size="3" becomes spike3), which the game treats identically.
     /// </summary>
     public sealed class LevelDocument
     {
@@ -18,6 +22,19 @@ namespace CtrDxEditor.Core.Document
         private LevelDocument(XDocument doc)
         {
             _doc = doc;
+            NormalizeSizedElements();
+        }
+
+        // Spikes (spike1-4) and bouncers (bouncer1/2) derive their size purely from the size
+        // attribute in-game; the tag suffix is ignored. Align the suffix to the attribute so the
+        // editor's stored XML is self-consistent. Lossless in game behavior.
+        private void NormalizeSizedElements()
+        {
+            foreach (LevelObject obj in Objects)
+            {
+                SpikeObject.NormalizeElementName(obj);
+                BouncerObject.NormalizeElementName(obj);
+            }
         }
 
         /// <summary>Parses a level document from an XML string.</summary>

--- a/src/CtrDxEditor.Core/Document/LevelDocument.cs
+++ b/src/CtrDxEditor.Core/Document/LevelDocument.cs
@@ -5,15 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
-using CtrDxEditor.Core.Editing;
-
 namespace CtrDxEditor.Core.Document
 {
     /// <summary>
     /// Owns the parsed level XML tree. Unknown layers, elements, and attributes are retained
-    /// verbatim on the underlying XDocument so a no-edit save round-trips losslessly. The one
-    /// exception is that spike/bouncer tags are normalized on load to match their authoritative
-    /// size attribute (e.g. spike2 size="3" becomes spike3), which the game treats identically.
+    /// verbatim on the underlying XDocument so a no-edit save round-trips losslessly. Load-time
+    /// fixups (binding-key and spike/bouncer size normalization) are applied by LevelObjectPolicy
+    /// during editor load, not here, so a bare Parse stays lossless.
     /// </summary>
     public sealed class LevelDocument
     {
@@ -22,19 +20,6 @@ namespace CtrDxEditor.Core.Document
         private LevelDocument(XDocument doc)
         {
             _doc = doc;
-            NormalizeSizedElements();
-        }
-
-        // Spikes (spike1-4) and bouncers (bouncer1/2) derive their size purely from the size
-        // attribute in-game; the tag suffix is ignored. Align the suffix to the attribute so the
-        // editor's stored XML is self-consistent. Lossless in game behavior.
-        private void NormalizeSizedElements()
-        {
-            foreach (LevelObject obj in Objects)
-            {
-                SpikeObject.NormalizeElementName(obj);
-                BouncerObject.NormalizeElementName(obj);
-            }
         }
 
         /// <summary>Parses a level document from an XML string.</summary>

--- a/src/CtrDxEditor.Core/Editing/BouncerObject.cs
+++ b/src/CtrDxEditor.Core/Editing/BouncerObject.cs
@@ -30,6 +30,25 @@ namespace CtrDxEditor.Core.Editing
             obj.SetAttr("size", size!);
         }
 
+        /// <summary>
+        /// Renames the element to bouncerN so the tag matches its authoritative size attribute.
+        /// The game reads size only from the attribute, so this is behavior-preserving. Elements
+        /// without a valid size attribute are left untouched.
+        /// </summary>
+        public static void NormalizeElementName(LevelObject obj)
+        {
+            if (!IsBouncer(obj.Type))
+            {
+                return;
+            }
+
+            string? size = obj.GetAttr("size");
+            if (IsValidSize(size) && obj.Type != $"bouncer{size}")
+            {
+                obj.Element.Name = $"bouncer{size}";
+            }
+        }
+
         private static bool IsValidSize(string? size)
         {
             return size is "1" or "2";

--- a/src/CtrDxEditor.Core/Editing/LevelObjectPolicy.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelObjectPolicy.cs
@@ -49,6 +49,26 @@ namespace CtrDxEditor.Core.Editing
         }
 
         /// <summary>
+        /// Aligns each spike/bouncer element name with its authoritative <c>size</c> attribute
+        /// (e.g. <c>spike2 size="3"</c> becomes <c>spike3</c>). The game reads size only from the
+        /// attribute, so this is behavior-preserving; electro, missing-size, and out-of-range
+        /// sizes are left untouched. Returns whether any element was renamed.
+        /// </summary>
+        public static bool NormalizeSizedElements(LevelDocument document)
+        {
+            bool changed = false;
+            foreach (LevelObject obj in document.Objects)
+            {
+                string before = obj.Type;
+                SpikeObject.NormalizeElementName(obj);
+                BouncerObject.NormalizeElementName(obj);
+                changed |= obj.Type != before;
+            }
+
+            return changed;
+        }
+
+        /// <summary>
         /// Reassigns hidden candy and bulb ids from zero in object order, updating grab references
         /// that pointed at matching legacy keys.
         /// </summary>

--- a/src/CtrDxEditor.Core/Editing/SpikeObject.cs
+++ b/src/CtrDxEditor.Core/Editing/SpikeObject.cs
@@ -37,6 +37,25 @@ namespace CtrDxEditor.Core.Editing
             obj.SetAttr("size", size!);
         }
 
+        /// <summary>
+        /// Renames the element to spikeN so the tag matches its authoritative size attribute.
+        /// The game reads size only from the attribute, so this is behavior-preserving. Elements
+        /// without a valid size attribute (bare spikes, electro, out-of-range) are left untouched.
+        /// </summary>
+        public static void NormalizeElementName(LevelObject obj)
+        {
+            if (!IsSpike(obj.Type))
+            {
+                return;
+            }
+
+            string? size = obj.GetAttr("size");
+            if (IsValidSize(size) && obj.Type != $"spike{size}")
+            {
+                obj.Element.Name = $"spike{size}";
+            }
+        }
+
         /// <summary>Whether this spike uses rotatable spike state. Group 0 is rotatable but has no embedded button.</summary>
         public static bool IsToggled(LevelObject obj)
         {

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -133,7 +133,14 @@ namespace CtrDxEditor.ViewModels
             // The canvas fits the level to the viewport once it is laid out (LevelCanvas.FitToView).
             RefreshPalette();
             RefreshObjectList();
+            // Baseline captured before size normalization so a level whose spike/bouncer tags
+            // disagree with their size attribute loads as a pending (savable) change, while a
+            // consistent level stays clean. See LevelObjectPolicy.NormalizeSizedElements.
             _savedBaselineXml = ToXml();
+            if (LevelObjectPolicy.NormalizeSizedElements(Document))
+            {
+                RefreshObjectList();
+            }
             LevelLoaded?.Invoke();
         }
 

--- a/src/CtrDxEditor.Tests/EditorModifiedStateTests.cs
+++ b/src/CtrDxEditor.Tests/EditorModifiedStateTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using CtrDxEditor.Content;
 using CtrDxEditor.ViewModels;
 
@@ -8,6 +10,40 @@ namespace CtrDxEditor.Tests
     /// <summary>Tests the unsaved-changes signal that gates the new/open/close discard prompts.</summary>
     public class EditorModifiedStateTests
     {
+        private static string SpikeLevel(string element, string size) => $"""
+        <?xml version='1.0' encoding='utf-8'?>
+        <map>
+            <layer name="settings">
+                <map gridSize="32" width="640" height="480" />
+            </layer>
+            <layer name="Objects">
+                <{element} x="100" y="100" size="{size}" />
+            </layer>
+        </map>
+        """;
+
+        /// <summary>A level whose spike tag disagrees with its size attribute loads normalized and pending save.</summary>
+        [Fact]
+        public void LoadingMismatchedSpikeTagNormalizesLiveAndMarksModified()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyContentStore()));
+
+            vm.LoadLevelXml(SpikeLevel("spike2", "3"));
+
+            Assert.Equal("spike3", vm.Document!.Objects.First().Type);
+            Assert.True(vm.IsModified);
+        }
+
+        /// <summary>A level whose spike tag already matches its size attribute loads clean.</summary>
+        [Fact]
+        public void LoadingConsistentSpikeTagIsNotModified()
+        {
+            EditorViewModel vm = new(new SpriteCache(new EmptyContentStore()));
+
+            vm.LoadLevelXml(SpikeLevel("spike3", "3"));
+
+            Assert.False(vm.IsModified);
+        }
         private const string Level = """
         <?xml version='1.0' encoding='utf-8'?>
         <map>

--- a/src/CtrDxEditor.Tests/SizedElementNormalizationTests.cs
+++ b/src/CtrDxEditor.Tests/SizedElementNormalizationTests.cs
@@ -1,15 +1,16 @@
 using System.Linq;
 
 using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
 
 using Xunit;
 
 namespace CtrDxEditor.Tests
 {
     /// <summary>
-    /// Verifies that on load, spike/bouncer tag names are normalized to match a valid
-    /// <c>size</c> attribute. The game reads size only from the attribute, so renaming the
-    /// tag to match is behavior-preserving (see Spikes.GetSpikeTextureAndQuad / Bouncer).
+    /// Verifies that spike/bouncer tag names are normalized to match a valid <c>size</c>
+    /// attribute. The game reads size only from the attribute, so renaming the tag to match is
+    /// behavior-preserving (see Spikes.GetSpikeTextureAndQuad / Bouncer).
     /// </summary>
     public class SizedElementNormalizationTests
     {
@@ -18,7 +19,9 @@ namespace CtrDxEditor.Tests
             string xml =
                 "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer>" +
                 "<layer name=\"Objects\">" + objectsXml + "</layer></map>";
-            return LevelDocument.Parse(xml);
+            LevelDocument doc = LevelDocument.Parse(xml);
+            _ = LevelObjectPolicy.NormalizeSizedElements(doc);
+            return doc;
         }
 
         private static string TypeOfFirst(LevelDocument doc)
@@ -83,6 +86,29 @@ namespace CtrDxEditor.Tests
             LevelDocument doc = Load("<bouncer2 x=\"10\" y=\"20\" size=\"5\" />");
 
             Assert.Equal("bouncer2", TypeOfFirst(doc));
+        }
+
+        [Fact]
+        public void ReportsChangedWhenATagIsRenamed()
+        {
+            LevelDocument doc = ParseWithoutNormalizing("<spike2 x=\"10\" y=\"20\" size=\"3\" />");
+
+            Assert.True(LevelObjectPolicy.NormalizeSizedElements(doc));
+        }
+
+        [Fact]
+        public void ReportsUnchangedWhenAllTagsAlreadyMatch()
+        {
+            LevelDocument doc = ParseWithoutNormalizing("<spike3 x=\"10\" y=\"20\" size=\"3\" /><electro x=\"5\" y=\"5\" size=\"5\" />");
+
+            Assert.False(LevelObjectPolicy.NormalizeSizedElements(doc));
+        }
+
+        private static LevelDocument ParseWithoutNormalizing(string objectsXml)
+        {
+            return LevelDocument.Parse(
+                "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer>" +
+                "<layer name=\"Objects\">" + objectsXml + "</layer></map>");
         }
     }
 }

--- a/src/CtrDxEditor.Tests/SizedElementNormalizationTests.cs
+++ b/src/CtrDxEditor.Tests/SizedElementNormalizationTests.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+
+using CtrDxEditor.Core.Document;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>
+    /// Verifies that on load, spike/bouncer tag names are normalized to match a valid
+    /// <c>size</c> attribute. The game reads size only from the attribute, so renaming the
+    /// tag to match is behavior-preserving (see Spikes.GetSpikeTextureAndQuad / Bouncer).
+    /// </summary>
+    public class SizedElementNormalizationTests
+    {
+        private static LevelDocument Load(string objectsXml)
+        {
+            string xml =
+                "<map><layer name=\"settings\"><map gridSize=\"32\" width=\"100\" height=\"80\" /></layer>" +
+                "<layer name=\"Objects\">" + objectsXml + "</layer></map>";
+            return LevelDocument.Parse(xml);
+        }
+
+        private static string TypeOfFirst(LevelDocument doc)
+        {
+            return doc.Objects.First().Type;
+        }
+
+        [Fact]
+        public void SpikeTagRenamedToMatchSizeAttribute()
+        {
+            LevelDocument doc = Load("<spike2 x=\"10\" y=\"20\" size=\"3\" />");
+
+            Assert.Equal("spike3", TypeOfFirst(doc));
+            Assert.Equal("3", doc.Objects.First().GetAttr("size"));
+        }
+
+        [Fact]
+        public void BouncerTagRenamedToMatchSizeAttribute()
+        {
+            LevelDocument doc = Load("<bouncer1 x=\"10\" y=\"20\" size=\"2\" />");
+
+            Assert.Equal("bouncer2", TypeOfFirst(doc));
+            Assert.Equal("2", doc.Objects.First().GetAttr("size"));
+        }
+
+        [Fact]
+        public void MatchingSpikeTagLeftUnchanged()
+        {
+            LevelDocument doc = Load("<spike3 x=\"10\" y=\"20\" size=\"3\" />");
+
+            Assert.Equal("spike3", TypeOfFirst(doc));
+        }
+
+        [Fact]
+        public void ElectroTagLeftUnchanged()
+        {
+            LevelDocument doc = Load("<electro x=\"10\" y=\"20\" size=\"5\" />");
+
+            Assert.Equal("electro", TypeOfFirst(doc));
+        }
+
+        [Fact]
+        public void SpikeWithoutSizeAttributeLeftUnchanged()
+        {
+            LevelDocument doc = Load("<spike3 x=\"10\" y=\"20\" />");
+
+            Assert.Equal("spike3", TypeOfFirst(doc));
+            Assert.Null(doc.Objects.First().GetAttr("size"));
+        }
+
+        [Fact]
+        public void SpikeWithOutOfRangeSizeLeftUnchanged()
+        {
+            LevelDocument doc = Load("<spike2 x=\"10\" y=\"20\" size=\"9\" />");
+
+            Assert.Equal("spike2", TypeOfFirst(doc));
+        }
+
+        [Fact]
+        public void BouncerWithOutOfRangeSizeLeftUnchanged()
+        {
+            LevelDocument doc = Load("<bouncer2 x=\"10\" y=\"20\" size=\"5\" />");
+
+            Assert.Equal("bouncer2", TypeOfFirst(doc));
+        }
+    }
+}


### PR DESCRIPTION
## Description

On level load, spike (`spike1-4`) and bouncer (`bouncer1/2`) tags are normalized so the tag suffix agrees with the object's `size` attribute — e.g. `spike2 size="3"` becomes `spike3 size="3"`.

Cut the Rope: DX reads the size of spikes and bouncers purely from the `size` attribute. The number in the tag name is only used for dispatch and is otherwise ignored:

- `Spikes.GetSpikeTextureAndQuad` selects the quad from the `size` value (1-4, or 5/`electro` for electrodes).
- `Bouncer.InitWithPosXYWidthAndAngle` selects small/large from `size` (1/2).

So `spike2 size="3"` already renders identically to `spike3 size="3"` in-game. Making the tag agree with the authoritative `size` attribute keeps the editor's stored XML self-consistent and is lossless in game behavior.