### PR TITLE
Fix hitbox overlays and warn when candy spawns inside a hazard/Om Nom

### DIFF
--- a/src/CtrDxEditor.Core.Tests/HazardOverlapTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HazardOverlapTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests the candy-starts-inside-a-breaking-hazard geometric check.</summary>
+    public class HazardOverlapTests
+    {
+        // spike1 desktop band = 212x10 world, +15 tolerance => 242x40 world, /3 => level half-extents
+        // X in [-40.33, 40.33], Y in [-6.67, 6.67] about the spike center.
+        private static LevelDocument Doc(string objects, string flags = "")
+        {
+            return LevelDocument.Parse($"""
+            <map>
+                <layer name="settings">
+                    <map gridSize="32" width="320" height="480" />
+                    <gameDesign {flags} />
+                </layer>
+                <layer name="Objects">{objects}</layer>
+            </map>
+            """);
+        }
+
+        /// <summary>A candy sitting on a spike's center is inside the band and gets flagged.</summary>
+        [Fact]
+        public void CandyCenteredOnSpikeIsFlagged()
+        {
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"0\" /><spike1 x=\"0\" y=\"0\" />");
+            _ = Assert.Single(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>A candy past the band's half-height clears the spike and is not flagged.</summary>
+        [Fact]
+        public void CandyOutsideBandIsNotFlagged()
+        {
+            // y=8 is beyond the band's 6.67 half-height, so no overlap.
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"8\" /><spike1 x=\"0\" y=\"0\" />");
+            Assert.Empty(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>Rotating the spike's band 90 deg brings a candy the axis-aligned band missed into range.</summary>
+        [Fact]
+        public void RotatedSpikeCatchesCandyTheAxisAlignedBandMisses()
+        {
+            // Candy at (0,8): outside the unrotated band, inside once the band is rotated 90 deg.
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"8\" /><spike1 x=\"0\" y=\"0\" angle=\"90\" />");
+            _ = Assert.Single(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>Rotating the spike's band 90 deg moves a candy the axis-aligned band caught out of range.</summary>
+        [Fact]
+        public void RotatedSpikeMissesCandyTheAxisAlignedBandWouldCatch()
+        {
+            // Candy at (40,0): inside the unrotated band, outside once rotated 90 deg.
+            LevelDocument doc = Doc("<candy x=\"40\" y=\"0\" /><spike1 x=\"0\" y=\"0\" angle=\"90\" />");
+            Assert.Empty(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>Electro is a breaking hazard, so a candy on it is flagged like a spike.</summary>
+        [Fact]
+        public void ElectroCountsAsBreakingHazard()
+        {
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"0\" /><electro x=\"0\" y=\"0\" />");
+            _ = Assert.Single(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>Bouncer and bubble do not break candy, so overlapping them is not flagged.</summary>
+        [Fact]
+        public void BouncerAndBubbleAreNotBreakingHazards()
+        {
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"0\" /><bouncer1 x=\"0\" y=\"0\" /><bubble x=\"0\" y=\"0\" />");
+            Assert.Empty(HazardOverlap.CandiesInHazards(doc));
+        }
+
+        /// <summary>Split-candy halves (candyL/candyR) are checked, and only the overlapping half is returned.</summary>
+        [Fact]
+        public void SplitCandyHalvesAreChecked()
+        {
+            LevelDocument doc = Doc(
+                "<candyL x=\"0\" y=\"0\" /><candyR x=\"200\" y=\"200\" /><spike1 x=\"0\" y=\"0\" />",
+                "twoParts=\"true\"");
+            IReadOnlyList<LevelObject> hit = HazardOverlap.CandiesInHazards(doc);
+            _ = Assert.Single(hit);
+            Assert.Equal("candyL", hit[0].Type);
+        }
+
+        /// <summary>The mobile physics model resolves its own band, catching a candy the desktop band would miss.</summary>
+        [Fact]
+        public void MobilePhysicsModelResolves()
+        {
+            // Mobile spike1 band = 204x30 world, +15 => 234x60, /3 => Y half-extent 10. Candy at y=8 is inside.
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"8\" /><spike1 x=\"0\" y=\"0\" />", "useMobilePhysics=\"true\"");
+            _ = Assert.Single(HazardOverlap.CandiesInHazards(doc));
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/HazardOverlapTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HazardOverlapTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -8,223 +8,234 @@ using Xunit;
 
 namespace CtrDxEditor.Core.Tests
 {
-    /// <summary>Tests for mapping game hitboxes into editor level space.</summary>
+    /// <summary>Regression coverage for hitbox geometry ported from the active cuttherope-dx physics model.</summary>
     public class HitboxTests
     {
-        // scale = 3 makes s = scale/mapScale = 1, so level units == game px for clean expectations.
-
-        /// <summary>Verifies that the candy desktop hitbox is centered using its source-size frame.</summary>
-        [Fact]
-        public void CandyDesktopBoxCentersOnObjectUsingSourcesizeFrame()
+        /// <summary>Candy collision remains in raw game-object units even though its artwork is scaled to 0.71.</summary>
+        [Theory]
+        [InlineData(HitboxModel.Desktop, -18, -17.333333333333332, 37.333333333333336, 34.666666666666664)]
+        [InlineData(HitboxModel.Phone, -19.333333333333332, -20.666666666666668, 35, 35)]
+        public void CandyMatchesRawGameObjectBounds(
+            HitboxModel model,
+            double x,
+            double y,
+            double width,
+            double height)
         {
-            // desktop (142,157,112,104), ref (393,418):
-            // center offset = (142+56-196.5, 157+52-209) = (1.5, 0); box = center - size/2.
-            LevelBounds? box = HitboxTable.Compute("candy", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(-54.5, -52, 112, 104), box);
+            LevelBounds? box = HitboxTable.Compute("candy", 0, 0, scale: 0.71, model);
+
+            AssertBounds(box, x, y, width, height);
         }
 
-        /// <summary>Verifies that the star desktop hitbox aligns with the trimmed glow frame.</summary>
-        [Fact]
-        public void StarDesktopBoxUsesTrimmedGlowFrame()
+        /// <summary>Both split candy elements use GetSplitCandyBoundingBox from the game.</summary>
+        [Theory]
+        [InlineData("candyL")]
+        [InlineData("candyR")]
+        public void SplitCandyMatchesGameBounds(string element)
         {
-            // desktop (70,64,82,82), ref (236,223): offset = (-7, -6.5).
-            LevelBounds? box = HitboxTable.Compute("star", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(-48, -47.5, 82, 82), box);
+            AssertBounds(
+                HitboxTable.Compute(element, 0, 0, scale: 0.71, HitboxModel.Desktop),
+                -41 / 3.0,
+                -11,
+                88 / 3.0,
+                76 / 3.0);
         }
 
-        /// <summary>Verifies that the target desktop hitbox maps to the mouth line.</summary>
-        [Fact]
-        public void TargetDesktopBoxIsTheMouthLine()
+        /// <summary>Texture-offset boxes use the game's integer center anchor before world-to-level conversion.</summary>
+        [Theory]
+        [InlineData("bubble", HitboxModel.Desktop, -77, -77, 152, 152)]
+        [InlineData("bubble", HitboxModel.Phone, -125, -125, 171, 171)]
+        [InlineData("star", HitboxModel.Desktop, -48, -47, 82, 82)]
+        [InlineData("star", HitboxModel.Phone, -52, -51, 90, 90)]
+        [InlineData("target", HitboxModel.Desktop, -56, 30, 108, 2)]
+        [InlineData("target", HitboxModel.Phone, -50, 10, 75, 3)]
+        [InlineData("pump", HitboxModel.Desktop, -80, -80, 175, 175)]
+        [InlineData("pump", HitboxModel.Phone, -98, -95, 171, 171)]
+        public void BoundingBoxesMatchDxWorldGeometry(
+            string element,
+            HitboxModel model,
+            double worldX,
+            double worldY,
+            double worldWidth,
+            double worldHeight)
         {
-            // desktop (264,350,108,2), ref (640,640): offset = (-2, 31).
-            LevelBounds? box = HitboxTable.Compute("target", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(-56, 30, 108, 2), box);
+            AssertBounds(
+                HitboxTable.Compute(element, 0, 0, scale: 0.25, model),
+                worldX / 3.0,
+                worldY / 3.0,
+                worldWidth / 3.0,
+                worldHeight / 3.0);
         }
 
-        /// <summary>Verifies that phone hitboxes use WP7 scaling and differ from desktop bounds.</summary>
-        [Fact]
-        public void PhoneBoxScalesRawValuesByWp7AndDiffersFromDesktop()
+        /// <summary>Static spike collision uses the original physics tables, not repacked atlas widths.</summary>
+        [Theory]
+        [InlineData("spike1", 212, 204)]
+        [InlineData("spike2", 333, 318)]
+        [InlineData("spike3", 453, 438)]
+        [InlineData("spike4", 566, 543)]
+        public void StaticSpikesMatchDesktopAndMobilePhysicsConstants(
+            string element,
+            double desktopWidth,
+            double mobileWidth)
         {
-            // phone (46,49,35,35)*3 = (138,147,105,105), ref (393,418):
-            // offset = (138+52.5-196.5, 147+52.5-209) = (-6, -9.5).
-            LevelBounds? box = HitboxTable.Compute("candy", 0, 0, scale: 3, HitboxModel.Phone);
-            Assert.Equal(new LevelBounds(-58.5, -62, 105, 105), box);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30);
         }
 
-        /// <summary>Verifies that object coordinates translate the computed hitbox.</summary>
-        [Fact]
-        public void ObjectPositionTranslatesTheBox()
+        /// <summary>Rotatable spike collision uses the separate rotatable-width tables in the game.</summary>
+        [Theory]
+        [InlineData("spike1", 202, 204)]
+        [InlineData("spike2", 319, 354)]
+        [InlineData("spike3", 444, 426)]
+        [InlineData("spike4", 559, 534)]
+        public void RotatableSpikesMatchDesktopAndMobilePhysicsConstants(
+            string element,
+            double desktopWidth,
+            double mobileWidth)
         {
-            LevelBounds? box = HitboxTable.Compute("candy", 100, 200, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(45.5, 148, 112, 104), box);
+            AssertCenteredStrip(element, toggled: true, HitboxModel.Desktop, desktopWidth, 10);
+            AssertCenteredStrip(element, toggled: true, HitboxModel.Phone, mobileWidth, 30);
         }
 
-        /// <summary>Verifies that per-object scale shrinks the hitbox around the object center.</summary>
+        /// <summary>Electrodes select both width reduction and collision-band height from the active model.</summary>
         [Fact]
-        public void ObjectScaleShrinksTheBoxAboutTheObjectCenter()
+        public void ElectroMatchesActivePhysicsConstants()
         {
-            // candy scale 0.71, s = 0.71/3. Width = 112 * s; center stays near (0,0).
-            LevelBounds? box = HitboxTable.Compute("candy", 0, 0, scale: 0.71, HitboxModel.Desktop);
-            double s = 0.71 / 3.0;
-            _ = Assert.NotNull(box);
-            Assert.Equal(112 * s, box.Value.W, precision: 9);
-            Assert.Equal(104 * s, box.Value.H, precision: 9);
-            Assert.Equal(1.5 * s, box.Value.X + (box.Value.W / 2.0), precision: 9); // center x
-            Assert.Equal(0.0, box.Value.Y + (box.Value.H / 2.0), precision: 9); // center y
+            AssertCenteredStrip("electro", toggled: false, HitboxModel.Desktop, 433, 10);
+            AssertCenteredStrip("electro", toggled: false, HitboxModel.Phone, 411, 30);
         }
 
-        /// <summary>Verifies that the bubble desktop hitbox is the game box centered on its 250px frame.</summary>
-        [Fact]
-        public void BubbleDesktopBoxCentersOnItsFlightFrame()
+        /// <summary>Bouncers use frozen original-asset widths rather than the repacked JSON atlas widths.</summary>
+        [Theory]
+        [InlineData("bouncer1", 194, 138)]
+        [InlineData("bouncer2", 302, 273)]
+        public void BouncersMatchActivePhysicsConstants(
+            string element,
+            double desktopWidth,
+            double mobileWidth)
         {
-            // desktop (48,48,152,152), ref (250,250): offset = (48+76-125, 48+76-125) = (-1, -1).
-            LevelBounds? box = HitboxTable.Compute("bubble", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(-77, -77, 152, 152), box);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30);
         }
 
-        /// <summary>Verifies that the bubble phone hitbox scales the raw WP7 box by 3.</summary>
+        /// <summary>Rocket catch geometry is raw world-space physics and does not inherit the 0.7 art scale.</summary>
         [Fact]
-        public void BubblePhoneBoxScalesRawValuesByWp7()
+        public void RocketMatchesDesktopAndMobileCatchSlatConstants()
         {
-            // phone (0,0,57,57)*3 = (0,0,171,171), ref (250,250): offset = (85.5-125) = (-39.5, -39.5).
-            LevelBounds? box = HitboxTable.Compute("bubble", 0, 0, scale: 3, HitboxModel.Phone);
-            Assert.Equal(new LevelBounds(-125, -125, 171, 171), box);
+            AssertBounds(
+                HitboxTable.Compute("rocket", 0, 0, scale: 0.7, HitboxModel.Desktop),
+                -128.9 / 3.0,
+                -4.975 / 3.0,
+                71.6,
+                8.95 / 3.0);
+            AssertBounds(
+                HitboxTable.Compute("rocket", 0, 0, scale: 0.7, HitboxModel.Phone),
+                -43.3,
+                -1.45,
+                69.6,
+                2.9);
         }
 
-        /// <summary>Verifies that unsupported elements do not produce hitboxes.</summary>
+        /// <summary>The magic-hat mouth changes to the smaller WP7 rectangle under mobile physics.</summary>
+        [Fact]
+        public void SockMatchesActivePhysicsModel()
+        {
+            AssertBounds(
+                HitboxTable.Compute("sock", 0, 0, scale: 0.7, HitboxModel.Desktop),
+                -30,
+                0,
+                140 / 3.0,
+                5);
+            AssertBounds(
+                HitboxTable.Compute("sock", 0, 0, scale: 0.7, HitboxModel.Phone),
+                -15,
+                0,
+                30,
+                1);
+        }
+
+        /// <summary>Hitbox model selection follows the level's useMobilePhysics flag.</summary>
+        [Fact]
+        public void ModelSelectionFollowsMobilePhysicsSetting()
+        {
+            Assert.Equal(HitboxModel.Desktop, HitboxTable.ModelFor(useMobilePhysics: false));
+            Assert.Equal(HitboxModel.Phone, HitboxTable.ModelFor(useMobilePhysics: true));
+        }
+
+        /// <summary>World-space collision geometry is independent of the object's visual sprite scale.</summary>
+        [Fact]
+        public void VisualScaleDoesNotChangeCollisionBounds()
+        {
+            LevelBounds? normal = HitboxTable.Compute("candy", 0, 0, scale: 0.71, HitboxModel.Desktop);
+            LevelBounds? arbitrary = HitboxTable.Compute("candy", 0, 0, scale: 9, HitboxModel.Desktop);
+
+            Assert.Equal(normal, arbitrary);
+        }
+
+        /// <summary>Object coordinates translate collision bounds without changing their size.</summary>
+        [Fact]
+        public void ObjectPositionTranslatesBounds()
+        {
+            AssertBounds(
+                HitboxTable.Compute("candy", 100, 200, scale: 0.71, HitboxModel.Desktop),
+                82,
+                200 - (52 / 3.0),
+                112 / 3.0,
+                104 / 3.0);
+        }
+
+        /// <summary>Objects without a ported collision primitive do not receive an indicator.</summary>
         [Theory]
         [InlineData("grab")]
         [InlineData("gravitySwitch")]
         [InlineData("")]
         public void UnsupportedElementsReturnNull(string element)
         {
-            Assert.Null(HitboxTable.Compute(element, 0, 0, scale: 3, HitboxModel.Desktop));
+            Assert.Null(HitboxTable.Compute(element, 0, 0, scale: 1, HitboxModel.Desktop));
         }
 
-        /// <summary>Verifies the pump desktop hitbox uses the raw game box against the 761 ref frame.</summary>
-        [Fact]
-        public void PumpDesktopBoxUsesRawGameValues()
+        private static void AssertCenteredStrip(
+            string element,
+            bool toggled,
+            HitboxModel model,
+            double worldWidth,
+            double worldHeight)
         {
-            // desktop (300,300,175,175), ref 761: drawX = x - 761/2 = -380.5; box left = -380.5+300 = -80.5.
-            LevelBounds? box = HitboxTable.Compute("pump", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.Equal(new LevelBounds(-80.5, -80.5, 175, 175), box);
+            LevelBounds? box;
+            if (toggled)
+            {
+                LevelObject obj = new(new XElement(
+                    element,
+                    new XAttribute("x", "0"),
+                    new XAttribute("y", "0"),
+                    new XAttribute("toggled", "0")));
+                box = HitboxTable.Compute(obj, scale: 3, model);
+            }
+            else
+            {
+                box = HitboxTable.Compute(element, 0, 0, scale: 3, model);
+            }
+
+            AssertBounds(
+                box,
+                -worldWidth / 6.0,
+                -worldHeight / 6.0,
+                worldWidth / 3.0,
+                worldHeight / 3.0);
         }
 
-        /// <summary>Spike hitboxes follow the game's narrow rotated collision strip.</summary>
-        [Theory]
-        [InlineData("spike1", 214)]
-        [InlineData("spike2", 335)]
-        [InlineData("spike3", 455)]
-        [InlineData("spike4", 568)]
-        public void SpikeDesktopBoxUsesAtlasQuadWidthAndTenPixelCollisionHeight(string element, int width)
+        private static void AssertBounds(
+            LevelBounds? actual,
+            double x,
+            double y,
+            double width,
+            double height)
         {
-            LevelBounds? box = HitboxTable.Compute(element, 0, 0, scale: 3, HitboxModel.Desktop);
-
-            Assert.Equal(new LevelBounds(-width / 2.0, -5, width, 10), box);
-        }
-
-        /// <summary>Toggled spikes use the rotatable spike quad width for their hitbox.</summary>
-        [Theory]
-        [InlineData("spike1", 204)]
-        [InlineData("spike2", 321)]
-        [InlineData("spike3", 446)]
-        [InlineData("spike4", 561)]
-        public void ToggledSpikeDesktopBoxUsesRotatableAtlasQuadWidth(string element, int width)
-        {
-            LevelObject spike = new(new XElement(
-                element,
-                new XAttribute("x", "0"),
-                new XAttribute("y", "0"),
-                new XAttribute("size", element[^1].ToString()),
-                new XAttribute("toggled", "0")));
-
-            LevelBounds? box = HitboxTable.Compute(spike, 3, HitboxModel.Desktop);
-
-            Assert.Equal(new LevelBounds(-width / 2.0, -5, width, 10), box);
-        }
-
-        /// <summary>Electrodes use the game's active electric strip width rather than the full visible art width.</summary>
-        [Fact]
-        public void ElectroDesktopBoxUsesActiveElectricStripWidth()
-        {
-            LevelBounds? box = HitboxTable.Compute("electro", 0, 0, scale: 3, HitboxModel.Desktop);
-
-            Assert.Equal(new LevelBounds(-216.5, -5, 433, 10), box);
-        }
-
-        /// <summary>Electrodes use the same Spikes.UpdateRotation collision strip for phone physics.</summary>
-        [Fact]
-        public void ElectroPhoneBoxMatchesDesktopSpikesCollisionStrip()
-        {
-            LevelBounds? box = HitboxTable.Compute("electro", 0, 0, scale: 3, HitboxModel.Phone);
-
-            Assert.Equal(new LevelBounds(-216.5, -5, 433, 10), box);
-        }
-
-        /// <summary>
-        /// Bouncer collision uses the resting quad width (model-independent) and 2·BouncerHeight for its
-        /// height. BouncerHeight = SelectScaled(5, 5): desktop 5 → full height 10; phone ToWorld(5) = 15 →
-        /// full height 30. So the phone box is 3× taller than desktop, not equal to it.
-        /// </summary>
-        [Theory]
-        [InlineData("bouncer1", 196)]
-        [InlineData("bouncer2", 304)]
-        public void BouncerBoxMatchesDxRotatedCollisionRectangle(string element, int width)
-        {
-            LevelBounds? desktop = HitboxTable.Compute(element, 0, 0, scale: 3, HitboxModel.Desktop);
-            LevelBounds? phone = HitboxTable.Compute(element, 0, 0, scale: 3, HitboxModel.Phone);
-
-            Assert.Equal(new LevelBounds(-width / 2.0, -5, width, 10), desktop);
-            Assert.Equal(new LevelBounds(-width / 2.0, -15, width, 30), phone);
-        }
-
-        /// <summary>The magic hat returns its mouth box, ignoring scale and physics model.</summary>
-        [Fact]
-        public void SockBoxIsTheMagicHatMouth()
-        {
-            LevelBounds? box = HitboxTable.Compute("sock", 0, 0, scale: 3, HitboxModel.Desktop);
-
-            Assert.Equal(SockHitbox.Compute(0, 0), box);
-        }
-
-        /// <summary>The hat's box is identical for desktop and phone and independent of scale.</summary>
-        [Fact]
-        public void SockBoxIsIdenticalForDesktopAndPhone()
-        {
-            LevelBounds? desktop = HitboxTable.Compute("sock", 10, 20, scale: 3, HitboxModel.Desktop);
-            LevelBounds? phone = HitboxTable.Compute("sock", 10, 20, scale: 0.7, HitboxModel.Phone);
-
-            Assert.Equal(SockHitbox.Compute(10, 20), desktop);
-            Assert.Equal(desktop, phone);
-        }
-
-        /// <summary>
-        /// The rocket box is the thin launch strip from LoadRockets.cs quad 10 (0.6x width, 0.05x height),
-        /// centered on the quad. At scale 3 (s=1): center x = quadCenter.X - RefWidth/2 = 288 - 309.5 = -21.5,
-        /// centered vertically; width 214.8, height 8.95.
-        /// </summary>
-        [Fact]
-        public void RocketHasThinLaunchStripHitbox()
-        {
-            LevelBounds? box = HitboxTable.Compute("rocket", 0, 0, scale: 3, HitboxModel.Desktop);
-            Assert.NotNull(box);
-            Assert.Equal(-128.9, box.Value.X, 3);
-            Assert.Equal(-4.475, box.Value.Y, 3);
-            Assert.Equal(214.8, box.Value.W, 3);
-            Assert.Equal(8.95, box.Value.H, 3);
-        }
-
-        /// <summary>The rocket has no WP7-specific box, so the phone model matches the desktop model.</summary>
-        [Fact]
-        public void RocketPhoneHitboxMatchesDesktop()
-        {
-            LevelBounds? desktop = HitboxTable.Compute("rocket", 0, 0, scale: 3, HitboxModel.Desktop);
-            LevelBounds? phone = HitboxTable.Compute("rocket", 0, 0, scale: 3, HitboxModel.Phone);
-            Assert.NotNull(phone);
-            Assert.Equal(desktop!.Value.X, phone!.Value.X, 3);
-            Assert.Equal(desktop.Value.Y, phone.Value.Y, 3);
-            Assert.Equal(desktop.Value.W, phone.Value.W, 3);
-            Assert.Equal(desktop.Value.H, phone.Value.H, 3);
+            LevelBounds box = Assert.IsType<LevelBounds>(actual);
+            Assert.Equal(x, box.X, precision: 9);
+            Assert.Equal(y, box.Y, precision: 9);
+            Assert.Equal(width, box.W, precision: 9);
+            Assert.Equal(height, box.H, precision: 9);
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -56,8 +56,6 @@ namespace CtrDxEditor.Core.Tests
         [InlineData("star", HitboxModel.Phone, -52, -51, 90, 90)]
         [InlineData("target", HitboxModel.Desktop, -56, 30, 108, 2)]
         [InlineData("target", HitboxModel.Phone, -50, 10, 75, 3)]
-        [InlineData("pump", HitboxModel.Desktop, -80, -80, 175, 175)]
-        [InlineData("pump", HitboxModel.Phone, -98, -95, 171, 171)]
         public void BoundingBoxesMatchDxWorldGeometry(
             string element,
             HitboxModel model,
@@ -219,6 +217,7 @@ namespace CtrDxEditor.Core.Tests
         [Theory]
         [InlineData("grab")]
         [InlineData("gravitySwitch")]
+        [InlineData("pump")]
         [InlineData("")]
         public void UnsupportedElementsReturnNull(string element)
         {

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -27,18 +27,30 @@ namespace CtrDxEditor.Core.Tests
             AssertBounds(box, x, y, width, height);
         }
 
-        /// <summary>Both split candy elements use GetSplitCandyBoundingBox from the game.</summary>
+        /// <summary>
+        /// Both split candy elements use GetSplitCandyBoundingBox from the game, in both physics
+        /// models. Desktop world box (155,176,88,76) and phone box (52,56,23,24) x Wp7ToWorldScale(3)
+        /// = (156,168,69,72), each less the candy sprite's (196,209) center anchor, then /3 to level space.
+        /// </summary>
         [Theory]
-        [InlineData("candyL")]
-        [InlineData("candyR")]
-        public void SplitCandyMatchesGameBounds(string element)
+        [InlineData("candyL", HitboxModel.Desktop, -41, -33, 88, 76)]
+        [InlineData("candyR", HitboxModel.Desktop, -41, -33, 88, 76)]
+        [InlineData("candyL", HitboxModel.Phone, -40, -41, 69, 72)]
+        [InlineData("candyR", HitboxModel.Phone, -40, -41, 69, 72)]
+        public void SplitCandyMatchesGameBounds(
+            string element,
+            HitboxModel model,
+            double worldX,
+            double worldY,
+            double worldWidth,
+            double worldHeight)
         {
             AssertBounds(
-                HitboxTable.Compute(element, 0, 0, scale: 0.71, HitboxModel.Desktop),
-                -41 / 3.0,
-                -11,
-                88 / 3.0,
-                76 / 3.0);
+                HitboxTable.Compute(element, 0, 0, scale: 0.71, model),
+                worldX / 3.0,
+                worldY / 3.0,
+                worldWidth / 3.0,
+                worldHeight / 3.0);
         }
 
         /// <summary>Bubble collision is the PointInRect capture square (2 x BubbleCaptureRadius), not the sprite bb.</summary>

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -67,6 +67,16 @@ namespace CtrDxEditor.Core.Tests
                 worldHeight / 3.0);
         }
 
+        /// <summary>Spike bands are inflated by the 15-unit candy point tolerance on every side.</summary>
+        [Fact]
+        public void SpikeBandIncludesCandyTolerance()
+        {
+            // spike1 desktop band = 212 x 10; +15 tolerance each side => 242 x 40, centered.
+            AssertBounds(
+                HitboxTable.Compute("spike1", 0, 0, scale: 3, HitboxModel.Desktop),
+                -242 / 6.0, -40 / 6.0, 242 / 3.0, 40 / 3.0);
+        }
+
         /// <summary>Static spike collision uses the original physics tables, not repacked atlas widths.</summary>
         [Theory]
         [InlineData("spike1", 212, 204)]
@@ -78,8 +88,8 @@ namespace CtrDxEditor.Core.Tests
             double desktopWidth,
             double mobileWidth)
         {
-            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10);
-            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10, tolerance: 15);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30, tolerance: 15);
         }
 
         /// <summary>Rotatable spike collision uses the separate rotatable-width tables in the game.</summary>
@@ -93,16 +103,16 @@ namespace CtrDxEditor.Core.Tests
             double desktopWidth,
             double mobileWidth)
         {
-            AssertCenteredStrip(element, toggled: true, HitboxModel.Desktop, desktopWidth, 10);
-            AssertCenteredStrip(element, toggled: true, HitboxModel.Phone, mobileWidth, 30);
+            AssertCenteredStrip(element, toggled: true, HitboxModel.Desktop, desktopWidth, 10, tolerance: 15);
+            AssertCenteredStrip(element, toggled: true, HitboxModel.Phone, mobileWidth, 30, tolerance: 15);
         }
 
         /// <summary>Electrodes select both width reduction and collision-band height from the active model.</summary>
         [Fact]
         public void ElectroMatchesActivePhysicsConstants()
         {
-            AssertCenteredStrip("electro", toggled: false, HitboxModel.Desktop, 433, 10);
-            AssertCenteredStrip("electro", toggled: false, HitboxModel.Phone, 411, 30);
+            AssertCenteredStrip("electro", toggled: false, HitboxModel.Desktop, 433, 10, tolerance: 15);
+            AssertCenteredStrip("electro", toggled: false, HitboxModel.Phone, 411, 30, tolerance: 15);
         }
 
         /// <summary>Bouncers use frozen original-asset widths rather than the repacked JSON atlas widths.</summary>
@@ -199,7 +209,8 @@ namespace CtrDxEditor.Core.Tests
             bool toggled,
             HitboxModel model,
             double worldWidth,
-            double worldHeight)
+            double worldHeight,
+            double tolerance = 0)
         {
             LevelBounds? box;
             if (toggled)
@@ -216,12 +227,14 @@ namespace CtrDxEditor.Core.Tests
                 box = HitboxTable.Compute(element, 0, 0, scale: 3, model);
             }
 
+            double inflatedWidth = worldWidth + (2 * tolerance);
+            double inflatedHeight = worldHeight + (2 * tolerance);
             AssertBounds(
                 box,
-                -worldWidth / 6.0,
-                -worldHeight / 6.0,
-                worldWidth / 3.0,
-                worldHeight / 3.0);
+                -inflatedWidth / 6.0,
+                -inflatedHeight / 6.0,
+                inflatedWidth / 3.0,
+                inflatedHeight / 3.0);
         }
 
         private static void AssertBounds(

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -41,10 +41,17 @@ namespace CtrDxEditor.Core.Tests
                 76 / 3.0);
         }
 
+        /// <summary>Bubble collision is the PointInRect capture square (2 x BubbleCaptureRadius), not the sprite bb.</summary>
+        [Theory]
+        [InlineData(HitboxModel.Desktop, -85, -85, 170, 170)]
+        [InlineData(HitboxModel.Phone, -90, -90, 180, 180)]
+        public void BubbleUsesCaptureSquare(HitboxModel model, double x, double y, double w, double h)
+        {
+            AssertBounds(HitboxTable.Compute("bubble", 0, 0, scale: 0.25, model), x / 3.0, y / 3.0, w / 3.0, h / 3.0);
+        }
+
         /// <summary>Texture-offset boxes use the game's integer center anchor before world-to-level conversion.</summary>
         [Theory]
-        [InlineData("bubble", HitboxModel.Desktop, -77, -77, 152, 152)]
-        [InlineData("bubble", HitboxModel.Phone, -125, -125, 171, 171)]
         [InlineData("star", HitboxModel.Desktop, -48, -47, 82, 82)]
         [InlineData("star", HitboxModel.Phone, -52, -51, 90, 90)]
         [InlineData("target", HitboxModel.Desktop, -56, 30, 108, 2)]

--- a/src/CtrDxEditor.Core.Tests/HitboxTests.cs
+++ b/src/CtrDxEditor.Core.Tests/HitboxTests.cs
@@ -115,6 +115,20 @@ namespace CtrDxEditor.Core.Tests
             AssertCenteredStrip("electro", toggled: false, HitboxModel.Phone, 411, 30, tolerance: 15);
         }
 
+        /// <summary>Bouncer bands are inflated by BouncerCollisionRadius (40 desktop / 60 world mobile).</summary>
+        [Fact]
+        public void BouncerBandIncludesCollisionRadius()
+        {
+            // bouncer1 desktop 194 x 10, +40 => 274 x 90.
+            AssertBounds(
+                HitboxTable.Compute("bouncer1", 0, 0, scale: 3, HitboxModel.Desktop),
+                -274 / 6.0, -90 / 6.0, 274 / 3.0, 90 / 3.0);
+            // bouncer1 mobile 138 x 30, +60 => 258 x 150.
+            AssertBounds(
+                HitboxTable.Compute("bouncer1", 0, 0, scale: 3, HitboxModel.Phone),
+                -258 / 6.0, -150 / 6.0, 258 / 3.0, 150 / 3.0);
+        }
+
         /// <summary>Bouncers use frozen original-asset widths rather than the repacked JSON atlas widths.</summary>
         [Theory]
         [InlineData("bouncer1", 194, 138)]
@@ -124,8 +138,8 @@ namespace CtrDxEditor.Core.Tests
             double desktopWidth,
             double mobileWidth)
         {
-            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10);
-            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Desktop, desktopWidth, 10, tolerance: 40);
+            AssertCenteredStrip(element, toggled: false, HitboxModel.Phone, mobileWidth, 30, tolerance: 60);
         }
 
         /// <summary>Rocket catch geometry is raw world-space physics and does not inherit the 0.7 art scale.</summary>

--- a/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
@@ -184,5 +184,25 @@ namespace CtrDxEditor.Core.Tests
 
             Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.GhostIdle");
         }
+
+        /// <summary>A candy starting inside a spike is flagged so the author can move it.</summary>
+        [Fact]
+        public void CandyInsideSpikeWarns()
+        {
+            LevelDocument doc = Doc("",
+                "<candy x=\"0\" y=\"0\" candyNumber=\"1\" /><spike1 x=\"0\" y=\"0\" /><target x=\"3\" y=\"3\" />");
+
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.CandyInHazard");
+        }
+
+        /// <summary>A candy clear of every hazard produces no hazard warning.</summary>
+        [Fact]
+        public void CandyClearOfHazardsDoesNotWarn()
+        {
+            LevelDocument doc = Doc("",
+                "<candy x=\"0\" y=\"0\" /><spike1 x=\"200\" y=\"200\" /><target x=\"3\" y=\"3\" />");
+
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.CandyInHazard");
+        }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
@@ -29,7 +29,7 @@ namespace CtrDxEditor.Core.Tests
         public void ValidTwoPartLevelHasNoWarnings()
         {
             LevelDocument doc = Doc("twoParts=\"true\"",
-                "<candyL x=\"1\" y=\"1\" /><candyR x=\"2\" y=\"2\" /><target x=\"3\" y=\"3\" />");
+                "<candyL x=\"1\" y=\"1\" /><candyR x=\"2\" y=\"2\" /><target x=\"300\" y=\"300\" />");
 
             Assert.Empty(LevelValidator.Validate(doc));
         }
@@ -200,9 +200,29 @@ namespace CtrDxEditor.Core.Tests
         public void CandyClearOfHazardsDoesNotWarn()
         {
             LevelDocument doc = Doc("",
-                "<candy x=\"0\" y=\"0\" /><spike1 x=\"200\" y=\"200\" /><target x=\"3\" y=\"3\" />");
+                "<candy x=\"0\" y=\"0\" /><spike1 x=\"200\" y=\"200\" /><target x=\"200\" y=\"400\" />");
 
             Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.CandyInHazard");
+        }
+
+        /// <summary>A candy starting on Om Nom's mouth is flagged so the author can move it.</summary>
+        [Fact]
+        public void CandyOnMouthWarns()
+        {
+            LevelDocument doc = Doc("",
+                "<candy x=\"100\" y=\"100\" candyNumber=\"1\" /><target x=\"100\" y=\"100\" />");
+
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == "Validation.CandyOnMouth");
+        }
+
+        /// <summary>A candy clear of every Om Nom's mouth produces no mouth warning.</summary>
+        [Fact]
+        public void CandyClearOfMouthDoesNotWarn()
+        {
+            LevelDocument doc = Doc("",
+                "<candy x=\"100\" y=\"100\" /><target x=\"250\" y=\"400\" />");
+
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == "Validation.CandyOnMouth");
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/MouthOverlapTests.cs
+++ b/src/CtrDxEditor.Core.Tests/MouthOverlapTests.cs
@@ -1,0 +1,82 @@
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Editing;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests the candy-starts-on-Om-Nom's-mouth geometric check.</summary>
+    public class MouthOverlapTests
+    {
+        // Desktop mouth band (target: -56,30,108,2 world / mapScale 3) about the target center:
+        // x in [-18.67, 17.33], y in [10, 10.67].
+        // Desktop candy band (candy: -54,-52,112,104 world / 3) about the candy center:
+        // x in [-18, 19.33], y in [-17.33, 17.33].
+        private static LevelDocument Doc(string objects, string flags = "")
+        {
+            return LevelDocument.Parse($"""
+            <map>
+                <layer name="settings">
+                    <map gridSize="32" width="320" height="480" />
+                    <gameDesign {flags} />
+                </layer>
+                <layer name="Objects">{objects}</layer>
+            </map>
+            """);
+        }
+
+        /// <summary>A candy centered on the target overlaps the mouth line and gets flagged.</summary>
+        [Fact]
+        public void CandyCenteredOnTargetIsFlagged()
+        {
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"0\" /><target x=\"0\" y=\"0\" />");
+            _ = Assert.Single(MouthOverlap.CandiesOnMouth(doc));
+        }
+
+        /// <summary>A candy sitting well above the mouth line clears it and is not flagged.</summary>
+        [Fact]
+        public void CandyAboveMouthIsNotFlagged()
+        {
+            // Candy bottom edge (y-17.33 .. y+17.33) must stay above the mouth top (y+10).
+            // At y=-30 the candy band is y in [-47.33, -12.67], clear of the mouth at [10, 10.67].
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"-30\" /><target x=\"0\" y=\"0\" />");
+            Assert.Empty(MouthOverlap.CandiesOnMouth(doc));
+        }
+
+        /// <summary>A candy horizontally clear of the narrow mouth band is not flagged.</summary>
+        [Fact]
+        public void CandyBesideMouthIsNotFlagged()
+        {
+            // Candy at x=60: band x in [42, 79.33], mouth x in [-18.67, 17.33]. No x overlap.
+            LevelDocument doc = Doc("<candy x=\"60\" y=\"10\" /><target x=\"0\" y=\"0\" />");
+            Assert.Empty(MouthOverlap.CandiesOnMouth(doc));
+        }
+
+        /// <summary>Two-part halves are checked too: a candyL on the mouth is flagged.</summary>
+        [Fact]
+        public void CandyLeftOnMouthIsFlagged()
+        {
+            LevelDocument doc = Doc(
+                "<candyL x=\"0\" y=\"0\" /><target x=\"0\" y=\"0\" />",
+                flags: "twoParts=\"1\"");
+            _ = Assert.Single(MouthOverlap.CandiesOnMouth(doc));
+        }
+
+        /// <summary>Every Om Nom is checked: a candy on a second target is flagged.</summary>
+        [Fact]
+        public void CandyOnSecondTargetIsFlagged()
+        {
+            LevelDocument doc = Doc(
+                "<candy x=\"200\" y=\"200\" /><target x=\"0\" y=\"0\" /><target x=\"200\" y=\"200\" />");
+            _ = Assert.Single(MouthOverlap.CandiesOnMouth(doc));
+        }
+
+        /// <summary>A level with no target produces no mouth-overlap flags.</summary>
+        [Fact]
+        public void NoTargetProducesNoFlags()
+        {
+            LevelDocument doc = Doc("<candy x=\"0\" y=\"0\" />");
+            Assert.Empty(MouthOverlap.CandiesOnMouth(doc));
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/SteamTubeGeometryTests.cs
+++ b/src/CtrDxEditor.Core.Tests/SteamTubeGeometryTests.cs
@@ -1,50 +1,14 @@
 using System.Linq;
 
 using CtrDxEditor.Core.Editing;
-using CtrDxEditor.Core.Geometry;
 
 using Xunit;
 
 namespace CtrDxEditor.Core.Tests
 {
-    /// <summary>Tests physical SteamTube geometry that is distinct from its valve touch target.</summary>
+    /// <summary>Tests the frozen SteamTube plume geometry ported from the game.</summary>
     public class SteamTubeGeometryTests
     {
-        /// <summary>The body uses the game's transporter collision radius, not the valve touch zone.</summary>
-        [Fact]
-        public void BodyCollisionUsesExactGameRadius()
-        {
-            Assert.Equal(52.5, SteamTubeGeometry.BodyCollisionRadius);
-            Assert.NotEqual(SteamTubeGeometry.ValveTouchRadius, SteamTubeGeometry.BodyCollisionRadius);
-            Assert.Equal(40, SteamTubeGeometry.ValveTouchRadius);
-            Assert.Equal(28, SteamTubeGeometry.ValveTouchOffset);
-        }
-
-        /// <summary>Raw game-space radius maps through the standard world-to-level scale.</summary>
-        [Fact]
-        public void BodyBoundsConvertToLevelSpaceAroundPipeOrigin()
-        {
-            LevelBounds bounds = SteamTubeGeometry.BodyBounds(100, 200);
-
-            Assert.Equal(82.5, bounds.X);
-            Assert.Equal(207.7, bounds.Y, 6);
-            Assert.Equal(35, bounds.W);
-            Assert.Equal(35, bounds.H);
-        }
-
-        /// <summary>The conveyor collision circle is centered at SteamTube.BindPoint, not XML x/y.</summary>
-        [Fact]
-        public void BodyBindPointUsesTrimmedTubeHeightAndRotation()
-        {
-            Vec2 down = SteamTubeGeometry.BodyBindPoint(100, 200, rotationDegrees: 0);
-            Vec2 left = SteamTubeGeometry.BodyBindPoint(100, 200, rotationDegrees: 90);
-
-            Assert.Equal(new Vec2(100, 225.2), down);
-            Assert.Equal(74.8, left.X, 6);
-            Assert.Equal(200, left.Y, 6);
-            Assert.Equal(31.5, SteamTubeGeometry.ConveyorPickupRadius);
-        }
-
         /// <summary>Maximum steam freezes the game's 20 staggered puffs across its three frame loops.</summary>
         [Fact]
         public void MaximumPlumeMatchesGamePuffCountVariantsAndLayers()

--- a/src/CtrDxEditor.Core/Editing/HazardOverlap.cs
+++ b/src/CtrDxEditor.Core/Editing/HazardOverlap.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Finds candies whose authored start position already sits inside a candy-breaking hazard
+    /// (spikes / electro); such a candy dies the instant the level loads. Mirrors the game's
+    /// BarrierCollision.Hits(point, band, spikeCollisionRadius: 15) — the candy center against the
+    /// hazard's tolerance-inflated collision band, rotated by the hazard's display angle.
+    /// </summary>
+    public static class HazardOverlap
+    {
+        private static readonly string[] CandyTypes = ["candy", "candyL", "candyR"];
+
+        /// <summary>Candies whose center lies inside any breaking hazard's collision region.</summary>
+        public static IReadOnlyList<LevelObject> CandiesInHazards(LevelDocument document)
+        {
+            HitboxModel model = HitboxTable.ModelFor(document.UseMobilePhysics);
+            IReadOnlyList<LevelObject> objects = document.Objects;
+            List<LevelObject> result = [];
+            foreach (LevelObject candy in objects)
+            {
+                if (!CandyTypes.Contains(candy.Type))
+                {
+                    continue;
+                }
+                if (CandyInAnyHazard(candy, objects, model))
+                {
+                    result.Add(candy);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>True when the candy center point is inside any breaking hazard's rotated band.</summary>
+        public static bool CandyInAnyHazard(
+            LevelObject candy, IReadOnlyList<LevelObject> objects, HitboxModel model)
+        {
+            foreach (LevelObject hazard in objects)
+            {
+                if (!IsBreakingHazard(hazard.Type))
+                {
+                    continue;
+                }
+                if (HitboxTable.Compute(hazard, scale: 1, model) is not { } band)
+                {
+                    continue;
+                }
+                double degrees = RotationTable.For(hazard.Type) is { } spec
+                    ? ObjectRotation.DisplayDegrees(hazard, spec)
+                    : 0;
+                if (PointInRotatedBounds(candy.X, candy.Y, hazard.X, hazard.Y, degrees, band))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool IsBreakingHazard(string type)
+        {
+            return SpikeObject.IsSpike(type) || type == "electro";
+        }
+
+        // The drawn hitbox rotates the band by DisplayDegrees about the object center (see DrawHitbox);
+        // the view transform is translation + uniform scale, so rotating the band in level space is
+        // equivalent. Testing the point means rotating it by -degrees back into the band's local frame.
+        private static bool PointInRotatedBounds(
+            double px, double py, double cx, double cy, double degrees, LevelBounds band)
+        {
+            double rad = -degrees * Math.PI / 180.0;
+            double dx = px - cx;
+            double dy = py - cy;
+            double rx = cx + (dx * Math.Cos(rad)) - (dy * Math.Sin(rad));
+            double ry = cy + (dx * Math.Sin(rad)) + (dy * Math.Cos(rad));
+            return rx >= band.X && rx < band.X + band.W
+                && ry >= band.Y && ry < band.Y + band.H;
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/Hitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/Hitbox.cs
@@ -10,7 +10,12 @@ namespace CtrDxEditor.Core.Editing
     public readonly record struct GameRect(double X, double Y, double W, double H);
 
     /// <summary>One object's desktop and mobile collision rectangles in game world space.</summary>
-    public sealed record HitboxDef(string Element, GameRect Desktop, GameRect Phone);
+    public sealed record HitboxDef(
+        string Element,
+        GameRect Desktop,
+        GameRect Phone,
+        double DesktopTolerance = 0,
+        double PhoneTolerance = 0);
 
     /// <summary>Which physics model's collision geometry to use.</summary>
     public enum HitboxModel
@@ -42,16 +47,17 @@ namespace CtrDxEditor.Core.Editing
                 new("target", new(-56, 30, 108, 2), new(-50, 10, 75, 3)),
                 new("pump", new(-80, -80, 175, 175), new(-98, -95, 171, 171)),
 
-                // ActivePhysicsConstants.SpikesCollisionLineWidth and SpikesCollisionBandHalfHeight.
-                new("spike1", Centered(212, 10), Centered(204, 30)),
-                new("spike2", Centered(333, 10), Centered(318, 30)),
-                new("spike3", Centered(453, 10), Centered(438, 30)),
-                new("spike4", Centered(566, 10), Centered(543, 30)),
-                new("spike1_toggled", Centered(202, 10), Centered(204, 30)),
-                new("spike2_toggled", Centered(319, 10), Centered(354, 30)),
-                new("spike3_toggled", Centered(444, 10), Centered(426, 30)),
-                new("spike4_toggled", Centered(559, 10), Centered(534, 30)),
-                new("electro", Centered(433, 10), Centered(411, 30)),
+                // ActivePhysicsConstants.SpikesCollisionLineWidth and SpikesCollisionBandHalfHeight,
+                // inflated by the 15-unit spikeCollisionRadius candy tolerance (literal, both models).
+                new("spike1", Centered(212, 10), Centered(204, 30), 15, 15),
+                new("spike2", Centered(333, 10), Centered(318, 30), 15, 15),
+                new("spike3", Centered(453, 10), Centered(438, 30), 15, 15),
+                new("spike4", Centered(566, 10), Centered(543, 30), 15, 15),
+                new("spike1_toggled", Centered(202, 10), Centered(204, 30), 15, 15),
+                new("spike2_toggled", Centered(319, 10), Centered(354, 30), 15, 15),
+                new("spike3_toggled", Centered(444, 10), Centered(426, 30), 15, 15),
+                new("spike4_toggled", Centered(559, 10), Centered(534, 30), 15, 15),
+                new("electro", Centered(433, 10), Centered(411, 30), 15, 15),
 
                 // ActivePhysicsConstants.BouncerCollisionWidth and BouncerHeight.
                 new("bouncer1", Centered(194, 10), Centered(138, 30)),
@@ -111,11 +117,12 @@ namespace CtrDxEditor.Core.Editing
             }
 
             GameRect box = model == HitboxModel.Phone ? def.Phone : def.Desktop;
+            double tol = model == HitboxModel.Phone ? def.PhoneTolerance : def.DesktopTolerance;
             return new LevelBounds(
-                x + (box.X / mapScale),
-                y + (box.Y / mapScale),
-                box.W / mapScale,
-                box.H / mapScale);
+                x + ((box.X - tol) / mapScale),
+                y + ((box.Y - tol) / mapScale),
+                (box.W + (2 * tol)) / mapScale,
+                (box.H + (2 * tol)) / mapScale);
         }
 
         private static GameRect Centered(

--- a/src/CtrDxEditor.Core/Editing/Hitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/Hitbox.cs
@@ -46,7 +46,6 @@ namespace CtrDxEditor.Core.Editing
                 new("candyR", new(-41, -33, 88, 76), new(-40, -41, 69, 72)),
                 new("star", new(-48, -47, 82, 82), new(-52, -51, 90, 90)),
                 new("target", new(-56, 30, 108, 2), new(-50, 10, 75, 3)),
-                new("pump", new(-80, -80, 175, 175), new(-98, -95, 171, 171)),
 
                 // ActivePhysicsConstants.SpikesCollisionLineWidth and SpikesCollisionBandHalfHeight,
                 // inflated by the 15-unit spikeCollisionRadius candy tolerance (literal, both models).

--- a/src/CtrDxEditor.Core/Editing/Hitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/Hitbox.cs
@@ -59,9 +59,10 @@ namespace CtrDxEditor.Core.Editing
                 new("spike4_toggled", Centered(559, 10), Centered(534, 30), 15, 15),
                 new("electro", Centered(433, 10), Centered(411, 30), 15, 15),
 
-                // ActivePhysicsConstants.BouncerCollisionWidth and BouncerHeight.
-                new("bouncer1", Centered(194, 10), Centered(138, 30)),
-                new("bouncer2", Centered(302, 10), Centered(273, 30)),
+                // ActivePhysicsConstants.BouncerCollisionWidth and BouncerHeight, inflated by
+                // BouncerCollisionRadius (40 desktop; 20 mobile x Wp7ToWorldScale(3) = 60 world).
+                new("bouncer1", Centered(194, 10), Centered(138, 30), 40, 60),
+                new("bouncer2", Centered(302, 10), Centered(273, 30), 40, 60),
 
                 // ActivePhysicsConstants.RocketCatchBox*; the rocket's 0.7 scale affects artwork only.
                 new(

--- a/src/CtrDxEditor.Core/Editing/Hitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/Hitbox.cs
@@ -6,72 +6,72 @@ using CtrDxEditor.Core.Geometry;
 
 namespace CtrDxEditor.Core.Editing
 {
-    /// <summary>A raw game bounding box (offset + size) in game texture pixels.</summary>
+    /// <summary>A center-relative collision rectangle in cuttherope-dx world units.</summary>
     public readonly record struct GameRect(double X, double Y, double W, double H);
 
-    /// <summary>
-    /// One object's ported hitbox: the verbatim game bounding boxes plus the reference frame
-    /// (the object width/height the box was authored against, where drawX = x - RefWidth/2).
-    /// </summary>
-    public sealed record HitboxDef(
-        string Element,
-        GameRect Desktop,
-        GameRect Phone,
-        double RefWidth,
-        double RefHeight);
+    /// <summary>One object's desktop and mobile collision rectangles in game world space.</summary>
+    public sealed record HitboxDef(string Element, GameRect Desktop, GameRect Phone);
 
-    /// <summary>Which physics model's bounding box to use.</summary>
+    /// <summary>Which physics model's collision geometry to use.</summary>
     public enum HitboxModel
     {
-        /// <summary>The desktop physics bounding box.</summary>
+        /// <summary>The desktop physics model.</summary>
         Desktop,
 
-        /// <summary>The phone physics bounding box.</summary>
+        /// <summary>The mobile/WP7 physics model transformed into desktop world units.</summary>
         Phone,
     }
 
     /// <summary>
-    /// Maps ported game collision boxes (GameScene.BoundingBoxes.cs) into editor level space,
-    /// mirroring <see cref="SpritePlacement"/>. Because a box is a sub-region of the same sprite
-    /// scaled by the same s = scale / mapScale, it stays glued to the drawn art at any zoom.
-    /// Add an object by adding a row to <see cref="Defs"/>.
+    /// Maps the active cuttherope-dx collision geometry into editor level space. Definitions are stored
+    /// center-relative in raw world units, exactly where the game performs collision checks; visual sprite
+    /// scale is intentionally ignored because it does not transform <c>GameObject.bb</c> or collision strips.
     /// </summary>
     public static class HitboxTable
     {
-        /// <summary>ActivePhysicsConstants.Wp7ToWorldScale in the main project.</summary>
-        public const double Wp7ToWorldScale = 3.0;
-
-        //                                 desktop bb            phone bb (pre-scale)  ref frame
         private static readonly Dictionary<string, HitboxDef> Defs =
             new HitboxDef[]
             {
-                new("bubble", new(48, 48, 152, 152), new(0, 0, 57, 57), 250, 250),
-                new("candy", new(142, 157, 112, 104), new(46, 49, 35, 35), 393, 418),
-                new("star", new(70, 64, 82, 82), new(22, 20, 30, 30), 236, 223),
-                new("target", new(264, 350, 108, 2), new(90, 110, 25, 1), 640, 640),
-                new("pump", new(300, 300, 175, 175), new(94, 95, 57, 57), 761, 761),
-                new("spike1", new(309.5, 120, 214, 10), new(309.5, 120, 214, 10), 833, 250),
-                new("spike2", new(249, 120, 335, 10), new(249, 120, 335, 10), 833, 250),
-                new("spike3", new(189, 120, 455, 10), new(189, 120, 455, 10), 833, 250),
-                new("spike4", new(132.5, 120, 568, 10), new(132.5, 120, 568, 10), 833, 250),
-                new("spike1_toggled", new(314.5, 120, 204, 10), new(314.5, 120, 204, 10), 833, 250),
-                new("spike2_toggled", new(256, 120, 321, 10), new(256, 120, 321, 10), 833, 250),
-                new("spike3_toggled", new(193.5, 120, 446, 10), new(193.5, 120, 446, 10), 833, 250),
-                new("spike4_toggled", new(136, 120, 561, 10), new(136, 120, 561, 10), 833, 250),
-                new("electro", new(200, 120, 433, 10), new(200 / 3.0, 40, 433 / 3.0, 10 / 3.0), 833, 250),
-                new("bouncer1", new(318.5, 120, 196, 10), new(318.5 / 3.0, 110.0 / 3.0, 196 / 3.0, 30.0 / 3.0), 833, 250),
-                new("bouncer2", new(264.5, 120, 304, 10), new(264.5 / 3.0, 110.0 / 3.0, 304 / 3.0, 30.0 / 3.0), 833, 250),
-                // Rocket: bb from LoadRockets.cs quad 10 (sourceSize 619x418): quadCenter (288,209),
-                // quadSize (358*0.6, 179*0.05). No WP7 box, so Phone = Desktop/3 reproduces it after the
-                // x3 phone scaling. Drawn (and hit-tested) at sprite.Scale 0.7, passed in by DrawHitbox.
-                new("rocket",
-                    new(180.6, 204.525, 214.8, 8.95),
-                    new(180.6 / 3.0, 204.525 / 3.0, 214.8 / 3.0, 8.95 / 3.0),
-                    619, 418),
+                // Bounding boxes are converted from top-left texture offsets using BaseElement's integer
+                // center anchor (width >> 1), then WP7 rows are scaled by ActivePhysicsConstants.Wp7ToWorldScale.
+                new("bubble", new(-77, -77, 152, 152), new(-125, -125, 171, 171)),
+                new("candy", new(-54, -52, 112, 104), new(-58, -62, 105, 105)),
+                new("candyL", new(-41, -33, 88, 76), new(-40, -41, 69, 72)),
+                new("candyR", new(-41, -33, 88, 76), new(-40, -41, 69, 72)),
+                new("star", new(-48, -47, 82, 82), new(-52, -51, 90, 90)),
+                new("target", new(-56, 30, 108, 2), new(-50, 10, 75, 3)),
+                new("pump", new(-80, -80, 175, 175), new(-98, -95, 171, 171)),
+
+                // ActivePhysicsConstants.SpikesCollisionLineWidth and SpikesCollisionBandHalfHeight.
+                new("spike1", Centered(212, 10), Centered(204, 30)),
+                new("spike2", Centered(333, 10), Centered(318, 30)),
+                new("spike3", Centered(453, 10), Centered(438, 30)),
+                new("spike4", Centered(566, 10), Centered(543, 30)),
+                new("spike1_toggled", Centered(202, 10), Centered(204, 30)),
+                new("spike2_toggled", Centered(319, 10), Centered(354, 30)),
+                new("spike3_toggled", Centered(444, 10), Centered(426, 30)),
+                new("spike4_toggled", Centered(559, 10), Centered(534, 30)),
+                new("electro", Centered(433, 10), Centered(411, 30)),
+
+                // ActivePhysicsConstants.BouncerCollisionWidth and BouncerHeight.
+                new("bouncer1", Centered(194, 10), Centered(138, 30)),
+                new("bouncer2", Centered(302, 10), Centered(273, 30)),
+
+                // ActivePhysicsConstants.RocketCatchBox*; the rocket's 0.7 scale affects artwork only.
+                new(
+                    "rocket",
+                    Centered(214.8, 8.95, centerX: -21.5, centerY: -0.5),
+                    Centered(208.8, 8.7, centerX: -25.5, centerY: 0)),
             }.ToDictionary(d => d.Element);
 
+        /// <summary>Returns the active model selected by a level's <c>useMobilePhysics</c> setting.</summary>
+        public static HitboxModel ModelFor(bool useMobilePhysics)
+        {
+            return useMobilePhysics ? HitboxModel.Phone : HitboxModel.Desktop;
+        }
+
         /// <summary>
-        /// The level-space box for <paramref name="obj"/>, accounting for state-dependent variants such as
+        /// Computes an object's level-space collision bounds, including state-dependent variants such as
         /// rotatable spike quads.
         /// </summary>
         public static LevelBounds? Compute(
@@ -87,9 +87,8 @@ namespace CtrDxEditor.Core.Editing
         }
 
         /// <summary>
-        /// The level-space box for <paramref name="element"/> at object center
-        /// (<paramref name="x"/>,<paramref name="y"/>), or <see langword="null"/> if the element
-        /// has no ported hitbox.
+        /// Computes an element's level-space collision bounds at object center
+        /// (<paramref name="x"/>, <paramref name="y"/>), or <see langword="null"/> when unsupported.
         /// </summary>
         public static LevelBounds? Compute(
             string element,
@@ -99,11 +98,11 @@ namespace CtrDxEditor.Core.Editing
             HitboxModel model,
             double mapScale = SpritePlacement.MapScale)
         {
-            // The magic hat's mouth is world-unit, off-center, and scale/model-independent, so it
-            // does not fit the texture-pixel HitboxDef rows; compute it directly.
+            _ = scale; // Collision geometry is authored in world space and does not inherit visual scale.
+
             if (element == "sock")
             {
-                return SockHitbox.Compute(x, y, mapScale);
+                return SockHitbox.Compute(x, y, model, mapScale);
             }
 
             if (!Defs.TryGetValue(element, out HitboxDef? def))
@@ -111,18 +110,25 @@ namespace CtrDxEditor.Core.Editing
                 return null;
             }
 
-            GameRect bb = model == HitboxModel.Phone
-                ? new GameRect(
-                    def.Phone.X * Wp7ToWorldScale, def.Phone.Y * Wp7ToWorldScale,
-                    def.Phone.W * Wp7ToWorldScale, def.Phone.H * Wp7ToWorldScale)
-                : def.Desktop;
+            GameRect box = model == HitboxModel.Phone ? def.Phone : def.Desktop;
+            return new LevelBounds(
+                x + (box.X / mapScale),
+                y + (box.Y / mapScale),
+                box.W / mapScale,
+                box.H / mapScale);
+        }
 
-            double s = scale / mapScale;
-            double cx = x + ((bb.X + (bb.W / 2) - (def.RefWidth / 2)) * s);
-            double cy = y + ((bb.Y + (bb.H / 2) - (def.RefHeight / 2)) * s);
-            double w = bb.W * s;
-            double h = bb.H * s;
-            return new LevelBounds(cx - (w / 2), cy - (h / 2), w, h);
+        private static GameRect Centered(
+            double width,
+            double height,
+            double centerX = 0,
+            double centerY = 0)
+        {
+            return new GameRect(
+                centerX - (width / 2.0),
+                centerY - (height / 2.0),
+                width,
+                height);
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/Hitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/Hitbox.cs
@@ -39,7 +39,8 @@ namespace CtrDxEditor.Core.Editing
             {
                 // Bounding boxes are converted from top-left texture offsets using BaseElement's integer
                 // center anchor (width >> 1), then WP7 rows are scaled by ActivePhysicsConstants.Wp7ToWorldScale.
-                new("bubble", new(-77, -77, 152, 152), new(-125, -125, 171, 171)),
+                // PointInRect capture square: 2 x BubbleCaptureRadius (85 desktop; 30 x 3 = 90 world mobile).
+                new("bubble", new(-85, -85, 170, 170), new(-90, -90, 180, 180)),
                 new("candy", new(-54, -52, 112, 104), new(-58, -62, 105, 105)),
                 new("candyL", new(-41, -33, 88, 76), new(-40, -41, 69, 72)),
                 new("candyR", new(-41, -33, 88, 76), new(-40, -41, 69, 72)),

--- a/src/CtrDxEditor.Core/Editing/LevelValidator.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelValidator.cs
@@ -119,6 +119,11 @@ namespace CtrDxEditor.Core.Editing
                 warnings.Add(new LevelWarning("Validation.CandyInHazard", CandyLabel(candy)));
             }
 
+            foreach (LevelObject candy in MouthOverlap.CandiesOnMouth(document))
+            {
+                warnings.Add(new LevelWarning("Validation.CandyOnMouth", CandyLabel(candy)));
+            }
+
             return warnings;
         }
 

--- a/src/CtrDxEditor.Core/Editing/LevelValidator.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelValidator.cs
@@ -114,12 +114,32 @@ namespace CtrDxEditor.Core.Editing
                 }
             }
 
+            foreach (LevelObject candy in HazardOverlap.CandiesInHazards(document))
+            {
+                warnings.Add(new LevelWarning("Validation.CandyInHazard", CandyLabel(candy)));
+            }
+
             return warnings;
         }
 
         private static bool IsTrueAttr(LevelObject obj, string name)
         {
             return bool.TryParse(obj.GetAttr(name), out bool b) && b;
+        }
+
+        private static string CandyLabel(LevelObject candy)
+        {
+            string? number = candy.GetAttr("candyNumber");
+            if (!string.IsNullOrWhiteSpace(number))
+            {
+                return number.Trim();
+            }
+            return candy.Type switch
+            {
+                "candyL" => "L",
+                "candyR" => "R",
+                _ => "?",
+            };
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/LevelValidator.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelValidator.cs
@@ -130,16 +130,14 @@ namespace CtrDxEditor.Core.Editing
         private static string CandyLabel(LevelObject candy)
         {
             string? number = candy.GetAttr("candyNumber");
-            if (!string.IsNullOrWhiteSpace(number))
-            {
-                return number.Trim();
-            }
-            return candy.Type switch
-            {
-                "candyL" => "L",
-                "candyR" => "R",
-                _ => "?",
-            };
+            return !string.IsNullOrWhiteSpace(number)
+                ? number.Trim()
+                : candy.Type switch
+                {
+                    "candyL" => "L",
+                    "candyR" => "R",
+                    _ => "?",
+                };
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/MouthOverlap.cs
+++ b/src/CtrDxEditor.Core/Editing/MouthOverlap.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Core.Editing
+{
+    /// <summary>
+    /// Finds candies whose authored start position already overlaps an Om Nom's mouth; such a candy
+    /// is eaten the instant the mouth's idle cadence opens it, winning the level with no player input.
+    /// Mirrors the game's eat test in GameScene.Update — GameObject.ObjectsIntersect(candy, target),
+    /// an inclusive AABB overlap (CTRMathHelper.RectInRect) between the candy's bounding box and the
+    /// target's mouth box. Both boxes come from HitboxTable, exactly where the game checks them.
+    /// </summary>
+    public static class MouthOverlap
+    {
+        private static readonly string[] CandyTypes = ["candy", "candyL", "candyR"];
+
+        /// <summary>Candies whose collision box overlaps any Om Nom's mouth box.</summary>
+        public static IReadOnlyList<LevelObject> CandiesOnMouth(LevelDocument document)
+        {
+            HitboxModel model = HitboxTable.ModelFor(document.UseMobilePhysics);
+            IReadOnlyList<LevelObject> objects = document.Objects;
+            List<LevelObject> result = [];
+            foreach (LevelObject candy in objects)
+            {
+                if (!CandyTypes.Contains(candy.Type))
+                {
+                    continue;
+                }
+                if (CandyOnAnyMouth(candy, objects, model))
+                {
+                    result.Add(candy);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>True when the candy's box overlaps any target's mouth box.</summary>
+        public static bool CandyOnAnyMouth(
+            LevelObject candy, IReadOnlyList<LevelObject> objects, HitboxModel model)
+        {
+            if (HitboxTable.Compute(candy, scale: 1, model) is not { } candyBand)
+            {
+                return false;
+            }
+            foreach (LevelObject target in objects)
+            {
+                if (target.Type != "target")
+                {
+                    continue;
+                }
+                if (HitboxTable.Compute(target, scale: 1, model) is { } mouthBand
+                    && Overlaps(candyBand, mouthBand))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Inclusive AABB overlap, matching CTRMathHelper.RectInRect (edges touching counts as a hit).
+        // Targets are never rotated, so no rotation handling is needed (unlike HazardOverlap).
+        private static bool Overlaps(LevelBounds a, LevelBounds b)
+        {
+            return a.X <= b.X + b.W && a.X + a.W >= b.X
+                && a.Y <= b.Y + b.H && a.Y + a.H >= b.Y;
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Editing/SockHitbox.cs
+++ b/src/CtrDxEditor.Core/Editing/SockHitbox.cs
@@ -5,10 +5,9 @@ namespace CtrDxEditor.Core.Editing
     /// <summary>
     /// The magic hat's game collision "mouth" box, ported from Sock.UpdateRotation
     /// (cuttherope-dx). In world units, relative to the hat center, the pre-rotation mouth
-    /// spans X in [-90, +50] (width 140, shifted -20) and Y in [0, +15]. Level units are
-    /// world units divided by MapScale, so the box is a fixed level size — independent of the
-    /// hat's sprite scale and of the physics model. Rotation is applied by the overlay's
-    /// existing DrawHitbox path (authored angle + 90 deg).
+    /// spans X in [-90, +50] and Y in [0, +15] for desktop physics. Mobile physics uses the
+    /// WP7 mouth transformed into world units: X in [-45, +45], Y in [0, +3]. Level units are
+    /// world units divided by MapScale, and neither model inherits the hat's visual sprite scale.
     /// </summary>
     public static class SockHitbox
     {
@@ -18,13 +17,18 @@ namespace CtrDxEditor.Core.Editing
         /// </summary>
         /// <param name="x">Hat center X, in level units.</param>
         /// <param name="y">Hat center Y (mouth top edge), in level units.</param>
+        /// <param name="model">The active desktop or mobile physics model.</param>
         /// <param name="mapScale">World-to-level scale factor; defaults to <see cref="SpritePlacement.MapScale"/>.</param>
         /// <returns>The pre-rotation mouth bounds in level units.</returns>
-        public static LevelBounds Compute(double x, double y, double mapScale = SpritePlacement.MapScale)
+        public static LevelBounds Compute(
+            double x,
+            double y,
+            HitboxModel model = HitboxModel.Desktop,
+            double mapScale = SpritePlacement.MapScale)
         {
-            double left = -90.0 / mapScale; // (x - sockWidth/2 - 20) world -> level
-            double w = 140.0 / mapScale;    // sockWidth world -> level
-            double h = 15.0 / mapScale;     // mouth depth world -> level
+            double left = (model == HitboxModel.Phone ? -45.0 : -90.0) / mapScale;
+            double w = (model == HitboxModel.Phone ? 90.0 : 140.0) / mapScale;
+            double h = (model == HitboxModel.Phone ? 3.0 : 15.0) / mapScale;
             return new LevelBounds(x + left, y, w, h);
         }
     }

--- a/src/CtrDxEditor.Core/Editing/SteamTubeGeometry.cs
+++ b/src/CtrDxEditor.Core/Editing/SteamTubeGeometry.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 
-using CtrDxEditor.Core.Geometry;
-
 namespace CtrDxEditor.Core.Editing
 {
     /// <summary>One deterministic puff sampled from SteamTube's steady-state maximum plume.</summary>
@@ -16,15 +14,6 @@ namespace CtrDxEditor.Core.Editing
     /// <summary>Exact SteamTube physical and input geometry ported from the game.</summary>
     public static class SteamTubeGeometry
     {
-        /// <summary>ITransporterItem collision radius around the tube body, in raw game units.</summary>
-        public const double BodyCollisionRadius = 52.5;
-
-        /// <summary>Valve input radius, kept only to make clear that it is not the body indicator.</summary>
-        public const double ValveTouchRadius = 40;
-
-        /// <summary>Valve input center offset along local +Y, in raw game units.</summary>
-        public const double ValveTouchOffset = 28;
-
         /// <summary>Trimmed tube quad height used by Image.SetDrawQuad and SteamTube.BindPoint.</summary>
         public const double BodyQuadHeight = 168;
 
@@ -34,39 +23,10 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Maximum-state puff endpoint after the game's heightScale/mapScale cancellation.</summary>
         public const double MaximumSteamHeight = 141;
 
-        /// <summary>Radius used only while a conveyor searches for newly overlapping items.</summary>
-        public const double ConveyorPickupRadius = BodyCollisionRadius * 0.6;
-
         /// <summary>Center offset of the top-anchored tube art in level space.</summary>
         public static double BodyDrawCenterOffset(double mapScale = SpritePlacement.MapScale)
         {
             return BodyQuadHeight / (2.0 * mapScale);
-        }
-
-        /// <summary>Returns the game's rotated transporter bind point at 45% of trimmed tube height.</summary>
-        public static Vec2 BodyBindPoint(
-            double x,
-            double y,
-            double rotationDegrees,
-            double mapScale = SpritePlacement.MapScale)
-        {
-            double offset = BodyQuadHeight * 0.45 / mapScale;
-            double radians = rotationDegrees * Math.PI / 180.0;
-            return new Vec2(
-                x - (Math.Sin(radians) * offset),
-                y + (Math.Cos(radians) * offset));
-        }
-
-        /// <summary>Returns the body's circular collision bounds in editor level space.</summary>
-        public static LevelBounds BodyBounds(
-            double x,
-            double y,
-            double rotationDegrees = 0,
-            double mapScale = SpritePlacement.MapScale)
-        {
-            Vec2 center = BodyBindPoint(x, y, rotationDegrees, mapScale);
-            double radius = BodyCollisionRadius / mapScale;
-            return new LevelBounds(center.X - radius, center.Y - radius, radius * 2, radius * 2);
         }
 
         /// <summary>

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -23,7 +23,6 @@
     "Menu.View.StopAnimations": "Stop Animations",
     "Menu.View.SnapToGrid": "Snap to Grid",
     "Menu.View.ShowHitboxes": "Show Hitboxes",
-    "Menu.View.ShowMobileHitboxes": "Show Mobile Hitboxes",
     "Menu.View.ShowForceFields": "Show Force Fields",
     "Menu.View.ShowMovementPaths": "Show Movement Paths",
 

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -258,5 +258,6 @@
     "Validation.GrabUnmatchedCandyNumber": "A grab references candyNumber '{0}', which no candy has, it will bind to the primary candy.",
     "Validation.GrabUnmatchedBulbNumber": "A grab binds to bulbNumber '{0}', which no light bulb has.",
     "Validation.GhostIdle": "A ghost has no enabled states (grab/bubble/bouncer), it will sit idle and do nothing.",
-    "Validation.CandyInHazard": "Candy {0} starts inside a spike and will break immediately."
+    "Validation.CandyInHazard": "Candy {0} starts inside a spike and will break immediately.",
+    "Validation.CandyOnMouth": "Candy {0} starts on Om Nom's mouth and will be eaten immediately, winning the level."
 }

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -257,5 +257,6 @@
     "Validation.DuplicateCandyNumber": "Duplicate candyNumber values found; grabs cannot tell those candies apart.",
     "Validation.GrabUnmatchedCandyNumber": "A grab references candyNumber '{0}', which no candy has, it will bind to the primary candy.",
     "Validation.GrabUnmatchedBulbNumber": "A grab binds to bulbNumber '{0}', which no light bulb has.",
-    "Validation.GhostIdle": "A ghost has no enabled states (grab/bubble/bouncer), it will sit idle and do nothing."
+    "Validation.GhostIdle": "A ghost has no enabled states (grab/bubble/bouncer), it will sit idle and do nothing.",
+    "Validation.CandyInHazard": "Candy {0} starts inside a spike and will break immediately."
 }

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -34,6 +34,10 @@ namespace CtrDxEditor.Rendering
         /// <summary>Hitbox overlay for the level's active physics model.</summary>
         public Pen HitboxDesktop { get; private set; } = OverlayPen(Brushes.LimeGreen, 1.5);
 
+        /// <summary>Candy physics-center crosshair, drawn solid so it reads as a point marker
+        /// against the dashed hitbox boxes.</summary>
+        public Pen CandyCrosshair { get; private set; } = SolidPen(Colors.LimeGreen, 1.5);
+
         /// <summary>Selection marquee for the locked object.</summary>
         public Pen ObjectLocked { get; private set; } = OverlayPen(Brushes.Red, 2);
 
@@ -70,7 +74,9 @@ namespace CtrDxEditor.Rendering
 
             GrabRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayGrabRadius", Colors.Orange), 1.5);
             BulbRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayBulbRadius", Colors.Gold), 1.5);
-            HitboxDesktop = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxDesktop", Colors.LimeGreen), 1.5);
+            Color hitboxColor = ThemeColor(host, "EditorColor.OverlayHitboxDesktop", Colors.LimeGreen);
+            HitboxDesktop = OverlayPen(hitboxColor, 1.5);
+            CandyCrosshair = SolidPen(hitboxColor, 1.5);
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
             ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -38,6 +38,9 @@ namespace CtrDxEditor.Rendering
         /// against the dashed hitbox boxes.</summary>
         public Pen CandyCrosshair { get; private set; } = SolidPen(Colors.LimeGreen, 1.5);
 
+        /// <summary>Candy crosshair when the candy starts inside a breaking hazard: solid red alert.</summary>
+        public Pen CandyCrosshairAlert { get; private set; } = SolidPen(Colors.Red, 2);
+
         /// <summary>Selection marquee for the locked object.</summary>
         public Pen ObjectLocked { get; private set; } = OverlayPen(Brushes.Red, 2);
 
@@ -77,6 +80,7 @@ namespace CtrDxEditor.Rendering
             Color hitboxColor = ThemeColor(host, "EditorColor.OverlayHitboxDesktop", Colors.LimeGreen);
             HitboxDesktop = OverlayPen(hitboxColor, 1.5);
             CandyCrosshair = SolidPen(hitboxColor, 1.5);
+            CandyCrosshairAlert = SolidPen(ThemeColor(host, "EditorColor.OverlayHitboxAlert", Colors.Red), 2);
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
             ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);

--- a/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
+++ b/src/CtrDxEditor.Shared/Rendering/CanvasPalette.cs
@@ -31,11 +31,8 @@ namespace CtrDxEditor.Rendering
         /// <summary>A light bulb's lit-radius ring.</summary>
         public Pen BulbRadius { get; private set; } = OverlayPen(Brushes.Gold, 1.5);
 
-        /// <summary>Desktop hitbox overlay.</summary>
+        /// <summary>Hitbox overlay for the level's active physics model.</summary>
         public Pen HitboxDesktop { get; private set; } = OverlayPen(Brushes.LimeGreen, 1.5);
-
-        /// <summary>Phone hitbox overlay.</summary>
-        public Pen HitboxPhone { get; private set; } = OverlayPen(Brushes.Magenta, 1.5);
 
         /// <summary>Selection marquee for the locked object.</summary>
         public Pen ObjectLocked { get; private set; } = OverlayPen(Brushes.Red, 2);
@@ -74,7 +71,6 @@ namespace CtrDxEditor.Rendering
             GrabRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayGrabRadius", Colors.Orange), 1.5);
             BulbRadius = OverlayPen(ThemeColor(host, "EditorColor.OverlayBulbRadius", Colors.Gold), 1.5);
             HitboxDesktop = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxDesktop", Colors.LimeGreen), 1.5);
-            HitboxPhone = OverlayPen(ThemeColor(host, "EditorColor.OverlayHitboxPhone", Colors.Magenta), 1.5);
             ObjectLocked = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectLocked", Colors.Red), 2);
             ObjectSelected = OverlayPen(ThemeColor(host, "EditorColor.OverlayObjectSelected", Colors.DeepSkyBlue), 1.5);
             ForceArrow = new Pen(new SolidColorBrush(ThemeColor(host, "EditorColor.OverlayForceArrow", Color.FromRgb(0x7F, 0x22, 0xFE))), 2);

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -98,33 +98,35 @@ namespace CtrDxEditor.Rendering
                 }
             }
 
-            if (ShowHitboxes || ShowMobileHitboxes)
+            if (ShowHitboxes)
             {
+                HitboxModel hitboxModel = HitboxTable.ModelFor(doc.UseMobilePhysics);
                 foreach (LevelObject obj in objects)
                 {
                     if (sprites.GetSprite(LevelSceneRenderer.CanvasSpriteKey(obj, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is not { } sprite)
                     {
                         continue;
                     }
-                    if (ShowHitboxes)
+                    LevelSceneRenderer.DrawHitbox(
+                        context,
+                        v,
+                        obj,
+                        sprite.Scale,
+                        hitboxModel,
+                        _palette.HitboxDesktop,
+                        PreviewSpinDegrees(obj),
+                        PreviewAnimationSeconds(obj));
+                    if (obj.Type == "steamTube")
                     {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
-                        if (obj.Type == "steamTube")
-                        {
-                            double angle = ObjectRotation.StoredAngle(obj, RotationTable.For("steamTube")!);
-                            LevelBounds body = SteamTubeGeometry.BodyBounds(obj.X, obj.Y, angle);
-                            Vec2 center = v.LevelToScreen(new Vec2(body.X + (body.W / 2), body.Y + (body.H / 2)));
-                            context.DrawEllipse(
-                                null,
-                                _palette.HitboxDesktop,
-                                new Point(center.X, center.Y),
-                                body.W * v.Zoom / 2,
-                                body.H * v.Zoom / 2);
-                        }
-                    }
-                    if (ShowMobileHitboxes)
-                    {
-                        LevelSceneRenderer.DrawHitbox(context, v, obj, sprite.Scale, HitboxModel.Phone, _palette.HitboxPhone, PreviewSpinDegrees(obj), PreviewAnimationSeconds(obj));
+                        double angle = ObjectRotation.StoredAngle(obj, RotationTable.For("steamTube")!);
+                        LevelBounds body = SteamTubeGeometry.BodyBounds(obj.X, obj.Y, angle);
+                        Vec2 center = v.LevelToScreen(new Vec2(body.X + (body.W / 2), body.Y + (body.H / 2)));
+                        context.DrawEllipse(
+                            null,
+                            _palette.HitboxDesktop,
+                            new Point(center.X, center.Y),
+                            body.W * v.Zoom / 2,
+                            body.H * v.Zoom / 2);
                     }
                 }
 
@@ -147,14 +149,13 @@ namespace CtrDxEditor.Rendering
                     LevelObject proxy = new(proxyEl);
                     if (sprites.GetSprite(LevelSceneRenderer.CanvasSpriteKey(proxy, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is { } proxySprite)
                     {
-                        if (ShowHitboxes)
-                        {
-                            LevelSceneRenderer.DrawHitbox(context, v, proxy, proxySprite.Scale, HitboxModel.Desktop, _palette.HitboxDesktop);
-                        }
-                        if (ShowMobileHitboxes)
-                        {
-                            LevelSceneRenderer.DrawHitbox(context, v, proxy, proxySprite.Scale, HitboxModel.Phone, _palette.HitboxPhone);
-                        }
+                        LevelSceneRenderer.DrawHitbox(
+                            context,
+                            v,
+                            proxy,
+                            proxySprite.Scale,
+                            hitboxModel,
+                            _palette.HitboxDesktop);
                     }
                 }
             }

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -120,18 +120,6 @@ namespace CtrDxEditor.Rendering
                     {
                         LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, _palette.HitboxDesktop);
                     }
-                    if (obj.Type == "steamTube")
-                    {
-                        double angle = ObjectRotation.StoredAngle(obj, RotationTable.For("steamTube")!);
-                        LevelBounds body = SteamTubeGeometry.BodyBounds(obj.X, obj.Y, angle);
-                        Vec2 center = v.LevelToScreen(new Vec2(body.X + (body.W / 2), body.Y + (body.H / 2)));
-                        context.DrawEllipse(
-                            null,
-                            _palette.HitboxDesktop,
-                            new Point(center.X, center.Y),
-                            body.W * v.Zoom / 2,
-                            body.H * v.Zoom / 2);
-                    }
                 }
 
                 // A selected ghost previewing a bubble/bouncer morph shows that transformed object's

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -101,6 +101,7 @@ namespace CtrDxEditor.Rendering
             if (ShowHitboxes)
             {
                 HitboxModel hitboxModel = HitboxTable.ModelFor(doc.UseMobilePhysics);
+                System.Collections.Generic.HashSet<LevelObject> hazardCandies = [.. HazardOverlap.CandiesInHazards(doc)];
                 foreach (LevelObject obj in objects)
                 {
                     if (sprites.GetSprite(LevelSceneRenderer.CanvasSpriteKey(obj, doc.NightLevel), ActiveCandySkin, ActiveOmNomSupport) is not { } sprite)
@@ -118,7 +119,10 @@ namespace CtrDxEditor.Rendering
                         PreviewAnimationSeconds(obj));
                     if (obj.Type is "candy" or "candyL" or "candyR")
                     {
-                        LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, _palette.CandyCrosshair);
+                        Pen crosshairPen = hazardCandies.Contains(obj)
+                            ? _palette.CandyCrosshairAlert
+                            : _palette.CandyCrosshair;
+                        LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, crosshairPen);
                     }
                 }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -116,6 +116,10 @@ namespace CtrDxEditor.Rendering
                         _palette.HitboxDesktop,
                         PreviewSpinDegrees(obj),
                         PreviewAnimationSeconds(obj));
+                    if (obj.Type is "candy" or "candyL" or "candyR")
+                    {
+                        LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, _palette.HitboxDesktop);
+                    }
                     if (obj.Type == "steamTube")
                     {
                         double angle = ObjectRotation.StoredAngle(obj, RotationTable.For("steamTube")!);

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -118,7 +118,7 @@ namespace CtrDxEditor.Rendering
                         PreviewAnimationSeconds(obj));
                     if (obj.Type is "candy" or "candyL" or "candyR")
                     {
-                        LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, _palette.HitboxDesktop);
+                        LevelSceneRenderer.DrawCandyCrosshair(context, v, obj, _palette.CandyCrosshair);
                     }
                 }
 

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.cs
@@ -46,10 +46,6 @@ namespace CtrDxEditor.Rendering
         public static readonly StyledProperty<bool> ShowHitboxesProperty =
             AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowHitboxes), defaultValue: true);
 
-        /// <summary>Avalonia property backing <see cref="ShowMobileHitboxes"/>.</summary>
-        public static readonly StyledProperty<bool> ShowMobileHitboxesProperty =
-            AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowMobileHitboxes));
-
         /// <summary>Avalonia property backing <see cref="ShowForceFields"/>.</summary>
         public static readonly StyledProperty<bool> ShowForceFieldsProperty =
             AvaloniaProperty.Register<LevelCanvas, bool>(nameof(ShowForceFields), defaultValue: true);
@@ -117,7 +113,7 @@ namespace CtrDxEditor.Rendering
             AffectsRender<LevelCanvas>(
                 DocumentProperty, SpritesProperty, ViewProperty, SnapEnabledProperty,
                 SelectedObjectProperty, LockedObjectProperty,
-                ShowHitboxesProperty, ShowMobileHitboxesProperty, ShowForceFieldsProperty, ShowMovementPathsProperty,
+                ShowHitboxesProperty, ShowForceFieldsProperty, ShowMovementPathsProperty,
                 ActiveRopeSkinProperty, ActiveBackgroundProperty, ActiveCandySkinProperty,
                 ActiveOmNomSupportProperty,
                 AnimationPreviewModeProperty, AnimationPreviewObjectProperty, AnimationPreviewElapsedSecondsProperty);
@@ -143,9 +139,6 @@ namespace CtrDxEditor.Rendering
 
         /// <summary>Whether desktop hitboxes are drawn over objects.</summary>
         public bool ShowHitboxes { get => GetValue(ShowHitboxesProperty); set => SetValue(ShowHitboxesProperty, value); }
-
-        /// <summary>Whether phone hitboxes are drawn over objects.</summary>
-        public bool ShowMobileHitboxes { get => GetValue(ShowMobileHitboxesProperty); set => SetValue(ShowMobileHitboxesProperty, value); }
 
         /// <summary>Whether directional force-field arrows (e.g. the pump's flow) are drawn over objects.</summary>
         public bool ShowForceFields { get => GetValue(ShowForceFieldsProperty); set => SetValue(ShowForceFieldsProperty, value); }

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -1527,7 +1527,7 @@ namespace CtrDxEditor.Rendering
             }
         }
 
-        /// <summary>Draws an object's hitbox rectangle for the given device model, if it has one.</summary>
+        /// <summary>Draws an object's hitbox outline for the active physics model, if it has one.</summary>
         /// <param name="ctx">Destination drawing context.</param>
         /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
         /// <param name="obj">The object whose hitbox is drawn.</param>

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -1575,6 +1575,34 @@ namespace CtrDxEditor.Rendering
             ctx.DrawRectangle(null, pen, box);
         }
 
+        /// <summary>
+        /// Draws the candy's physics-center point — the marker hazards (spike/bouncer/bubble) actually test —
+        /// as a small screen-space crosshair, sized in pixels so it stays readable at any zoom.
+        /// </summary>
+        public static void DrawCandyCrosshair(DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pen)
+        {
+            Point[] points = ComputeCandyCrosshairPoints(v, obj, armScreen: 6.0);
+            ctx.DrawLine(pen, points[0], points[1]);
+            ctx.DrawLine(pen, points[2], points[3]);
+        }
+
+        /// <summary>Computes the candy crosshair's horizontal and vertical arm endpoints in screen space.</summary>
+        /// <param name="v">View transform mapping level coordinates to screen coordinates.</param>
+        /// <param name="obj">The candy object; the crosshair marks its physics center.</param>
+        /// <param name="armScreen">Half-length of each arm in screen pixels.</param>
+        /// <returns>Horizontal endpoints [left, right] followed by vertical endpoints [top, bottom].</returns>
+        public static Point[] ComputeCandyCrosshairPoints(ViewTransform v, LevelObject obj, double armScreen)
+        {
+            Vec2 c = v.LevelToScreen(new Vec2(obj.X, obj.Y));
+            return
+            [
+                new Point(c.X - armScreen, c.Y),
+                new Point(c.X + armScreen, c.Y),
+                new Point(c.X, c.Y - armScreen),
+                new Point(c.X, c.Y + armScreen),
+            ];
+        }
+
         /// <summary>Computes hitbox bounds translated to the live orbit-preview position.</summary>
         public static LevelBounds? PreviewHitboxBounds(
             LevelObject obj,

--- a/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
+++ b/src/CtrDxEditor.Shared/Styles/EditorTheme.axaml
@@ -302,7 +302,6 @@
       <Color x:Key="EditorColor.OverlayGrabRadius">#CA3500</Color>     <!-- orange-700 -->
       <Color x:Key="EditorColor.OverlayBulbRadius">#BB4D00</Color>     <!-- amber-700 -->
       <Color x:Key="EditorColor.OverlayHitboxDesktop">#497D00</Color>  <!-- lime-700 -->
-      <Color x:Key="EditorColor.OverlayHitboxPhone">#A800B7</Color>    <!-- fuchsia-700 -->
       <Color x:Key="EditorColor.OverlayObjectLocked">#C10007</Color>   <!-- red-700 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#0069A8</Color> <!-- sky-700 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#7F22FE</Color>     <!-- violet-700 -->
@@ -345,7 +344,6 @@
       <Color x:Key="EditorColor.OverlayGrabRadius">#FF8904</Color>     <!-- orange-400, 7.50 -->
       <Color x:Key="EditorColor.OverlayBulbRadius">#FDC700</Color>     <!-- yellow-400, 12.98 -->
       <Color x:Key="EditorColor.OverlayHitboxDesktop">#7CCF00</Color>  <!-- lime-500, 9.15 -->
-      <Color x:Key="EditorColor.OverlayHitboxPhone">#F4A8FF</Color>    <!-- fuchsia-300, 10.10 -->
       <Color x:Key="EditorColor.OverlayObjectLocked">#FFA2A2</Color>   <!-- red-300, 9.29 -->
       <Color x:Key="EditorColor.OverlayObjectSelected">#00BCFF</Color> <!-- sky-400, 8.18 -->
       <Color x:Key="EditorColor.OverlayForceArrow">#C4B4FF</Color>     <!-- violet-300, 8.90 -->

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -44,7 +44,6 @@ namespace CtrDxEditor.ViewModels
         [ObservableProperty] public partial LevelObject? LockedObject { get; set; }
         [ObservableProperty] public partial bool SnapEnabled { get; set; }
         [ObservableProperty] public partial bool ShowHitboxes { get; set; } = true;
-        [ObservableProperty] public partial bool ShowMobileHitboxes { get; set; }
         [ObservableProperty] public partial bool ShowForceFields { get; set; } = true;
         [ObservableProperty] public partial bool ShowMovementPaths { get; set; } = true;
         [ObservableProperty] public partial int ActiveRopeSkin { get; set; }

--- a/src/CtrDxEditor.Shared/Views/MainView.Commands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.Commands.cs
@@ -52,14 +52,6 @@ namespace CtrDxEditor.Views
             }
         }
 
-        private void ShowMobileHitboxesToggle_Click(object? sender, RoutedEventArgs e)
-        {
-            if (DataContext is EditorViewModel vm)
-            {
-                vm.ShowMobileHitboxes = !vm.ShowMobileHitboxes;
-            }
-        }
-
         private void ShowForceFieldsToggle_Click(object? sender, RoutedEventArgs e)
         {
             if (DataContext is EditorViewModel vm)

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -209,18 +209,6 @@
             </Grid>
           </MenuItem.Header>
         </MenuItem>
-        <MenuItem Click="ShowMobileHitboxesToggle_Click" IsEnabled="{Binding HasDocument}">
-          <MenuItem.Icon>
-            <Border Width="16" Height="16" Background="Transparent" />
-          </MenuItem.Icon>
-          <MenuItem.Header>
-            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
-              <TextBlock Grid.Column="0" Text="{loc:Tr Menu.View.ShowMobileHitboxes}" VerticalAlignment="Center" />
-              <icons:MaterialIcon Grid.Column="1" Kind="CheckBold" Width="14" Height="14"
-                                  Margin="24,0,0,0" VerticalAlignment="Center" IsVisible="{Binding ShowMobileHitboxes}" />
-            </Grid>
-          </MenuItem.Header>
-        </MenuItem>
         <MenuItem Click="ShowForceFieldsToggle_Click" IsEnabled="{Binding HasDocument}">
           <MenuItem.Icon>
             <Border Width="16" Height="16" Background="Transparent" />
@@ -314,7 +302,6 @@
                             View="{Binding View, Mode=TwoWay}"
                             SnapEnabled="{Binding SnapEnabled}"
                             ShowHitboxes="{Binding ShowHitboxes}"
-                            ShowMobileHitboxes="{Binding ShowMobileHitboxes}"
                             ShowForceFields="{Binding ShowForceFields}"
                             ShowMovementPaths="{Binding ShowMovementPaths}"
                             ActiveRopeSkin="{Binding ActiveRopeSkin}"

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -296,6 +296,26 @@ namespace CtrDxEditor.Tests
             Assert.True(ccw[1].Y > ccw[0].Y);
         }
 
+        /// <summary>The candy crosshair centers on the object and keeps fixed screen-space arms at any zoom.</summary>
+        [Fact]
+        public void CandyCrosshairCentersOnObjectInScreenSpace()
+        {
+            MethodInfo? method = SceneRenderer.GetMethod(
+                "ComputeCandyCrosshairPoints",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            LevelObject candy = new(new XElement("candy", new XAttribute("x", "100"), new XAttribute("y", "200")));
+
+            // Zoomed 3x: the center moves with the transform but the 6px arms stay screen-fixed.
+            Point[] points = (Point[])method.Invoke(null, [new ViewTransform(3.0, 0.0, 0.0), candy, 6.0])!;
+
+            Assert.Equal(4, points.Length);
+            Assert.Equal(new Point(300 - 6, 600), points[0]);
+            Assert.Equal(new Point(300 + 6, 600), points[1]);
+            Assert.Equal(new Point(300, 600 - 6), points[2]);
+            Assert.Equal(new Point(300, 600 + 6), points[3]);
+        }
+
         /// <summary>Live orbit preview moves hitbox bounds with the object position, matching DX mover updates.</summary>
         [Fact]
         public void OrbitPreviewHitboxFollowsPreviewPosition()

--- a/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
+++ b/src/CtrDxEditor.Tests/LevelCanvasScreenshotTests.cs
@@ -447,6 +447,18 @@ namespace CtrDxEditor.Tests
             Assert.True(pen.Thickness > 1.5);
         }
 
+        /// <summary>The candy hazard-alert crosshair pen is solid red, distinct from the normal solid pen.</summary>
+        [Fact]
+        public void CandyCrosshairAlertPenIsSolid()
+        {
+            Type paletteType = typeof(LevelCanvas).Assembly.GetType("CtrDxEditor.Rendering.CanvasPalette")!;
+            object palette = Activator.CreateInstance(paletteType, nonPublic: true)!;
+            Pen pen = (Pen)paletteType.GetProperty("CandyCrosshairAlert")!.GetValue(palette)!;
+
+            Assert.Null(pen.DashStyle);
+            Assert.True(pen.Thickness > 1.0);
+        }
+
         /// <summary>Steam force ticks cross the shaft at the game's low, medium, and maximum levels.</summary>
         [Fact]
         public void SteamForceLevelMarksUseExactRotatedEndpoints()


### PR DESCRIPTION
## Description

Corrects several hitbox overlays so what the editor draws matches the game's actual collision geometry, adds a candy-center crosshair to the overlay, and introduces a validation warning when a candy is placed inside a breaking hazard or Om Nom's mouth.

## Changes

### Hitbox overlay accuracy

- Spike / electro: bake the candy point tolerance into the hitbox bands so the drawn region reflects the real collision distance.
- Bouncer: inflate the hitbox by `BouncerCollisionRadius`.
- Bubble: use the capture square rather than the sprite bounding box.
- Pump: drop the tap-box hitbox.
- Steam tube: remove the conveyor-radius circle from the overlay.

### Candy crosshair

- Draw a candy-center crosshair on the hitbox overlay with a solid pen.
- Recolor the crosshair red when the candy starts inside a hazard.

### Overlap validation

- Add a `HazardOverlap` / `MouthOverlap` check for a candy starting inside a spike/electro or Om Nom.
- Surface a validator warning (`Validation.CandyInHazard` / `Validation.CandyOnMouth`) when a candy spawns inside a breaking hazard or Om Nom.

### Cleanup

- Remove the standalone "Show Mobile Hitboxes" view option; mobile hitboxes now follow the "Use mobile physics" setting.