### PR TITLE
fix: prevent dismissing mandatory browser content setup

### DIFF
--- a/src/CtrDxEditor.Shared/App.axaml.cs
+++ b/src/CtrDxEditor.Shared/App.axaml.cs
@@ -69,9 +69,9 @@ namespace CtrDxEditor
 
             // Either no content is installed, or installed content passed the cheap existence check
             // yet failed to actually load (wrong-platform bundle, corrupt atlas, ...): run setup.
-            // The dialog tries to block Escape while setup is mandatory, but the browser has no Quit
-            // action and cannot run without content, so if it is dismissed anyway (Escape) without
-            // installing, re-open it until content actually loads. Desktop instead quits on dismissal.
+            // Browser setup blocks dismissal because the editor cannot run without content. Keep the
+            // loop as a defensive fallback in case the dialog is removed by some mechanism other than
+            // its normal close path. Desktop instead quits on dismissal.
             do
             {
                 ContentSetupViewModel vm = new(

--- a/src/CtrDxEditor.Shared/App.axaml.cs
+++ b/src/CtrDxEditor.Shared/App.axaml.cs
@@ -69,22 +69,30 @@ namespace CtrDxEditor
 
             // Either no content is installed, or installed content passed the cheap existence check
             // yet failed to actually load (wrong-platform bundle, corrupt atlas, ...): run setup.
-            ContentSetupViewModel vm = new(
-                _startup.Installer,
-                async () => await TryShowEditorAsync(root, _startup.InstalledStore()),
-                allowQuit: allowQuit,
-                allowManualDownload: true,
-                allowDownload: _startup.AllowDirectDownload,
-                downloadSizeLabel: _startup.DownloadSizeLabel,
-                manualDownloadUrl: _startup.ManualDownloadUrl);
-            ContentSetupDialog dialog = new() { DataContext = vm };
-            _ = await dialog.ShowAsync();
-
-            // Desktop may quit if the user dismissed setup without installing; the browser never quits.
-            if (allowQuit && root.DataContext is null)
+            // The dialog tries to block Escape while setup is mandatory, but the browser has no Quit
+            // action and cannot run without content, so if it is dismissed anyway (Escape) without
+            // installing, re-open it until content actually loads. Desktop instead quits on dismissal.
+            do
             {
-                desktop?.Shutdown();
+                ContentSetupViewModel vm = new(
+                    _startup.Installer,
+                    async () => await TryShowEditorAsync(root, _startup.InstalledStore()),
+                    allowQuit: allowQuit,
+                    allowManualDownload: true,
+                    allowDownload: _startup.AllowDirectDownload,
+                    downloadSizeLabel: _startup.DownloadSizeLabel,
+                    manualDownloadUrl: _startup.ManualDownloadUrl);
+                ContentSetupDialog dialog = new() { DataContext = vm };
+                _ = await dialog.ShowAsync();
+
+                if (allowQuit && root.DataContext is null)
+                {
+                    // Desktop: dismissing setup without installing quits the app.
+                    desktop?.Shutdown();
+                    return;
+                }
             }
+            while (root.DataContext is null);
         }
 
         private async Task<bool> TryShowEditorAsync(Control root, IContentStore store)

--- a/src/CtrDxEditor.Shared/ViewModels/ContentSetupViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/ContentSetupViewModel.cs
@@ -40,6 +40,9 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Whether the Quit button is shown (desktop can quit the app; the browser never does).</summary>
         public bool AllowQuit { get; }
 
+        /// <summary>Whether the setup dialog may be dismissed: immediately on desktop, or after browser setup completes.</summary>
+        public bool CanDismiss { get; private set; }
+
         /// <summary>Whether the in-app Download button is shown; false where a cross-origin fetch is blocked (the browser), leaving only manual download and zip upload.</summary>
         public bool AllowDownload { get; }
 
@@ -70,6 +73,7 @@ namespace CtrDxEditor.ViewModels
             _installer = installer;
             _onInstalled = onInstalled;
             AllowQuit = allowQuit;
+            CanDismiss = allowQuit;
             AllowManualDownload = allowManualDownload;
             AllowDownload = allowDownload;
             DownloadSizeLabel = downloadSizeLabel;
@@ -151,6 +155,7 @@ namespace CtrDxEditor.ViewModels
         private async Task CompleteAsync()
         {
             await _onInstalled();
+            CanDismiss = true;
             Completed?.Invoke();
         }
     }

--- a/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
@@ -69,6 +69,14 @@ namespace CtrDxEditor.Views
             Close("");
         }
 
+        /// <inheritdoc />
+        public override bool OnClosing()
+        {
+            // Browser setup is mandatory because the editor cannot run without content. In
+            // particular, keep Escape from dismissing the dialog while an install is in flight.
+            return _vm?.CanDismiss ?? true;
+        }
+
         private async void PickZip_Click(object? sender, RoutedEventArgs e)
         {
             if (DataContext is not ContentSetupViewModel vm)

--- a/src/CtrDxEditor.Tests/ContentSetupViewModelTests.cs
+++ b/src/CtrDxEditor.Tests/ContentSetupViewModelTests.cs
@@ -64,6 +64,24 @@ namespace CtrDxEditor.Tests
             Assert.False(vm.ShowDownloadSizeLabel);
         }
 
+        /// <summary>Browser setup is mandatory until installation completes, while desktop setup remains dismissible.</summary>
+        [Fact]
+        public async Task CanDismissReflectsQuitPermissionAndCompletion()
+        {
+            ContentSetupViewModel browser = new(
+                new FakeInstaller(), () => Task.CompletedTask, allowQuit: false);
+            ContentSetupViewModel desktop = new(
+                new FakeInstaller(), () => Task.CompletedTask, allowQuit: true);
+
+            Assert.False(browser.CanDismiss);
+            Assert.True(desktop.CanDismiss);
+
+            using MemoryStream zip = new();
+            await browser.InstallFromZipAsync(zip);
+
+            Assert.True(browser.CanDismiss);
+        }
+
         /// <summary>Verifies the download-size disclosure is hidden by default (no label supplied).</summary>
         [Fact]
         public void ShowDownloadSizeLabelIsFalseWhenNoLabelSupplied()


### PR DESCRIPTION
## Description

In the browser, pressing <kbd>Esc</kbd> could dismiss the content setup dialog before the required assets were installed, leaving the editor unusable.

This PR prevents the browser’s mandatory setup dialog from being dismissed until installation completes. The existing prompt loop remains as a defensive fallback if the dialog closes unexpectedly.