### PR TITLE
perf: clip movement paths to the viewport, and add a render benchmark project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ nunit-*.xml
 
 # Binary content assets — fetched from ctrdx-assets at build time, not stored in Git
 /content/
+
+# BenchmarkDotNet run output (reports, logs, generated build projects).
+BenchmarkDotNet.Artifacts/

--- a/CtrDxEditor.slnx
+++ b/CtrDxEditor.slnx
@@ -1,4 +1,5 @@
 <Solution>
+  <Project Path="src/CtrDxEditor.Benchmarks/CtrDxEditor.Benchmarks.csproj" />
   <Project Path="src/CtrDxEditor.Browser/CtrDxEditor.Browser.csproj" />
   <Project Path="src/CtrDxEditor.Core.Tests/CtrDxEditor.Core.Tests.csproj" />
   <Project Path="src/CtrDxEditor.Core/CtrDxEditor.Core.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,9 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
     <PackageVersion Include="Avalonia.Skia" Version="12.1.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="AvaloniaDialogs" Version="3.7.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="3.0.2" />

--- a/src/CtrDxEditor.Benchmarks/CtrDxEditor.Benchmarks.csproj
+++ b/src/CtrDxEditor.Benchmarks/CtrDxEditor.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>CtrDxEditor.Benchmarks</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet builds and reflects over the benchmark assembly at run time. -->
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="Avalonia.Skia" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CtrDxEditor.Shared\CtrDxEditor.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/CtrDxEditor.Benchmarks/HeadlessRenderTarget.cs
+++ b/src/CtrDxEditor.Benchmarks/HeadlessRenderTarget.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+
+namespace CtrDxEditor.Benchmarks
+{
+    /// <summary>
+    /// A real Skia surface to draw into, without a window.
+    /// <para>
+    /// The headless platform normally stubs out drawing, which would measure nothing; passing
+    /// <c>UseHeadlessDrawing = false</c> keeps Skia doing genuine rasterization, so pen tessellation and
+    /// fill costs are the same work the desktop editor pays. Avalonia can only be configured once per
+    /// process, so <see cref="EnsureAvalonia"/> is idempotent.
+    /// </para>
+    /// </summary>
+    public sealed class HeadlessRenderTarget : IDisposable
+    {
+        private static readonly Lock BootLock = new();
+        private static bool _booted;
+
+        private readonly RenderTargetBitmap _bitmap;
+
+        /// <summary>Creates a surface of the given pixel size, booting Avalonia if it is not already up.</summary>
+        /// <param name="width">Surface width in pixels.</param>
+        /// <param name="height">Surface height in pixels.</param>
+        public HeadlessRenderTarget(int width, int height)
+        {
+            EnsureAvalonia();
+            Width = width;
+            Height = height;
+            _bitmap = new RenderTargetBitmap(new PixelSize(width, height), new Vector(96, 96));
+        }
+
+        /// <summary>Surface width in pixels.</summary>
+        public int Width { get; }
+
+        /// <summary>Surface height in pixels.</summary>
+        public int Height { get; }
+
+        /// <summary>Boots the headless Skia platform once per process.</summary>
+        public static void EnsureAvalonia()
+        {
+            lock (BootLock)
+            {
+                if (_booted)
+                {
+                    return;
+                }
+
+                _ = AppBuilder.Configure<Application>()
+                    .UseSkia()
+                    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                    .SetupWithoutStarting();
+                _booted = true;
+            }
+        }
+
+        /// <summary>
+        /// Runs <paramref name="draw"/> against a fresh drawing context and disposes it, which is what forces
+        /// Skia to actually rasterize. Without the dispose the work could be deferred out of the measurement.
+        /// </summary>
+        /// <param name="draw">The drawing to perform.</param>
+        public void Frame(Action<DrawingContext> draw)
+        {
+            using DrawingContext ctx = _bitmap.CreateDrawingContext();
+            ctx.FillRectangle(Brushes.DimGray, new Rect(0, 0, Width, Height));
+            draw(ctx);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _bitmap.Dispose();
+        }
+    }
+}

--- a/src/CtrDxEditor.Benchmarks/MovementPathBenchmarks.cs
+++ b/src/CtrDxEditor.Benchmarks/MovementPathBenchmarks.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Avalonia.Media;
+
+using BenchmarkDotNet.Attributes;
+
+using CtrDxEditor.Core.Document;
+using CtrDxEditor.Core.Geometry;
+
+namespace CtrDxEditor.Benchmarks
+{
+    /// <summary>
+    /// Measures the movement-path overlay pass, which redraws on every <c>InvalidateVisual</c> — so its cost
+    /// lands directly on drag and pan responsiveness, not just on load.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class MovementPathBenchmarks : IDisposable
+    {
+        private const int SurfaceWidth = 1400;
+        private const int SurfaceHeight = 900;
+        private const int ObjectCount = 56;
+
+        // LevelSceneRenderer is internal to the Shared assembly. Binding it to a delegate once in setup keeps
+        // reflection out of the measured loop, so the numbers are drawing cost rather than dispatch cost.
+        private delegate void DrawMovementPathFn(
+            DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pathPen, Pen arrowPen, IntSize viewport);
+
+        // Mirrors CanvasPalette's OrbitPath/OrbitPathArrow. The dash pattern is the point of the benchmark:
+        // a dotted pen tessellates a segment's whole length, so pen shape drives the cost.
+        private static readonly Pen PathPen =
+            new(new SolidColorBrush(Color.FromRgb(0x25, 0x63, 0xEB)), 1.5) { DashStyle = new DashStyle([1, 3], 0) };
+
+        private static readonly Pen ArrowPen =
+            new(new SolidColorBrush(Color.FromRgb(0x25, 0x63, 0xEB)), 2.25);
+
+        private HeadlessRenderTarget _target = null!;
+        private DrawMovementPathFn _drawMovementPath = null!;
+        private IReadOnlyList<LevelObject> _objects = null!;
+
+        /// <summary>The level shape under test.</summary>
+        [Params(LevelShape.OffMapMovers, LevelShape.LocalMovers, LevelShape.DenseStatic)]
+        public LevelShape Shape { get; set; }
+
+        /// <summary>Canvas zoom. Cost that grows with zoom means work is being done off-screen.</summary>
+        [Params(0.5, 1.0, 2.0)]
+        public double Zoom { get; set; }
+
+        /// <summary>Which generated level a run uses.</summary>
+        public enum LevelShape
+        {
+            /// <summary>Movers with sentinel paths running far off the map.</summary>
+            OffMapMovers,
+
+            /// <summary>Movers with short on-map paths; the control for path length.</summary>
+            LocalMovers,
+
+            /// <summary>Objects with no paths; the floor for object count.</summary>
+            DenseStatic,
+        }
+
+        /// <summary>Boots Avalonia, binds the internal renderer, and builds the level for this run.</summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+            _target = new HeadlessRenderTarget(SurfaceWidth, SurfaceHeight);
+
+            Type renderer = typeof(Rendering.LevelCanvas).Assembly
+                .GetType("CtrDxEditor.Rendering.LevelSceneRenderer")
+                ?? throw new InvalidOperationException("LevelSceneRenderer not found.");
+            MethodInfo method = renderer.GetMethod("DrawMovementPath", BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException("DrawMovementPath not found.");
+            _drawMovementPath = method.CreateDelegate<DrawMovementPathFn>();
+
+            LevelDocument document = Shape switch
+            {
+                LevelShape.OffMapMovers => StressLevels.OffMapMovers(ObjectCount),
+                LevelShape.LocalMovers => StressLevels.LocalMovers(ObjectCount),
+                LevelShape.DenseStatic => StressLevels.DenseStatic(ObjectCount),
+                _ => throw new ArgumentOutOfRangeException(nameof(Shape)),
+            };
+            _objects = document.AllObjects;
+        }
+
+        /// <summary>Releases the render surface.</summary>
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            Dispose();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _target?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>Draws every object's movement path once, as one editor frame would.</summary>
+        [Benchmark]
+        public void DrawMovementPaths()
+        {
+            ViewTransform view = new(Zoom, 200, 100);
+            IntSize viewport = new(SurfaceWidth, SurfaceHeight);
+            _target.Frame(ctx =>
+            {
+                foreach (LevelObject obj in _objects)
+                {
+                    _drawMovementPath(ctx, view, obj, PathPen, ArrowPen, viewport);
+                }
+            });
+        }
+    }
+}

--- a/src/CtrDxEditor.Benchmarks/Program.cs
+++ b/src/CtrDxEditor.Benchmarks/Program.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+
+using BenchmarkDotNet.Running;
+
+using CtrDxEditor.Core.Document;
+
+namespace CtrDxEditor.Benchmarks
+{
+    /// <summary>Entry point for the render benchmarks.</summary>
+    public static class Program
+    {
+        /// <summary>Runs the benchmarks, or prints fixture sizes with <c>--describe</c>.</summary>
+        /// <param name="args">Command line arguments, forwarded to BenchmarkDotNet.</param>
+        public static void Main(string[] args)
+        {
+            if (Array.Exists(args, a => a == "--describe"))
+            {
+                Describe();
+                return;
+            }
+
+            _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+
+        // Prints how much path each generated level actually contains, so a fixture that has drifted away
+        // from the workload it is meant to represent is visible without running a full benchmark.
+        private static void Describe()
+        {
+            (string Name, LevelDocument Document)[] levels =
+            [
+                ("OffMapMovers(56)", StressLevels.OffMapMovers(56)),
+                ("LocalMovers(56)", StressLevels.LocalMovers(56)),
+                ("DenseStatic(56)", StressLevels.DenseStatic(56)),
+            ];
+
+            foreach ((string name, LevelDocument document) in levels)
+            {
+                double length = StressLevels.TotalPathLength(document);
+                Console.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0,-18} objects={1,4}  total path={2,12:N0} level units",
+                    name,
+                    document.AllObjects.Count,
+                    length));
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Benchmarks/README.md
+++ b/src/CtrDxEditor.Benchmarks/README.md
@@ -1,0 +1,40 @@
+# Render benchmarks
+
+Measures editor render passes against real Skia rasterization, so the numbers reflect work the desktop
+editor actually pays rather than a model of it. Avalonia boots headless with `UseHeadlessDrawing = false`
+and draws into a `RenderTargetBitmap`.
+
+## Running
+
+```sh
+cd src/CtrDxEditor.Benchmarks
+dotnet run -c Release -- --filter '*'          # full run, a few minutes
+dotnet run -c Release -- --filter '*' --job short   # quicker, noisier
+dotnet run -c Release -- --describe            # print fixture sizes, no benchmarking
+```
+
+Release is required — BenchmarkDotNet refuses to measure a Debug build.
+
+## Levels
+
+Levels are generated in code (`StressLevels`), so no level files are needed and the fixtures cannot drift
+with someone's saved content. Three shapes isolate different costs:
+
+| Shape          | Objects | Total path        | Isolates                          |
+| -------------- | ------: | ----------------: | --------------------------------- |
+| `OffMapMovers` |      56 | ~1,296,900 units  | path length (sentinel off-map paths) |
+| `LocalMovers`  |      56 |     ~26,900 units | mover count, without the length   |
+| `DenseStatic`  |      56 |                 0 | object count, with no paths at all |
+
+`OffMapMovers` is tuned to match a real pathological level (~1.30M level units across 56 movers) that made
+the editor lag. Run `--describe` to confirm a fixture still carries the workload it claims to.
+
+## Reading the results
+
+`Zoom` is the axis that matters most for the movement-path pass. Cost that **grows with zoom** means work
+is being spent on geometry that is off-screen — segments get longer in screen space as you zoom in, and a
+dashed or dotted pen tessellates a segment's whole length before rasterization can discard the invisible
+part. Cost that stays **flat across zoom** means clipping is doing its job.
+
+`DenseStatic` is the floor: surface clear plus the per-object walk, drawing no paths. Subtract it to see
+what the path drawing itself costs.

--- a/src/CtrDxEditor.Benchmarks/StressLevels.cs
+++ b/src/CtrDxEditor.Benchmarks/StressLevels.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+using CtrDxEditor.Core.Document;
+
+namespace CtrDxEditor.Benchmarks
+{
+    /// <summary>
+    /// Builds level documents in code so the benchmarks depend on no level files. Each shape isolates one
+    /// cost: <see cref="OffMapMovers"/> varies path length, <see cref="LocalMovers"/> holds the mover count
+    /// but not the length, and <see cref="DenseStatic"/> holds the object count but has no paths at all.
+    /// Comparing the three separates "how much path" from "how many objects".
+    /// </summary>
+    public static class StressLevels
+    {
+        private const int Width = 853;
+        private const int Height = 2880;
+
+        /// <summary>
+        /// Movers whose paths run far off the map, the shape that made the editor lag. Real levels express
+        /// "travel off-screen" with sentinel offsets in the ±10000 range, so a handful of objects can add up
+        /// to over a million level units of path.
+        /// </summary>
+        /// <param name="count">How many movers to place.</param>
+        /// <returns>A parsed level document.</returns>
+        public static LevelDocument OffMapMovers(int count)
+        {
+            StringBuilder objects = new();
+            for (int i = 0; i < count; i++)
+            {
+                int column = i % 8;
+                int row = i / 8;
+                int x = 100 + (column * 100);
+                int y = 200 + (row * 200);
+                // Alternate the sentinel direction so segments run vertically, horizontally and diagonally,
+                // rather than all overlapping into one span the rasterizer could treat as a single line.
+                string path = (i % 3) switch
+                {
+                    0 => "0,-10734",
+                    1 => "-9999,0",
+                    _ => "-9999,-9999",
+                };
+                _ = objects.Append(CultureInfo.InvariantCulture, $"""
+                        <bouncer1 x="{x}" y="{y}" angle="0" size="2" path="{path}" moveSpeed="100" />
+
+                    """);
+            }
+
+            return Build(objects.ToString());
+        }
+
+        /// <summary>
+        /// The control for <see cref="OffMapMovers"/>: the same mover count and the same per-object work,
+        /// but short paths that stay on the map. The gap between the two is the cost of path length alone.
+        /// </summary>
+        /// <param name="count">How many movers to place.</param>
+        /// <returns>A parsed level document.</returns>
+        public static LevelDocument LocalMovers(int count)
+        {
+            StringBuilder objects = new();
+            for (int i = 0; i < count; i++)
+            {
+                int column = i % 8;
+                int row = i / 8;
+                int x = 100 + (column * 100);
+                int y = 200 + (row * 200);
+                _ = objects.Append(CultureInfo.InvariantCulture, $"""
+                        <bouncer1 x="{x}" y="{y}" angle="0" size="2" path="120,0,120,120,0,120" moveSpeed="100" />
+
+                    """);
+            }
+
+            return Build(objects.ToString());
+        }
+
+        /// <summary>
+        /// Objects with no movement at all, so the movement-path pass walks the same object count but draws
+        /// nothing. This is the floor the other two shapes are measured against.
+        /// </summary>
+        /// <param name="count">How many objects to place.</param>
+        /// <returns>A parsed level document.</returns>
+        public static LevelDocument DenseStatic(int count)
+        {
+            StringBuilder objects = new();
+            for (int i = 0; i < count; i++)
+            {
+                int column = i % 16;
+                int row = i / 16;
+                int x = 40 + (column * 50);
+                int y = 100 + (row * 120);
+                _ = objects.Append(CultureInfo.InvariantCulture, $"""
+                        <spike2 x="{x}" y="{y}" angle="0" size="3" />
+
+                    """);
+            }
+
+            return Build(objects.ToString());
+        }
+
+        private static LevelDocument Build(string objectElements)
+        {
+            string xml = $"""
+                <map>
+                    <layer name="settings">
+                        <map gridSize="32" width="{Width}" height="{Height}" />
+                        <gameDesign ropePhysicsSpeed="1" twoParts="false" nightLevel="false" />
+                    </layer>
+                    <layer name="Objects">
+                {objectElements}    </layer>
+                </map>
+                """;
+            return LevelDocument.Parse(xml);
+        }
+
+        /// <summary>Total length of every path segment the movement-path pass will draw, in level units.</summary>
+        /// <param name="document">The level to measure.</param>
+        /// <returns>The summed segment length, useful for sanity-checking that a fixture is as heavy as intended.</returns>
+        public static double TotalPathLength(LevelDocument document)
+        {
+            double total = 0;
+            foreach (LevelObject obj in document.AllObjects)
+            {
+                Core.Geometry.Vec2[] points = Core.Editing.MoverPath.Points(
+                    new Core.Geometry.Vec2(obj.X, obj.Y), obj.GetAttr("path"));
+                for (int i = 0; i < points.Length; i++)
+                {
+                    Core.Geometry.Vec2 a = points[i];
+                    Core.Geometry.Vec2 b = points[(i + 1) % points.Length];
+                    total += Math.Sqrt(((b.X - a.X) * (b.X - a.X)) + ((b.Y - a.Y) * (b.Y - a.Y)));
+                }
+            }
+
+            return total;
+        }
+    }
+}

--- a/src/CtrDxEditor.Core.Tests/SegmentClipTests.cs
+++ b/src/CtrDxEditor.Core.Tests/SegmentClipTests.cs
@@ -1,0 +1,82 @@
+using CtrDxEditor.Core.Geometry;
+
+using Xunit;
+
+namespace CtrDxEditor.Core.Tests
+{
+    /// <summary>Tests for clipping screen-space segments to the visible viewport.</summary>
+    public class SegmentClipTests
+    {
+        private static readonly IntSize Viewport = new(800, 600);
+
+        /// <summary>Verifies that a segment wholly inside the viewport is kept unchanged.</summary>
+        [Fact]
+        public void SegmentInsideViewportIsUnchanged()
+        {
+            Vec2 a = new(100, 100);
+            Vec2 b = new(700, 500);
+
+            Assert.True(SegmentClip.ToViewport(ref a, ref b, Viewport));
+            Assert.Equal(new Vec2(100, 100), a);
+            Assert.Equal(new Vec2(700, 500), b);
+        }
+
+        /// <summary>Verifies that a segment entirely off-screen is rejected so it is never drawn.</summary>
+        [Fact]
+        public void SegmentEntirelyOffScreenIsRejected()
+        {
+            Vec2 a = new(-50_000, 100);
+            Vec2 b = new(-10_000, 500);
+
+            Assert.False(SegmentClip.ToViewport(ref a, ref b, Viewport));
+        }
+
+        /// <summary>Verifies that a segment straddling the viewport is trimmed to the visible span.</summary>
+        [Fact]
+        public void SegmentCrossingViewportIsTrimmedToBounds()
+        {
+            Vec2 a = new(-100_000, 300);
+            Vec2 b = new(100_000, 300);
+
+            Assert.True(SegmentClip.ToViewport(ref a, ref b, Viewport));
+            Assert.True(a.X >= -SegmentClip.Padding - 0.001);
+            Assert.True(b.X <= 800 + SegmentClip.Padding + 0.001);
+            Assert.Equal(300, a.Y, precision: 6);
+            Assert.Equal(300, b.Y, precision: 6);
+        }
+
+        /// <summary>
+        /// Verifies that clipping preserves direction: the kept span still runs a to b, so the arrow
+        /// chevrons drawn along a clipped path keep pointing the way the object travels.
+        /// </summary>
+        [Fact]
+        public void ClippedSegmentKeepsOriginalDirection()
+        {
+            Vec2 a = new(100_000, 300);
+            Vec2 b = new(-100_000, 300);
+
+            Assert.True(SegmentClip.ToViewport(ref a, ref b, Viewport));
+            Assert.True(a.X > b.X);
+        }
+
+        /// <summary>Verifies that a diagonal segment passing only through a corner is kept.</summary>
+        [Fact]
+        public void DiagonalThroughCornerIsKept()
+        {
+            Vec2 a = new(-1000, 1600);
+            Vec2 b = new(1600, -1000);
+
+            Assert.True(SegmentClip.ToViewport(ref a, ref b, Viewport));
+        }
+
+        /// <summary>Verifies that a degenerate zero-length segment outside the viewport is rejected.</summary>
+        [Fact]
+        public void ZeroLengthSegmentOffScreenIsRejected()
+        {
+            Vec2 a = new(-9999, -9999);
+            Vec2 b = new(-9999, -9999);
+
+            Assert.False(SegmentClip.ToViewport(ref a, ref b, Viewport));
+        }
+    }
+}

--- a/src/CtrDxEditor.Core/Geometry/SegmentClip.cs
+++ b/src/CtrDxEditor.Core/Geometry/SegmentClip.cs
@@ -1,0 +1,116 @@
+namespace CtrDxEditor.Core.Geometry
+{
+    /// <summary>
+    /// Clips screen-space segments to the visible viewport before they reach the renderer.
+    /// <para>
+    /// Movement paths use sentinel offsets (±9999 and larger) to mean "travel off the map", so a single
+    /// authored segment can span hundreds of thousands of screen pixels once zoom is applied. Handing that
+    /// to a dashed or dotted pen is what costs: the dash path effect tessellates the whole run into
+    /// on/off pieces before rasterization ever gets to reject the off-screen ones, so the work scales with
+    /// the segment's full length rather than with the part you can actually see. Trimming each segment to
+    /// the viewport first makes the cost proportional to the visible span instead.
+    /// </para>
+    /// </summary>
+    public static class SegmentClip
+    {
+        /// <summary>
+        /// Slack in pixels kept around the viewport. A stroke is drawn centered on the segment and can
+        /// carry caps and arrow barbs, so trimming exactly at the edge could shave pixels that belong
+        /// on-screen; this keeps a margin wider than any overlay stroke.
+        /// </summary>
+        public const double Padding = 16.0;
+
+        /// <summary>
+        /// Trims <paramref name="a"/>→<paramref name="b"/> to the padded viewport, preserving direction.
+        /// </summary>
+        /// <param name="a">The segment start in screen pixels; moved to the first visible point.</param>
+        /// <param name="b">The segment end in screen pixels; moved to the last visible point.</param>
+        /// <param name="viewport">The viewport size in screen pixels.</param>
+        /// <returns>
+        /// True when some part of the segment is visible and <paramref name="a"/>/<paramref name="b"/> now
+        /// bound that part; false when the segment misses the viewport entirely and should not be drawn.
+        /// </returns>
+        public static bool ToViewport(ref Vec2 a, ref Vec2 b, IntSize viewport)
+        {
+            double minX = -Padding;
+            double minY = -Padding;
+            double maxX = viewport.W + Padding;
+            double maxY = viewport.H + Padding;
+
+            // Cohen-Sutherland: push each endpoint onto the boundary it violates until both are inside
+            // (accept) or both sit outside the same edge (reject).
+            double x0 = a.X, y0 = a.Y, x1 = b.X, y1 = b.Y;
+            int code0 = OutCode(x0, y0, minX, minY, maxX, maxY);
+            int code1 = OutCode(x1, y1, minX, minY, maxX, maxY);
+
+            while (true)
+            {
+                if ((code0 | code1) == 0)
+                {
+                    a = new Vec2(x0, y0);
+                    b = new Vec2(x1, y1);
+                    return true;
+                }
+
+                if ((code0 & code1) != 0)
+                {
+                    return false;
+                }
+
+                // An endpoint can sit outside more than one edge at once (a corner), so the guards are
+                // bit tests taken in order rather than cases on the code's value: pull the point onto the
+                // first violated boundary, then re-test on the next pass until it lands inside.
+                int outside = code0 != 0 ? code0 : code1;
+                (double x, double y) = outside switch
+                {
+                    _ when (outside & Bottom) != 0 => (x0 + ((x1 - x0) * (maxY - y0) / (y1 - y0)), maxY),
+                    _ when (outside & Top) != 0 => (x0 + ((x1 - x0) * (minY - y0) / (y1 - y0)), minY),
+                    _ when (outside & Right) != 0 => (maxX, y0 + ((y1 - y0) * (maxX - x0) / (x1 - x0))),
+                    _ => (minX, y0 + ((y1 - y0) * (minX - x0) / (x1 - x0))),
+                };
+
+                if (outside == code0)
+                {
+                    x0 = x;
+                    y0 = y;
+                    code0 = OutCode(x0, y0, minX, minY, maxX, maxY);
+                }
+                else
+                {
+                    x1 = x;
+                    y1 = y;
+                    code1 = OutCode(x1, y1, minX, minY, maxX, maxY);
+                }
+            }
+        }
+
+        private const int Left = 1;
+        private const int Right = 2;
+        private const int Top = 4;
+        private const int Bottom = 8;
+
+        private static int OutCode(double x, double y, double minX, double minY, double maxX, double maxY)
+        {
+            int code = 0;
+            if (x < minX)
+            {
+                code |= Left;
+            }
+            else if (x > maxX)
+            {
+                code |= Right;
+            }
+
+            if (y < minY)
+            {
+                code |= Top;
+            }
+            else if (y > maxY)
+            {
+                code |= Bottom;
+            }
+
+            return code;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -88,11 +88,12 @@ namespace CtrDxEditor.Rendering
 
             GrabRenderer.DrawRadiusRings(context, v, objects, _palette.GrabRadius, _palette.BulbRadius, PreviewAnimationSeconds);
 
+            IntSize viewport = new((int)Math.Ceiling(Bounds.Width), (int)Math.Ceiling(Bounds.Height));
             foreach (LevelObject obj in objects)
             {
                 if (ShowMovementPaths)
                 {
-                    LevelSceneRenderer.DrawMovementPath(context, v, obj, _palette.OrbitPath, _palette.OrbitPathArrow);
+                    LevelSceneRenderer.DrawMovementPath(context, v, obj, _palette.OrbitPath, _palette.OrbitPathArrow, viewport);
                 }
                 if (!IsAnimationPreviewing(obj))
                 {

--- a/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelSceneRenderer.cs
@@ -1762,11 +1762,23 @@ namespace CtrDxEditor.Rendering
         }
 
         /// <summary>Draws the movement path used by active DX mover data.</summary>
-        public static void DrawMovementPath(DrawingContext ctx, ViewTransform v, LevelObject obj, Pen pathPen, Pen arrowPen)
+        /// <param name="ctx">The drawing context to render into.</param>
+        /// <param name="v">The view transform mapping level coordinates to screen pixels.</param>
+        /// <param name="obj">The mover whose path is drawn.</param>
+        /// <param name="pathPen">The pen for the path line.</param>
+        /// <param name="arrowPen">The pen for the direction chevrons.</param>
+        /// <param name="viewport">The canvas size in pixels, used to clip path segments to what is visible.</param>
+        public static void DrawMovementPath(
+            DrawingContext ctx,
+            ViewTransform v,
+            LevelObject obj,
+            Pen pathPen,
+            Pen arrowPen,
+            IntSize viewport)
         {
             if (AntPath.IsAnts(obj.Type))
             {
-                DrawAntMovementPath(ctx, v, obj, pathPen, arrowPen);
+                DrawAntMovementPath(ctx, v, obj, pathPen, arrowPen, viewport);
                 return;
             }
 
@@ -1784,7 +1796,7 @@ namespace CtrDxEditor.Rendering
 
             for (int i = 0; i < points.Length; i++)
             {
-                ctx.DrawLine(pathPen, points[i], points[(i + 1) % points.Length]);
+                DrawClippedPathLine(ctx, pathPen, points[i], points[(i + 1) % points.Length], viewport);
             }
 
             // A loop reads one way all the way round, so arrow every segment. A back-and-forth (retrace) path is
@@ -1805,6 +1817,25 @@ namespace CtrDxEditor.Rendering
                     DrawSegmentArrow(ctx, arrowPen, points[i], points[(i + 1) % points.Length]);
                 }
             }
+        }
+
+        /// <summary>
+        /// Draws one path segment, trimmed to the visible canvas. Movement paths use sentinel offsets that run
+        /// far off the map, and the dotted path pen tessellates a segment's whole screen length into dashes
+        /// before rasterization can discard the off-screen ones — so a level full of long paths pays for
+        /// hundreds of thousands of invisible dashes on every frame. Clipping first keeps that cost
+        /// proportional to what is actually on screen.
+        /// </summary>
+        private static void DrawClippedPathLine(DrawingContext ctx, Pen pathPen, Point a, Point b, IntSize viewport)
+        {
+            Vec2 start = new(a.X, a.Y);
+            Vec2 end = new(b.X, b.Y);
+            if (!SegmentClip.ToViewport(ref start, ref end, viewport))
+            {
+                return;
+            }
+
+            ctx.DrawLine(pathPen, new Point(start.X, start.Y), new Point(end.X, end.Y));
         }
 
         /// <summary>Draws a small chevron at the midpoint of <paramref name="a"/>→<paramref name="b"/> pointing toward b.</summary>
@@ -1874,7 +1905,8 @@ namespace CtrDxEditor.Rendering
             ViewTransform view,
             LevelObject ants,
             Pen pathPen,
-            Pen arrowPen)
+            Pen arrowPen,
+            IntSize viewport)
         {
             if (EditablePath.For(ants) is not { } path || path.Points is not { Length: >= 2 } points)
             {
@@ -1887,7 +1919,7 @@ namespace CtrDxEditor.Rendering
                 Vec2 b = view.LevelToScreen(points[(i + 1) % points.Length]);
                 Point start = new(a.X, a.Y);
                 Point end = new(b.X, b.Y);
-                ctx.DrawLine(pathPen, start, end);
+                DrawClippedPathLine(ctx, pathPen, start, end, viewport);
                 DrawSegmentArrow(ctx, arrowPen, start, end);
             }
         }


### PR DESCRIPTION
## Description

Levels built around long movement paths made the editor lag badly, especially with View → Show movement paths enabled.

Movement paths use sentinel offsets (`±9999`) to mean "travel off the map", so one authored segment can span hundreds of thousands of screen pixels once zoom is applied. The path pen is dotted, and Skia's dash effect tessellates a segment's *whole* screen length into on/off pieces before rasterization gets a chance to reject the off-screen ones — so the per-frame cost scaled with total path length rather than with the visible part.

A real level in this shape has 56 movers and only 137 segments, but ~1.30M level units of path. That cost 9–18 ms per frame on dashes that were almost entirely invisible. Since the canvas repaints on every `InvalidateVisual`, that alone capped the editor near 55 fps while dragging — and it got *worse* the further you zoomed in.

### Changes

New `SegmentClip.ToViewport` (Cohen–Sutherland) trims each segment to the padded canvas rect before it reaches the renderer, making cost proportional to what's actually on screen.

Measured on that level at 1400×900:

| zoom | before | after |
| ---- | ------ | ----- |
| 0.5  | 9.2 ms | 5.5 ms |
| 1    | 13.4 ms | 6.4 ms |
| 2    | 18.5 ms | 5.5 ms |

The ratio matters less than the shape: cost is now flat across zoom instead of climbing.

Arrow chevrons still use the original segment midpoints, so path direction reads exactly as before.

### Benchmark

```sh
cd src/CtrDxEditor.Benchmarks
dotnet run -c Release -- --filter '*'   # full run
dotnet run -c Release -- --describe     # fixture sizes only
```

| Shape | Objects | Total path | Isolates |
| ----- | ------: | ---------: | -------- |
| `OffMapMovers` | 56 | ~1,296,900 units | path length |
| `LocalMovers` | 56 | ~26,900 units | mover count, without the length |
| `DenseStatic` | 56 | 0 | object count, no paths — the floor |