### PR TITLE
enhancement: improve layer controls and rename validation

### DIFF
--- a/src/CtrDxEditor.Core.Tests/LevelLayerMutationTests.cs
+++ b/src/CtrDxEditor.Core.Tests/LevelLayerMutationTests.cs
@@ -139,6 +139,25 @@ namespace CtrDxEditor.Core.Tests
             Assert.True(doc.IsLayerNameAvailable("rock & <roll> \"mix\""));
         }
 
+        /// <summary>Layer-name validation reports why a rename was rejected.</summary>
+        [Fact]
+        public void ValidateLayerNameReportsSpecificFailure()
+        {
+            LevelDocument doc = TwoLayers();
+
+            Assert.Equal(LayerNameValidationError.Empty,
+                doc.ValidateLayerName("  ", out _));
+            Assert.Equal(LayerNameValidationError.Reserved,
+                doc.ValidateLayerName("SETTINGS", out _));
+            Assert.Equal(LayerNameValidationError.InvalidXml,
+                doc.ValidateLayerName("bad\u0001name", out _));
+            Assert.Equal(LayerNameValidationError.Duplicate,
+                doc.ValidateLayerName(" a ", out _));
+            Assert.Equal(LayerNameValidationError.None,
+                doc.ValidateLayerName(" c ", out string normalized));
+            Assert.Equal("c", normalized);
+        }
+
         /// <summary>Duplicate ordinary names gain stable suffixes without displacing an existing suffixed name.</summary>
         [Fact]
         public void NormalizeDuplicateLayerNamesUsesTreeOrderAndSkipsReservedSuffixes()

--- a/src/CtrDxEditor.Core/Document/LayerNameValidationError.cs
+++ b/src/CtrDxEditor.Core/Document/LayerNameValidationError.cs
@@ -1,0 +1,21 @@
+namespace CtrDxEditor.Core.Document
+{
+    /// <summary>Reason a proposed ordinary layer name cannot be stored.</summary>
+    public enum LayerNameValidationError
+    {
+        /// <summary>The name is valid.</summary>
+        None,
+
+        /// <summary>The trimmed name is empty.</summary>
+        Empty,
+
+        /// <summary>The name is reserved for the settings layer.</summary>
+        Reserved,
+
+        /// <summary>The name contains characters forbidden by XML.</summary>
+        InvalidXml,
+
+        /// <summary>Another ordinary layer already has this name.</summary>
+        Duplicate,
+    }
+}

--- a/src/CtrDxEditor.Core/Document/LevelDocument.cs
+++ b/src/CtrDxEditor.Core/Document/LevelDocument.cs
@@ -232,16 +232,29 @@ namespace CtrDxEditor.Core.Document
         /// <returns>True when the normalized name is XML-safe, non-empty, and unique.</returns>
         public bool TryNormalizeLayerName(string? name, out string normalized, LevelLayer? excluding = null)
         {
+            return ValidateLayerName(name, out normalized, excluding) == LayerNameValidationError.None;
+        }
+
+        /// <summary>Trims a candidate layer name and reports why it cannot be used.</summary>
+        /// <param name="name">The candidate name.</param>
+        /// <param name="normalized">The trimmed name when validation succeeds; otherwise an empty string.</param>
+        /// <param name="excluding">A layer to ignore in the uniqueness check (the one being renamed).</param>
+        /// <returns>The validation result.</returns>
+        public LayerNameValidationError ValidateLayerName(
+            string? name,
+            out string normalized,
+            LevelLayer? excluding = null)
+        {
             string candidate = name?.Trim() ?? "";
             normalized = "";
             if (candidate.Length == 0)
             {
-                return false;
+                return LayerNameValidationError.Empty;
             }
 
             if (IsSettingsLayerName(candidate))
             {
-                return false;
+                return LayerNameValidationError.Reserved;
             }
 
             try
@@ -250,17 +263,17 @@ namespace CtrDxEditor.Core.Document
             }
             catch (XmlException)
             {
-                return false;
+                return LayerNameValidationError.InvalidXml;
             }
 
             if (Layers.Any(layer =>
                 !ReferenceEquals(layer.Element, excluding?.Element) && layer.Name == candidate))
             {
-                return false;
+                return LayerNameValidationError.Duplicate;
             }
 
             normalized = candidate;
-            return true;
+            return LayerNameValidationError.None;
         }
 
         /// <summary>True when a normalized layer name is valid and not already used by another object layer.</summary>

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -141,6 +141,12 @@
     "Dialog.DeleteLayer.Body": "Delete the layer “{0}” and every object inside it?\nYou can undo this later.",
     "Dialog.DeleteLayer.Confirm": "Delete",
 
+    "Dialog.RenameLayer.Header": "Cannot rename layer",
+    "Dialog.RenameLayer.Duplicate": "A layer named “{0}” already exists.",
+    "Dialog.RenameLayer.Empty": "Layer name cannot be empty.",
+    "Dialog.RenameLayer.Reserved": "The name “settings” is reserved for level settings.",
+    "Dialog.RenameLayer.InvalidXml": "Layer name contains characters that XML cannot store.",
+
     "Dialog.Unsaved.Header": "Unsaved changes",
     "Dialog.Unsaved.Body": "You have unsaved changes that will be lost.",
     "Dialog.Unsaved.Close": "Discard and close",

--- a/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/ContentSetupDialog.axaml.cs
@@ -54,6 +54,7 @@ namespace CtrDxEditor.Views
                 {
                     Header = Localizer.Get("Dialog.Common.Error"),
                     Message = message,
+                    IsDanger = true,
                 };
                 _ = await error.ShowAsync();
             }

--- a/src/CtrDxEditor.Shared/Views/MainView.Commands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.Commands.cs
@@ -144,9 +144,7 @@ namespace CtrDxEditor.Views
 
             if (e.Key == Key.Escape)
             {
-                row.Name = row.Layer.Name;
-                row.IsRenaming = false;
-                _ = _canvas.Focus();
+                CancelLayerRename(row);
                 e.Handled = true;
             }
             else if (e.Key == Key.Enter)
@@ -157,6 +155,22 @@ namespace CtrDxEditor.Views
             }
         }
 
+        private void LayerRenameCancel_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is Control { Tag: LayerViewModel row })
+            {
+                CancelLayerRename(row);
+                e.Handled = true;
+            }
+        }
+
+        private void CancelLayerRename(LayerViewModel row)
+        {
+            row.Name = row.Layer.Name;
+            row.IsRenaming = false;
+            _ = _canvas.Focus();
+        }
+
         private void LayerName_Commit(object? sender, RoutedEventArgs e)
         {
             if (sender is TextBox { Tag: LayerViewModel row, Text: { } name })
@@ -165,19 +179,67 @@ namespace CtrDxEditor.Views
             }
         }
 
-        private void CommitLayerRename(LayerViewModel row, string name)
+        private bool _layerRenameCommitInProgress;
+
+        private async void CommitLayerRename(LayerViewModel row, string name)
         {
-            if (DataContext is EditorViewModel vm
-                && name != row.Layer.Name
-                && !vm.RenameLayer(row.Layer, name))
+            if (_layerRenameCommitInProgress)
             {
-                row.Name = row.Layer.Name;
-            }
-            else if (DataContext is not EditorViewModel)
-            {
-                row.Name = row.Layer.Name;
+                return;
             }
 
+            if (DataContext is not EditorViewModel vm)
+            {
+                row.Name = row.Layer.Name;
+                row.IsRenaming = false;
+                return;
+            }
+
+            if (name == row.Layer.Name)
+            {
+                row.IsRenaming = false;
+                return;
+            }
+
+            LayerNameValidationError error = vm.Document?.ValidateLayerName(name, out _, row.Layer)
+                ?? LayerNameValidationError.InvalidXml;
+            if (error != LayerNameValidationError.None)
+            {
+                string attemptedName = name;
+                _layerRenameCommitInProgress = true;
+                row.Name = row.Layer.Name;
+                row.IsRenaming = false;
+                try
+                {
+                    string key = error switch
+                    {
+                        LayerNameValidationError.Empty => "Dialog.RenameLayer.Empty",
+                        LayerNameValidationError.Reserved => "Dialog.RenameLayer.Reserved",
+                        LayerNameValidationError.InvalidXml => "Dialog.RenameLayer.InvalidXml",
+                        LayerNameValidationError.Duplicate => "Dialog.RenameLayer.Duplicate",
+                        LayerNameValidationError.None => "Dialog.RenameLayer.InvalidXml",
+                        _ => "Dialog.RenameLayer.InvalidXml",
+                    };
+                    MessageDialog warning = new()
+                    {
+                        Header = Localizer.Get("Dialog.RenameLayer.Header"),
+                        Message = Localizer.Get(key).Replace("{0}", name.Trim(), StringComparison.Ordinal),
+                    };
+                    _ = await warning.ShowAsync();
+                }
+                finally
+                {
+                    _layerRenameCommitInProgress = false;
+                }
+
+                BeginLayerRename(row, attemptedName);
+                return;
+            }
+
+            if (!vm.RenameLayer(row.Layer, name))
+            {
+                row.Name = row.Layer.Name;
+            }
             row.IsRenaming = false;
         }
 
@@ -200,14 +262,14 @@ namespace CtrDxEditor.Views
             }
         }
 
-        private void BeginLayerRename(LayerViewModel row)
+        private void BeginLayerRename(LayerViewModel row, string? initialName = null)
         {
             if (row.IsLocked)
             {
                 return;
             }
 
-            row.Name = row.Layer.Name;
+            row.Name = initialName ?? row.Layer.Name;
             row.IsRenaming = true;
             Dispatcher.UIThread.Post(() =>
             {

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -367,7 +367,7 @@
             </Style>
             <Style Selector="Border.layer-row">
               <Setter Property="HorizontalAlignment" Value="Stretch" />
-              <Setter Property="Padding" Value="6,2" />
+              <Setter Property="Padding" Value="6,2,2,2" />
               <Setter Property="Margin" Value="0,1,2,1" />
               <Setter Property="BorderThickness" Value="0" />
               <Setter Property="BorderBrush" Value="Transparent" />
@@ -437,7 +437,7 @@
                           IsVisible="{Binding IsActive}" Tag="{Binding .}"
                           IsEnabled="{Binding !IsLocked}"
                           Click="LayerRename_Click" ToolTip.Tip="{loc:Tr Layer.Rename}">
-                    <icons:MaterialIcon Kind="Pencil" Width="13" Height="13" />
+                    <icons:MaterialIcon Kind="Pencil" Width="14" Height="14" />
                   </Button>
                   <Button Grid.Column="4" Width="20" Height="20" Padding="0" Margin="2,0"
                           Background="Transparent" BorderBrush="Transparent"
@@ -513,7 +513,7 @@
                     </MultiBinding>
                   </Classes.selected>
                 </TextBlock>
-                <Button Grid.Column="2" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
+                <Button Grid.Column="3" Width="20" Height="20" Padding="0" Margin="2,0"
                         Background="Transparent" BorderBrush="Transparent"
                         Tag="{Binding .}" Click="ObjectLock_Click"
                         ToolTip.Tip="{loc:Tr Tooltip.ObjectLock}">
@@ -538,7 +538,7 @@
                     </icons:MaterialIcon>
                   </Grid>
                 </Button>
-                <Button Grid.Column="3" Width="16" Height="16" Padding="0" Margin="6,0,0,0"
+                <Button Grid.Column="2" Width="20" Height="20" Padding="0" Margin="2,0"
                         Background="Transparent" BorderBrush="Transparent"
                         Tag="{Binding .}" Click="ObjectAnimationPreview_Click"
                         ToolTip.Tip="{loc:Tr Tooltip.ObjectAnimationPreview}">
@@ -549,7 +549,7 @@
                     </MultiBinding>
                   </Button.IsVisible>
                   <Grid>
-                    <icons:MaterialIcon Kind="PlayArrow" Width="16" Height="16"
+                    <icons:MaterialIcon Kind="PlayArrow" Width="14" Height="14"
                                         Foreground="{DynamicResource EditorBrush.SuccessText}">
                       <icons:MaterialIcon.IsVisible>
                         <MultiBinding Converter="{x:Static conv:SpinPreviewConverters.IsObjectPreviewing}" ConverterParameter="Invert">
@@ -559,7 +559,7 @@
                         </MultiBinding>
                       </icons:MaterialIcon.IsVisible>
                     </icons:MaterialIcon>
-                    <icons:MaterialIcon Kind="Stop" Width="16" Height="16"
+                    <icons:MaterialIcon Kind="Stop" Width="14" Height="14"
                                         Foreground="{DynamicResource EditorBrush.DangerText}">
                       <icons:MaterialIcon.IsVisible>
                         <MultiBinding Converter="{x:Static conv:SpinPreviewConverters.IsObjectPreviewing}">

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -347,6 +347,7 @@
         <TreeView Grid.Row="1" Margin="4,0,4,4" x:Name="LayersTree"
                   Background="Transparent"
                   KeyDown="LayerTree_KeyDown"
+                  SelectionChanged="LayersTree_SelectionChanged"
                   ItemsSource="{Binding Layers}"
                   SelectedItem="{Binding SelectedTreeItem, Mode=TwoWay}">
           <TreeView.Styles>

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -423,7 +423,17 @@
                              IsVisible="{Binding IsRenaming}"
                              BorderThickness="0" Background="Transparent" Padding="0"
                              KeyDown="LayerName_KeyDown" LostFocus="LayerName_Commit" Tag="{Binding .}"
-                             ToolTip.Tip="{loc:Tr Layer.Rename}" />
+                             ToolTip.Tip="{loc:Tr Layer.Rename}">
+                      <TextBox.InnerRightContent>
+                        <Button Width="18" Height="18" Padding="0" Margin="2,0,0,0"
+                                Background="Transparent" BorderBrush="Transparent"
+                                Focusable="False" Tag="{Binding .}"
+                                Click="LayerRenameCancel_Click"
+                                ToolTip.Tip="{loc:Tr Dialog.Common.Cancel}">
+                          <icons:MaterialIcon Kind="Close" Width="12" Height="12" />
+                        </Button>
+                      </TextBox.InnerRightContent>
+                    </TextBox>
                   </Grid>
                   <Border Grid.Column="2" CornerRadius="8" Padding="5,1" Margin="3,0"
                           VerticalAlignment="Center"

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml.cs
@@ -111,6 +111,30 @@ namespace CtrDxEditor.Views
             {
                 Dispatcher.UIThread.Post(BringSelectedTreeItemIntoView, DispatcherPriority.Loaded);
             }
+
+            if (e.PropertyName == nameof(EditorViewModel.EffectivelyLockedObjects))
+            {
+                ClearLockedTreeSelection();
+            }
+        }
+
+        private void LayersTree_SelectionChanged(object? _, SelectionChangedEventArgs __)
+        {
+            ClearLockedTreeSelection();
+        }
+
+        private void ClearLockedTreeSelection()
+        {
+            if (DataContext is not EditorViewModel vm
+                || this.FindControl<TreeView>("LayersTree") is not { } tree
+                || tree.SelectedItem is not LevelObject selected
+                || !vm.EffectivelyLockedObjects.Contains(selected))
+            {
+                return;
+            }
+
+            tree.SelectedItem = null;
+            vm.SelectedTreeItem = null;
         }
 
         private void BringSelectedTreeItemIntoView()

--- a/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/MessageDialog.axaml
@@ -5,8 +5,14 @@
              x:Class="CtrDxEditor.Views.MessageDialog"
              x:CompileBindings="True"
              x:DataType="views:MessageDialog">
+  <UserControl.Styles>
+    <Style Selector="TextBlock.dialog-header.danger">
+      <Setter Property="Foreground" Value="{DynamicResource EditorBrush.DangerText}" />
+    </Style>
+  </UserControl.Styles>
   <StackPanel Margin="24" Spacing="16" Width="460">
-    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource EditorBrush.DangerText}" Text="{Binding Header}" />
+    <TextBlock Classes="dialog-header" Classes.danger="{Binding IsDanger}"
+               FontSize="18" FontWeight="SemiBold" Text="{Binding Header}" />
     <TextBlock TextWrapping="Wrap" Text="{Binding Message}" />
     <Button Content="{loc:Tr Dialog.Common.Ok}" Click="Ok_Click" HorizontalAlignment="Right" />
   </StackPanel>

--- a/src/CtrDxEditor.Shared/Views/MessageDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/MessageDialog.axaml.cs
@@ -17,6 +17,10 @@ namespace CtrDxEditor.Views
         public static readonly StyledProperty<string> MessageProperty =
             AvaloniaProperty.Register<MessageDialog, string>(nameof(Message));
 
+        /// <summary>The <see cref="IsDanger"/> property.</summary>
+        public static readonly StyledProperty<bool> IsDangerProperty =
+            AvaloniaProperty.Register<MessageDialog, bool>(nameof(IsDanger));
+
         /// <summary>The dialog's title line.</summary>
         public string Header
         {
@@ -29,6 +33,13 @@ namespace CtrDxEditor.Views
         {
             get => GetValue(MessageProperty);
             set => SetValue(MessageProperty, value);
+        }
+
+        /// <summary>Whether the header uses the danger color reserved for actual errors.</summary>
+        public bool IsDanger
+        {
+            get => GetValue(IsDangerProperty);
+            set => SetValue(IsDangerProperty, value);
         }
 
         /// <summary>Creates the message dialog.</summary>

--- a/src/CtrDxEditor.Tests/EditorLayerLockTests.cs
+++ b/src/CtrDxEditor.Tests/EditorLayerLockTests.cs
@@ -59,6 +59,7 @@ namespace CtrDxEditor.Tests
 
             Assert.Null(vm.LockedObject);
             Assert.Null(vm.SelectedObject);
+            Assert.Null(vm.SelectedTreeItem);
         }
 
         /// <summary>A locked layer's object cannot be selected through the layer tree.</summary>

--- a/src/CtrDxEditor.Tests/LocalizationTests.cs
+++ b/src/CtrDxEditor.Tests/LocalizationTests.cs
@@ -24,6 +24,21 @@ namespace CtrDxEditor.Tests
             Assert.DoesNotContain("Dialog.Close.Header", strings.Keys);
         }
 
+        /// <summary>Every rejected layer-name reason has user-facing dialog text.</summary>
+        [Fact]
+        public void LayerRenameFailuresAreLocalized()
+        {
+            string path = FindRepositoryFile("src/CtrDxEditor.Shared/Localization/en.json");
+            Dictionary<string, string> strings = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                File.ReadAllText(path))!;
+
+            Assert.Equal("Cannot rename layer", strings["Dialog.RenameLayer.Header"]);
+            Assert.Contains("already exists", strings["Dialog.RenameLayer.Duplicate"], StringComparison.Ordinal);
+            Assert.Contains("cannot be empty", strings["Dialog.RenameLayer.Empty"], StringComparison.Ordinal);
+            Assert.Contains("reserved", strings["Dialog.RenameLayer.Reserved"], StringComparison.Ordinal);
+            Assert.Contains("XML", strings["Dialog.RenameLayer.InvalidXml"], StringComparison.Ordinal);
+        }
+
         /// <summary>Verifies the magic hat and its pairing field have user-facing English text.</summary>
         [Fact]
         public void MagicHatObjectAndGroupAreLocalized()

--- a/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
+++ b/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
@@ -327,6 +327,19 @@ namespace CtrDxEditor.Tests
             Assert.Contains("container.BringIntoView();", viewCodeBehind, StringComparison.Ordinal);
         }
 
+        /// <summary>Locked-layer objects cannot retain or acquire the TreeView selection highlight.</summary>
+        [Fact]
+        public void LockedLayerObjectsCannotKeepTreeSelectionHighlight()
+        {
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+            string viewCodeBehind = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml.cs"));
+
+            Assert.Contains("SelectionChanged=\"LayersTree_SelectionChanged\"", view, StringComparison.Ordinal);
+            Assert.Contains("nameof(EditorViewModel.EffectivelyLockedObjects)", viewCodeBehind, StringComparison.Ordinal);
+            Assert.Contains("ClearLockedTreeSelection();", viewCodeBehind, StringComparison.Ordinal);
+            Assert.Contains("tree.SelectedItem = null;", viewCodeBehind, StringComparison.Ordinal);
+        }
+
         private static string SourcePath(params string[] parts)
         {
             string path = AppContext.BaseDirectory;

--- a/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
+++ b/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
@@ -211,6 +211,57 @@ namespace CtrDxEditor.Tests
             Assert.Contains("DispatcherPriority.Normal", codeBehind, StringComparison.Ordinal);
         }
 
+        /// <summary>The inline close button cancels layer rename just like Escape.</summary>
+        [Fact]
+        public void LayerRenameEditorHasCloseButtonThatCancelsRename()
+        {
+            XDocument view = XDocument.Load(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+            string codeBehind = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.Commands.cs"));
+            XElement editor = view.Descendants()
+                .Single(element => element.Name.LocalName == "TextBox"
+                    && (string?)element.Attribute("Classes.layer-name-editor") == "True");
+            XElement closeButton = editor.Descendants()
+                .Single(element => element.Name.LocalName == "Button");
+            XElement closeIcon = closeButton.Descendants()
+                .Single(element => element.Name.LocalName == "MaterialIcon");
+
+            Assert.Equal("LayerRenameCancel_Click", (string?)closeButton.Attribute("Click"));
+            Assert.Equal("False", (string?)closeButton.Attribute("Focusable"));
+            Assert.Equal("{loc:Tr Dialog.Common.Cancel}", (string?)closeButton.Attribute("ToolTip.Tip"));
+            Assert.Equal("Close", (string?)closeIcon.Attribute("Kind"));
+            Assert.Contains("private void CancelLayerRename(LayerViewModel row)", codeBehind, StringComparison.Ordinal);
+            Assert.True(
+                codeBehind.Split("CancelLayerRename(row);", StringSplitOptions.None).Length >= 3,
+                "Expected both Escape and the close button to use the shared cancellation path.");
+        }
+
+        /// <summary>Rejected inline layer names explain the failure and reopen the editor for correction.</summary>
+        [Fact]
+        public void InvalidLayerRenameShowsWarningAndResumesEditing()
+        {
+            string codeBehind = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.Commands.cs"));
+
+            Assert.Contains("private async void CommitLayerRename", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_layerRenameCommitInProgress", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("MessageDialog warning = new()", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("warning.ShowAsync();", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("BeginLayerRename(row, attemptedName);", codeBehind, StringComparison.Ordinal);
+        }
+
+        /// <summary>Message dialogs use normal headers unless the caller explicitly marks an error.</summary>
+        [Fact]
+        public void MessageDialogDangerHeaderIsOptIn()
+        {
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MessageDialog.axaml"));
+            string dialogCode = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MessageDialog.axaml.cs"));
+            string contentSetup = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "ContentSetupDialog.axaml.cs"));
+
+            Assert.Contains("Classes.danger=\"{Binding IsDanger}\"", view, StringComparison.Ordinal);
+            Assert.Contains("Selector=\"TextBlock.dialog-header.danger\"", view, StringComparison.Ordinal);
+            Assert.Contains("public bool IsDanger", dialogCode, StringComparison.Ordinal);
+            Assert.Contains("IsDanger = true", contentSetup, StringComparison.Ordinal);
+        }
+
         /// <summary>Object labels keep a readable gap after their visibility control.</summary>
         [Fact]
         public void ObjectVisibilityIconHasNameSpacing()

--- a/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
+++ b/src/CtrDxEditor.Tests/MainViewLayerPanelTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Xml.Linq;
 
 using Avalonia;
 using Avalonia.Controls;
@@ -216,6 +218,57 @@ namespace CtrDxEditor.Tests
             string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
 
             Assert.Contains("Classes.object-name=\"True\" Margin=\"6,0,0,0\"", view, StringComparison.Ordinal);
+        }
+
+        /// <summary>Layer and object actions occupy matching lock and secondary-action slots.</summary>
+        [Fact]
+        public void LayerAndObjectActionButtonsUseAlignedSlots()
+        {
+            XDocument view = XDocument.Load(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+            XElement Button(string handler)
+            {
+                return view.Descendants()
+                    .Single(element => element.Name.LocalName == "Button"
+                        && (string?)element.Attribute("Click") == handler);
+            }
+
+            XElement layerLock = Button("LayerLockToggle_Click");
+            XElement layerRename = Button("LayerRename_Click");
+            XElement objectLock = Button("ObjectLock_Click");
+            XElement objectAnimation = Button("ObjectAnimationPreview_Click");
+            XElement layerStyle = view.Descendants()
+                .Single(element => element.Name.LocalName == "Style"
+                    && (string?)element.Attribute("Selector") == "Border.layer-row");
+            XElement objectStyle = view.Descendants()
+                .Single(element => element.Name.LocalName == "Style"
+                    && (string?)element.Attribute("Selector") == "Border.object-row");
+            static string? Padding(XElement style)
+            {
+                return (string?)style.Elements()
+                    .Single(element => (string?)element.Attribute("Property") == "Padding")
+                    .Attribute("Value");
+            }
+
+            Assert.Equal("4", (string?)layerLock.Attribute("Grid.Column"));
+            Assert.Equal("3", (string?)layerRename.Attribute("Grid.Column"));
+            Assert.Equal("3", (string?)objectLock.Attribute("Grid.Column"));
+            Assert.Equal("2", (string?)objectAnimation.Attribute("Grid.Column"));
+            Assert.Equal("Auto,*,Auto,Auto,Auto", (string?)layerLock.Parent!.Attribute("ColumnDefinitions"));
+            Assert.Equal("Auto,*,Auto,Auto", (string?)objectLock.Parent!.Attribute("ColumnDefinitions"));
+            Assert.Equal("6,2,2,2", Padding(layerStyle));
+            Assert.Equal("2,1", Padding(objectStyle));
+            Assert.All([layerLock, layerRename, objectLock, objectAnimation], button =>
+            {
+                Assert.Equal("20", (string?)button.Attribute("Width"));
+                Assert.Equal("20", (string?)button.Attribute("Height"));
+                Assert.Equal("2,0", (string?)button.Attribute("Margin"));
+            });
+            Assert.All(layerRename.Descendants().Concat(objectAnimation.Descendants())
+                .Where(element => element.Name.LocalName == "MaterialIcon"), icon =>
+            {
+                Assert.Equal("14", (string?)icon.Attribute("Width"));
+                Assert.Equal("14", (string?)icon.Attribute("Height"));
+            });
         }
 
         /// <summary>Layer locking stays available inline without retaining object or layer context menus.</summary>


### PR DESCRIPTION
## Description

- Align layer and object action buttons with consistent sizing and placement
- Prevent objects on locked layers from retaining selection highlights
- Show localized warnings explaining why a layer name is invalid
- Resume editing with the attempted name after a validation warning
- Add an inline button for cancelling layer-name edits
- Reserve danger-colored dialog headers for actual errors