### PR TITLE
refactor: Localize remaining hardcoded strings, unify dialog headers, and browser download cleanup

### DIFF
--- a/src/CtrDxEditor.Browser/Program.cs
+++ b/src/CtrDxEditor.Browser/Program.cs
@@ -26,6 +26,9 @@ AppBuilder BuildAvaloniaApp()
         SpriteImageExtension = ".webp",
         DownloadSizeLabel = "30 MB",
         ManualDownloadUrl = ContentDownloader.WebpAssetsUrl,
+        // The asset host doesn't send CORS headers, so an in-app fetch fails in the browser;
+        // offer only manual download + zip upload there.
+        AllowDirectDownload = false,
         ResolveInstalled = async () =>
             await contentStore.IsPopulatedAsync() ? contentStore : null,
     };

--- a/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
@@ -41,7 +41,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"true\"",
                 "<candyL x=\"1\" y=\"1\" /><target x=\"3\" y=\"3\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("candy half"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.TwoPartMissingHalf");
         }
 
         /// <summary>Two-part levels warn when they also contain a plain candy.</summary>
@@ -51,7 +51,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"true\"",
                 "<candyL x=\"1\" y=\"1\" /><candyR x=\"2\" y=\"2\" /><candy x=\"9\" y=\"9\" /><target x=\"3\" y=\"3\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("plain candy"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.TwoPartHasPlainCandy");
         }
 
         /// <summary>Single-candy levels warn when split-candy objects are present.</summary>
@@ -61,7 +61,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<candy x=\"1\" y=\"1\" /><candyL x=\"5\" y=\"5\" /><target x=\"3\" y=\"3\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("candyL/candyR"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.SingleCandyHasHalves");
         }
 
         /// <summary>Night levels warn when no light bulb exists.</summary>
@@ -71,7 +71,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("nightLevel=\"true\"",
                 "<candy x=\"1\" y=\"1\" /><target x=\"3\" y=\"3\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("light bulb"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.NightNoBulb");
         }
 
         /// <summary>Levels warn when they are missing candy and Om Nom target objects.</summary>
@@ -80,9 +80,9 @@ namespace CtrDxEditor.Core.Tests
         {
             LevelDocument doc = Doc("twoParts=\"false\"", "");
 
-            IReadOnlyList<string> warnings = LevelValidator.Validate(doc);
-            Assert.Contains(warnings, w => w.Contains("no candy"));
-            Assert.Contains(warnings, w => w.Contains("Om Nom"));
+            IReadOnlyList<LevelWarning> warnings = LevelValidator.Validate(doc);
+            Assert.Contains(warnings, w => w.Key == "Validation.NoCandy");
+            Assert.Contains(warnings, w => w.Key == "Validation.NoTarget");
         }
 
         /// <summary>A captured lantern supplies the implicit primary candy, so no "no candy" warning fires.</summary>
@@ -92,7 +92,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<target x=\"1\" y=\"1\" /><lantern x=\"2\" y=\"2\" candyCaptured=\"true\" />");
 
-            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Contains("no candy", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.NoCandy");
         }
 
         /// <summary>An idle lantern feeds nothing, so a candy-less level still warns.</summary>
@@ -102,7 +102,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<target x=\"1\" y=\"1\" /><lantern x=\"2\" y=\"2\" candyCaptured=\"false\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("no candy", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.NoCandy");
         }
 
         /// <summary>Levels below the supported resolution floor produce a size warning.</summary>
@@ -119,7 +119,7 @@ namespace CtrDxEditor.Core.Tests
                 </map>
                 """);
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("smaller than 320"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.ResolutionTooSmall");
         }
 
         /// <summary>Normal level resolutions do not produce size warnings.</summary>
@@ -128,7 +128,7 @@ namespace CtrDxEditor.Core.Tests
         {
             LevelDocument doc = Doc("twoParts=\"false\"", "<candy x=\"1\" y=\"1\" /><target x=\"2\" y=\"2\" />");
 
-            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Contains("smaller than"));
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.ResolutionTooSmall");
         }
 
         /// <summary>Duplicate candyNumber values produce a validation warning.</summary>
@@ -138,7 +138,7 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<target x=\"1\" y=\"1\" /><candy x=\"1\" y=\"1\" candyNumber=\"0\" /><candy x=\"2\" y=\"2\" candyNumber=\"0\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.DuplicateCandyNumber");
         }
 
         /// <summary>Grabs with a candyNumber that no candy has produce a warning.</summary>
@@ -148,7 +148,8 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<target x=\"1\" y=\"1\" /><candy x=\"1\" y=\"1\" candyNumber=\"0\" /><grab x=\"3\" y=\"3\" length=\"10\" candyNumber=\"7\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("candyNumber", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(LevelValidator.Validate(doc),
+                w => w.Key == "Validation.GrabUnmatchedCandyNumber" && w.Args.Contains("7"));
         }
 
         /// <summary>Bulb-bound grabs warn when their bulbNumber has no matching bulb.</summary>
@@ -158,7 +159,8 @@ namespace CtrDxEditor.Core.Tests
             LevelDocument doc = Doc("twoParts=\"false\"",
                 "<target x=\"1\" y=\"1\" /><candy x=\"1\" y=\"1\" candyNumber=\"0\" /><grab x=\"3\" y=\"3\" bindBulb=\"true\" bulbNumber=\"5\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("bulbNumber", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(LevelValidator.Validate(doc),
+                w => w.Key == "Validation.GrabUnmatchedBulbNumber" && w.Args.Contains("5"));
         }
 
         /// <summary>A ghost with all morph states off warns that it does nothing.</summary>
@@ -169,7 +171,7 @@ namespace CtrDxEditor.Core.Tests
                 "<candy x=\"1\" y=\"1\" /><target x=\"3\" y=\"3\" />" +
                 "<ghost x=\"5\" y=\"5\" grab=\"false\" bubble=\"false\" bouncer=\"false\" />");
 
-            Assert.Contains(LevelValidator.Validate(doc), w => w.Contains("no enabled states"));
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.GhostIdle");
         }
 
         /// <summary>A ghost with at least one state produces no idle warning.</summary>
@@ -180,7 +182,7 @@ namespace CtrDxEditor.Core.Tests
                 "<candy x=\"1\" y=\"1\" /><target x=\"3\" y=\"3\" />" +
                 "<ghost x=\"5\" y=\"5\" grab=\"true\" bubble=\"false\" bouncer=\"false\" />");
 
-            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Contains("no enabled states"));
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.GhostIdle");
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/LevelValidator.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelValidator.cs
@@ -7,15 +7,15 @@ using CtrDxEditor.Core.Document;
 namespace CtrDxEditor.Core.Editing
 {
     /// <summary>
-    /// Non-blocking structural checks for a level. Returns human-readable warnings describing
-    /// states that make the level crash or play incorrectly in Cut the Rope: DX.
+    /// Non-blocking structural checks for a level. Returns keyed warnings describing states that
+    /// make the level crash or play incorrectly in Cut the Rope: DX; the UI layer localizes them.
     /// </summary>
     public static class LevelValidator
     {
         /// <summary>Returns the level's structural warnings, or an empty list when it looks playable.</summary>
-        public static IReadOnlyList<string> Validate(LevelDocument document)
+        public static IReadOnlyList<LevelWarning> Validate(LevelDocument document)
         {
-            List<string> warnings = [];
+            List<LevelWarning> warnings = [];
 
             IReadOnlyList<LevelObject> objects = document.Objects;
             bool HasType(string type)
@@ -31,42 +31,42 @@ namespace CtrDxEditor.Core.Editing
             {
                 if (!hasLeft || !hasRight)
                 {
-                    warnings.Add("Two-part level is missing a candy half - DX will crash without both candyL and candyR.");
+                    warnings.Add(new LevelWarning("Validation.TwoPartMissingHalf"));
                 }
                 if (hasCandy)
                 {
-                    warnings.Add("Two-part level shouldn't contain a plain candy.");
+                    warnings.Add(new LevelWarning("Validation.TwoPartHasPlainCandy"));
                 }
             }
             else
             {
                 if (hasLeft || hasRight)
                 {
-                    warnings.Add("Single-candy level shouldn't contain candyL/candyR.");
+                    warnings.Add(new LevelWarning("Validation.SingleCandyHasHalves"));
                 }
             }
 
             if (document.NightLevel && !HasType("lightBulb"))
             {
-                warnings.Add("Night level has no light bulb; it will render fully dark.");
+                warnings.Add(new LevelWarning("Validation.NightNoBulb"));
             }
 
             bool capturedLantern = document.Objects.Any(LanternObject.IsCaptured);
             if (!hasCandy && !hasLeft && !hasRight && !capturedLantern)
             {
-                warnings.Add("Level has no candy.");
+                warnings.Add(new LevelWarning("Validation.NoCandy"));
             }
 
             if (!HasType("target"))
             {
-                warnings.Add("Level has no Om Nom (target).");
+                warnings.Add(new LevelWarning("Validation.NoTarget"));
             }
 
             // Sizes below the smallest real level (320x480) are almost certainly a hand-edit mistake.
             // Warn only - auto-defaulting the size would break the lossless XML round-trip.
             if (document.Width < 320 || document.Height < 480)
             {
-                warnings.Add("Level resolution is smaller than 320x480.");
+                warnings.Add(new LevelWarning("Validation.ResolutionTooSmall"));
             }
 
             // Duplicate candy keys collide under string-identity matching.
@@ -80,7 +80,7 @@ namespace CtrDxEditor.Core.Editing
             ];
             if (candyKeys.Count != candyKeys.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {
-                warnings.Add("Duplicate candyNumber values found; grabs cannot tell those candies apart.");
+                warnings.Add(new LevelWarning("Validation.DuplicateCandyNumber"));
             }
 
             foreach (LevelObject grab in objects.Where(o => o.Type == "grab"))
@@ -89,7 +89,7 @@ namespace CtrDxEditor.Core.Editing
                 if (candyNumber is not null
                     && !candyKeys.Any(k => string.Equals(k, candyNumber.Trim(), StringComparison.OrdinalIgnoreCase)))
                 {
-                    warnings.Add($"A grab references candyNumber '{candyNumber}', which no candy has; it will bind to the primary candy.");
+                    warnings.Add(new LevelWarning("Validation.GrabUnmatchedCandyNumber", candyNumber));
                 }
 
                 if (IsTrueAttr(grab, "bindBulb"))
@@ -101,7 +101,7 @@ namespace CtrDxEditor.Core.Editing
                         && string.Equals(o.GetAttr("bulbNumber")?.Trim(), bulbNumber.Trim(), StringComparison.OrdinalIgnoreCase));
                     if (!anyBulbMatches)
                     {
-                        warnings.Add($"A grab binds to bulbNumber '{bulbNumber}', which no light bulb has.");
+                        warnings.Add(new LevelWarning("Validation.GrabUnmatchedBulbNumber", bulbNumber ?? string.Empty));
                     }
                 }
             }
@@ -110,7 +110,7 @@ namespace CtrDxEditor.Core.Editing
             {
                 if (GhostStates.IsIdleOnly(ghost))
                 {
-                    warnings.Add("A ghost has no enabled states (grab/bubble/bouncer); it will sit idle and do nothing.");
+                    warnings.Add(new LevelWarning("Validation.GhostIdle"));
                 }
             }
 

--- a/src/CtrDxEditor.Core/Editing/LevelWarning.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelWarning.cs
@@ -1,0 +1,9 @@
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// A single structural warning from <see cref="LevelValidator"/>: a localization key plus any
+    /// format arguments the message needs. Core stays presentation-agnostic - the UI layer resolves
+    /// <see cref="Key"/> to text and substitutes <see cref="Args"/>.
+    /// </summary>
+    public sealed record LevelWarning(string Key, params object[] Args);
+}

--- a/src/CtrDxEditor.Shared/App.axaml.cs
+++ b/src/CtrDxEditor.Shared/App.axaml.cs
@@ -73,7 +73,8 @@ namespace CtrDxEditor
                 _startup.Installer,
                 async () => await TryShowEditorAsync(root, _startup.InstalledStore()),
                 allowQuit: allowQuit,
-                allowManualDownload: allowQuit,
+                allowManualDownload: true,
+                allowDownload: _startup.AllowDirectDownload,
                 downloadSizeLabel: _startup.DownloadSizeLabel,
                 manualDownloadUrl: _startup.ManualDownloadUrl);
             ContentSetupDialog dialog = new() { DataContext = vm };

--- a/src/CtrDxEditor.Shared/Content/ContentDownloader.cs
+++ b/src/CtrDxEditor.Shared/Content/ContentDownloader.cs
@@ -17,7 +17,7 @@ namespace CtrDxEditor.Content
 
         /// <summary>Direct URL for the browser's WebP-sprite asset bundle (smaller download than the desktop bundle).</summary>
         public const string WebpAssetsUrl =
-            "https://github.com/yell0wsuit/ctrdx-assets/releases/latest/download/webp-assets.zip";
+            "https://github.com/yell0wsuit/ctrdx-assets/releases/latest/download/ctrdx-webp.zip";
 
         /// <summary>
         /// Downloads the asset bundle and installs it into <paramref name="destContentDir"/> for the

--- a/src/CtrDxEditor.Shared/Localization/Localizer.cs
+++ b/src/CtrDxEditor.Shared/Localization/Localizer.cs
@@ -8,6 +8,7 @@ using Avalonia.Platform;
 
 using CtrDxEditor.Content;
 using CtrDxEditor.Core.Descriptors;
+using CtrDxEditor.Core.Editing;
 
 namespace CtrDxEditor.Localization
 {
@@ -70,6 +71,15 @@ namespace CtrDxEditor.Localization
         public static string Get(string key)
         {
             return Strings.TryGetValue(key, out string? value) ? value : key;
+        }
+
+        /// <summary>Resolves a validator <see cref="LevelWarning"/> to its localized, formatted message.</summary>
+        public static string Format(LevelWarning warning)
+        {
+            string template = Get(warning.Key);
+            return warning.Args.Length == 0
+                ? template
+                : string.Format(CultureInfo.CurrentCulture, template, warning.Args);
         }
 
         /// <summary>Display name for a level element, falling back to its descriptor then its raw id.</summary>

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -70,11 +70,14 @@
     "Dialog.LevelSettings.TitleNew": "New level",
     "Dialog.LevelSettings.TitleEdit": "Level settings",
     "Dialog.LevelSettings.Resolution": "Resolution",
+    "Dialog.LevelSettings.Custom": "Custom...",
     "Dialog.LevelSettings.Width": "Width",
     "Dialog.LevelSettings.Height": "Height",
     "Dialog.LevelSettings.RopePhysicsSpeed": "Rope physics speed",
     "Dialog.LevelSettings.Special": "Special tutorial prompt",
     "Dialog.LevelSettings.SpecialTooltip": "Staging id for the game's built-in tutorial prompts. Might have no effect in custom levels.",
+    "Dialog.LevelSettings.Special.None": "None",
+    "Dialog.LevelSettings.Special.Default": "Default",
     "Dialog.LevelSettings.EnterNumber": "Enter a number",
     "Dialog.LevelSettings.HalfCandy": "Half candy",
     "Dialog.LevelSettings.NightLevel": "Night level",
@@ -122,6 +125,7 @@
     "Dialog.Validation.SaveProceed": "Save anyway",
     "Dialog.Validation.EditPrompt": "Would you like to edit it anyway?",
     "Dialog.Validation.EditProceed": "Edit anyway",
+
     "Dialog.Unsaved.Header": "Unsaved changes",
     "Dialog.Unsaved.Body": "You have unsaved changes that will be lost.",
     "Dialog.Unsaved.Close": "Discard and close",
@@ -205,5 +209,17 @@
     "Attr.bubble": "Bubble",
     "Attr.bouncer": "Bouncer",
 
-    "Hint.PolylinePointLimit": "Movement path is at its 99-point limit"
+    "Hint.PolylinePointLimit": "Movement path is at its 99-point limit",
+
+    "Validation.TwoPartMissingHalf": "Two-part level is missing a candy half.",
+    "Validation.TwoPartHasPlainCandy": "Two-part level shouldn't contain a plain candy.",
+    "Validation.SingleCandyHasHalves": "Single-candy level shouldn't contain candyL/candyR.",
+    "Validation.NightNoBulb": "Night level has no light bulb.",
+    "Validation.NoCandy": "Level has no candy.",
+    "Validation.NoTarget": "Level has no Om Nom.",
+    "Validation.ResolutionTooSmall": "Level resolution is smaller than 320x480.",
+    "Validation.DuplicateCandyNumber": "Duplicate candyNumber values found; grabs cannot tell those candies apart.",
+    "Validation.GrabUnmatchedCandyNumber": "A grab references candyNumber '{0}', which no candy has, it will bind to the primary candy.",
+    "Validation.GrabUnmatchedBulbNumber": "A grab binds to bulbNumber '{0}', which no light bulb has.",
+    "Validation.GhostIdle": "A ghost has no enabled states (grab/bubble/bouncer), it will sit idle and do nothing."
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -62,6 +62,7 @@
     "Dialog.ContentSetup.PickZip": "Browse zip…",
     "Dialog.ContentSetup.Cancel": "Cancel",
     "Dialog.ContentSetup.CancelConfirm": "Cancel the download?",
+    "Dialog.ContentSetup.CancelConfirm.Body": "Any downloaded progress will be lost.",
     "Dialog.ContentSetup.CancelConfirm.Yes": "Yes, cancel",
     "Dialog.ContentSetup.CancelConfirm.No": "Keep downloading",
     "Dialog.ContentSetup.Error.DownloadFailed": "Download failed: ",
@@ -120,7 +121,8 @@
     "Dialog.LevelSettings.Create": "Create",
     "Dialog.LevelSettings.Save": "Save",
 
-    "Dialog.Validation.Body": "This level may not be playable:",
+    "Dialog.Validation.Header": "This level may not be playable",
+    "Dialog.Validation.Body": "Reasons:",
     "Dialog.Validation.SavePrompt": "Save it anyway?",
     "Dialog.Validation.SaveProceed": "Save anyway",
     "Dialog.Validation.EditPrompt": "Would you like to edit it anyway?",

--- a/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
+++ b/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
@@ -28,5 +28,8 @@ namespace CtrDxEditor.Startup
 
         /// <summary>Direct download URL for this platform's asset bundle, opened in the browser by Download Manually.</summary>
         public required string ManualDownloadUrl { get; init; }
+
+        /// <summary>Whether the in-app direct download is offered; false where a cross-origin fetch is blocked (the browser), leaving only manual download + zip upload.</summary>
+        public bool AllowDirectDownload { get; init; } = true;
     }
 }

--- a/src/CtrDxEditor.Shared/ViewModels/ContentSetupViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/ContentSetupViewModel.cs
@@ -40,7 +40,10 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Whether the Quit button is shown (desktop can quit the app; the browser never does).</summary>
         public bool AllowQuit { get; }
 
-        /// <summary>Whether the Download Manually button is shown (desktop opens the bundle's direct URL in the browser).</summary>
+        /// <summary>Whether the in-app Download button is shown; false where a cross-origin fetch is blocked (the browser), leaving only manual download and zip upload.</summary>
+        public bool AllowDownload { get; }
+
+        /// <summary>Whether the Download Manually button is shown (opens the bundle's direct URL in a new tab / the default browser).</summary>
         public bool AllowManualDownload { get; }
 
         /// <summary>Direct download URL opened in the browser when the user clicks Download Manually.</summary>
@@ -49,8 +52,8 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Approximate size of the platform's asset bundle (e.g. "336 MB"), or empty to show nothing.</summary>
         public string DownloadSizeLabel { get; }
 
-        /// <summary>Whether the download-size disclosure should be shown: idle, and a label was supplied.</summary>
-        public bool ShowDownloadSizeLabel => !IsBusy && !string.IsNullOrEmpty(DownloadSizeLabel);
+        /// <summary>Whether the download-size disclosure should be shown: idle, direct download available, and a label was supplied.</summary>
+        public bool ShowDownloadSizeLabel => !IsBusy && AllowDownload && !string.IsNullOrEmpty(DownloadSizeLabel);
 
         /// <summary>Raised once content setup succeeds, so the view can close.</summary>
         public event Action? Completed;
@@ -61,13 +64,14 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Creates a content setup view model.</summary>
         public ContentSetupViewModel(
             IContentInstaller installer, Func<Task> onInstalled,
-            bool allowQuit = true, bool allowManualDownload = true, string downloadSizeLabel = "",
-            string manualDownloadUrl = ContentDownloader.AssetsUrl)
+            bool allowQuit = true, bool allowManualDownload = true, bool allowDownload = true,
+            string downloadSizeLabel = "", string manualDownloadUrl = ContentDownloader.AssetsUrl)
         {
             _installer = installer;
             _onInstalled = onInstalled;
             AllowQuit = allowQuit;
             AllowManualDownload = allowManualDownload;
+            AllowDownload = allowDownload;
             DownloadSizeLabel = downloadSizeLabel;
             ManualDownloadUrl = manualDownloadUrl;
             // AsyncRelayCommand disallows concurrent executions by default, so re-clicks are ignored while busy.

--- a/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
@@ -109,7 +109,7 @@ namespace CtrDxEditor.ViewModels
             new("640 x 480", 640, 480, false),
             new("320 x 960", 320, 960, false),
             new("640 x 960", 640, 960, false),
-            new("Custom...", 0, 0, true),
+            new(Localizer.Get("Dialog.LevelSettings.Custom"), 0, 0, true),
         ];
 
         [ObservableProperty]
@@ -124,9 +124,9 @@ namespace CtrDxEditor.ViewModels
         /// </summary>
         public ObservableCollection<SpecialOption> SpecialOptions { get; } =
         [
-            new("None", 0),
-            new("Default", 1),
-            new("Custom...", 0, IsCustom: true),
+            new(Localizer.Get("Dialog.LevelSettings.Special.None"), 0),
+            new(Localizer.Get("Dialog.LevelSettings.Special.Default"), 1),
+            new(Localizer.Get("Dialog.LevelSettings.Custom"), 0, IsCustom: true),
         ];
 
         // NumericUpDown.Value is decimal?, so these bind as decimal? (an exact match avoids the

--- a/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml
@@ -48,8 +48,10 @@
 
       <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right"
                   IsVisible="{Binding !IsBusy}">
-        <Button Content="{loc:Tr Dialog.ContentSetup.Download}" Classes="accent" Command="{Binding DownloadCommand}" />
-        <Button Content="{loc:Tr Dialog.ContentSetup.DownloadManually}" Click="DownloadManually_Click" />
+        <Button Content="{loc:Tr Dialog.ContentSetup.Download}" Classes="accent" Command="{Binding DownloadCommand}"
+                IsVisible="{Binding AllowDownload}" />
+        <Button Content="{loc:Tr Dialog.ContentSetup.DownloadManually}" Click="DownloadManually_Click"
+                IsVisible="{Binding AllowManualDownload}" />
         <Button Content="{loc:Tr Dialog.ContentSetup.PickZip}" Click="PickZip_Click" IsEnabled="{Binding !IsBusy}" />
         <Button Content="{loc:Tr Dialog.Common.Quit}" Click="Quit_Click" IsVisible="{Binding AllowQuit}" />
       </StackPanel>

--- a/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
@@ -21,7 +20,7 @@ namespace CtrDxEditor.Views
     public partial class ContentSetupDialog : BaseDialog<string>
     {
         private ContentSetupViewModel? _vm;
-        private TwofoldDialog? _cancelConfirm;
+        private ConfirmDialog? _cancelConfirm;
 
         /// <summary>Creates the content setup dialog and wires view-model completion handling.</summary>
         public ContentSetupDialog()
@@ -107,13 +106,10 @@ namespace CtrDxEditor.Views
 
             // Confirm before aborting; the download keeps running behind this nested dialog.
             // Tracked so OnCompleted can dismiss it if the download finishes first.
-            _cancelConfirm = new TwofoldDialog
+            _cancelConfirm = new ConfirmDialog
             {
-                // TwofoldDialog defaults to a narrow 300px width with two equal columns, which
-                // clips longer button labels; widen it and tighten the button margins so they fit.
-                Width = 420,
-                ButtonMargin = new Thickness(4, 12, 4, 0),
-                Message = Localizer.Get("Dialog.ContentSetup.CancelConfirm"),
+                Header = Localizer.Get("Dialog.ContentSetup.CancelConfirm"),
+                Message = Localizer.Get("Dialog.ContentSetup.CancelConfirm.Body"),
                 PositiveText = Localizer.Get("Dialog.ContentSetup.CancelConfirm.Yes"),
                 NegativeText = Localizer.Get("Dialog.ContentSetup.CancelConfirm.No"),
             };

--- a/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
@@ -136,10 +136,10 @@ namespace CtrDxEditor.Views
 
         // Shows the non-blocking validation warning; returns true when the user chooses to proceed.
         private static async Task<bool> ConfirmValidationAsync(
-            IReadOnlyList<string> warnings, string promptKey, string proceedKey)
+            IReadOnlyList<LevelWarning> warnings, string promptKey, string proceedKey)
         {
             string body = Localizer.Get("Dialog.Validation.Body") + "\n\n"
-                + string.Join("\n", warnings.Select(w => "- " + w)) + "\n\n"
+                + string.Join("\n", warnings.Select(w => "- " + Localizer.Format(w))) + "\n\n"
                 + Localizer.Get(promptKey);
             TwofoldDialog dialog = new()
             {
@@ -174,7 +174,7 @@ namespace CtrDxEditor.Views
                 using StreamReader reader = new(stream);
                 string xml = await reader.ReadToEndAsync();
 
-                IReadOnlyList<string> warnings = LevelValidator.Validate(LevelDocument.Parse(xml));
+                IReadOnlyList<LevelWarning> warnings = LevelValidator.Validate(LevelDocument.Parse(xml));
                 if (warnings.Count > 0
                     && !await ConfirmValidationAsync(warnings, "Dialog.Validation.EditPrompt", "Dialog.Validation.EditProceed"))
                 {
@@ -344,7 +344,7 @@ namespace CtrDxEditor.Views
         {
             if (vm.Document is { } doc)
             {
-                IReadOnlyList<string> warnings = LevelValidator.Validate(doc);
+                IReadOnlyList<LevelWarning> warnings = LevelValidator.Validate(doc);
                 if (warnings.Count > 0
                     && !await ConfirmValidationAsync(warnings, "Dialog.Validation.SavePrompt", "Dialog.Validation.SaveProceed"))
                 {

--- a/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Data;
@@ -12,8 +11,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-
-using AvaloniaDialogs.Views;
 
 using CtrDxEditor.Content;
 using CtrDxEditor.Core.Document;
@@ -141,10 +138,9 @@ namespace CtrDxEditor.Views
             string body = Localizer.Get("Dialog.Validation.Body") + "\n\n"
                 + string.Join("\n", warnings.Select(w => "- " + Localizer.Format(w))) + "\n\n"
                 + Localizer.Get(promptKey);
-            TwofoldDialog dialog = new()
+            ConfirmDialog dialog = new()
             {
-                Width = 460,
-                ButtonMargin = new Thickness(4, 12, 4, 0),
+                Header = Localizer.Get("Dialog.Validation.Header"),
                 Message = body,
                 PositiveText = Localizer.Get(proceedKey),
                 NegativeText = Localizer.Get("Dialog.Common.Cancel"),

--- a/src/CtrDxEditor.Tests/ContentDownloaderTests.cs
+++ b/src/CtrDxEditor.Tests/ContentDownloaderTests.cs
@@ -41,7 +41,7 @@ namespace CtrDxEditor.Tests
         public void WebpAssetsUrlIsDistinctFromDesktopAssetsUrl()
         {
             Assert.NotEqual(ContentDownloader.AssetsUrl, ContentDownloader.WebpAssetsUrl);
-            Assert.EndsWith("/webp-assets.zip", ContentDownloader.WebpAssetsUrl);
+            Assert.EndsWith("/ctrdx-webp.zip", ContentDownloader.WebpAssetsUrl);
             Assert.StartsWith("https://github.com/yell0wsuit/ctrdx-assets/releases/", ContentDownloader.WebpAssetsUrl);
         }
     }

--- a/src/CtrDxEditor.Tests/ContentSetupViewModelTests.cs
+++ b/src/CtrDxEditor.Tests/ContentSetupViewModelTests.cs
@@ -28,25 +28,40 @@ namespace CtrDxEditor.Tests
             }
         }
 
-        /// <summary>Verifies allowQuit/allowManualDownload default to true, matching today's always-shown buttons.</summary>
+        /// <summary>Verifies the button-visibility flags default to true, matching today's always-shown buttons.</summary>
         [Fact]
-        public void AllowQuitAndAllowManualDownloadDefaultToTrue()
+        public void ButtonFlagsDefaultToTrue()
         {
             ContentSetupViewModel vm = new(new FakeInstaller(), () => Task.CompletedTask);
 
             Assert.True(vm.AllowQuit);
             Assert.True(vm.AllowManualDownload);
+            Assert.True(vm.AllowDownload);
         }
 
-        /// <summary>Verifies allowQuit/allowManualDownload can each be disabled independently (the browser's setup).</summary>
+        /// <summary>Verifies the button-visibility flags can each be disabled independently.</summary>
         [Fact]
-        public void AllowQuitAndAllowManualDownloadCanBeDisabledIndependently()
+        public void ButtonFlagsCanBeDisabledIndependently()
         {
             ContentSetupViewModel vm = new(
                 new FakeInstaller(), () => Task.CompletedTask, allowQuit: false, allowManualDownload: true);
 
             Assert.False(vm.AllowQuit);
             Assert.True(vm.AllowManualDownload);
+        }
+
+        /// <summary>The browser setup hides the in-app download (CORS-blocked) and its size disclosure, keeping manual download.</summary>
+        [Fact]
+        public void BrowserSetupHidesDirectDownloadButKeepsManual()
+        {
+            ContentSetupViewModel vm = new(
+                new FakeInstaller(), () => Task.CompletedTask,
+                allowQuit: false, allowManualDownload: true, allowDownload: false, downloadSizeLabel: "30 MB");
+
+            Assert.False(vm.AllowDownload);
+            Assert.True(vm.AllowManualDownload);
+            // The size disclosure is tied to the in-app download, so it hides too even with a label supplied.
+            Assert.False(vm.ShowDownloadSizeLabel);
         }
 
         /// <summary>Verifies the download-size disclosure is hidden by default (no label supplied).</summary>


### PR DESCRIPTION
## Description

A few related cleanups to the editor's UI layer:

- Moves remaining user-facing hardcoded English strings into the localizer.
- Gives every confirmation dialog a header so they render uniformly.
- Drops the in-app fetch download on the browser head (CORS-blocked) and renames the WebP bundle to `ctrdx-webp.zip` for consistency with `ctrdx-assets.zip`.