### PR TITLE
fix: let the playtest locate dialog receive its drop again

### DIFF
--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -66,6 +66,7 @@
     "Dialog.FileType.Executable": "Application",
     "Notification.Playtest.Launching": "Launching Cut the Rope: DX…",
     "Notification.Playtest.Failed": "Could not play this level",
+    "Notification.Playtest.LocationSet": "The location of Cut the Rope: DX has been set",
 
     "Dialog.Common.Cancel": "Cancel",
     "Dialog.Common.Ok": "OK",

--- a/src/CtrDxEditor.Shared/Localization/en.json
+++ b/src/CtrDxEditor.Shared/Localization/en.json
@@ -61,6 +61,7 @@
     "Dialog.Playtest.Locate.ManualLabel": "Or type the full path to CutTheRope-DX.app:",
     "Dialog.Playtest.Locate.ManualSet": "Set",
     "Dialog.Playtest.Locate.ManualEmpty": "Enter the path to CutTheRope-DX.app.",
+    "Dialog.Playtest.Locate.DropNotBundle": "That is not an application. Drag CutTheRope-DX.app itself, or the folder it sits in.\n\nTo use a development build instead, type its full path above.",
     "Dialog.Playtest.Picker.Title": "Select the Cut the Rope: DX executable",
     "Dialog.FileType.Executable": "Application",
     "Notification.Playtest.Launching": "Launching Cut the Rope: DX…",

--- a/src/CtrDxEditor.Shared/Playtest/DxExecutableResolver.cs
+++ b/src/CtrDxEditor.Shared/Playtest/DxExecutableResolver.cs
@@ -29,15 +29,7 @@ namespace CtrDxEditor.Playtest
                 return false;
             }
 
-            // A directory dragged from Finder arrives with a trailing separator, which would defeat
-            // the .app suffix test below and send a bundle down the plain-folder path. Trimmed here,
-            // once, so every check afterwards sees the same shape of path. A path that is nothing but
-            // separators is left alone rather than trimmed away to nothing.
-            string trimmed = pickedPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            if (trimmed.Length > 0)
-            {
-                pickedPath = trimmed;
-            }
+            pickedPath = TrimTrailingSeparators(pickedPath);
 
             if (!pickedPath.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
             {
@@ -101,6 +93,51 @@ namespace CtrDxEditor.Playtest
                 ? $"The selected app bundle contains no executable:\n{pickedPath}"
                 : $"Could not determine which executable to run in:\n{pickedPath}";
             return false;
+        }
+
+        /// <summary>Whether a path is a macOS app bundle, or a folder holding at least one.</summary>
+        /// <remarks>
+        /// Only the macOS drop route uses this. Dropping is where a stray document is easiest to send in
+        /// by accident, and the drop hint there asks for a bundle by name, so the drop is held to it.
+        /// Resolution itself stays permissive - a typed dev-build binary has no .app around it and must
+        /// keep working - which is why this is a separate check rather than a rule inside
+        /// <see cref="TryResolve"/>.
+        /// </remarks>
+        /// <param name="path">The dropped path.</param>
+        /// <returns>True when the path is or contains an app bundle.</returns>
+        public static bool IsBundleOrBundleContainer(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            path = TrimTrailingSeparators(path);
+            if (path.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            try
+            {
+                return Directory.Exists(path) && Directory.GetDirectories(path, "*.app").Length > 0;
+            }
+            // An unreadable folder cannot be shown to hold a bundle, and the drop is refused with the
+            // same wording as any other non-bundle rather than failing the dialog outright.
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        // A directory dragged from Finder arrives with a trailing separator, which would defeat the .app
+        // suffix tests and send a bundle down the plain-folder path. Trimmed once, up front, so every
+        // check afterwards sees the same shape of path. A path that is nothing but separators is left
+        // alone rather than trimmed away to nothing.
+        private static string TrimTrailingSeparators(string path)
+        {
+            string trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return trimmed.Length > 0 ? trimmed : path;
         }
 
         // Resolves through a bundle sitting directly inside a dropped folder. Only an unambiguous

--- a/src/CtrDxEditor.Shared/Views/MainView.DropCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.DropCommands.cs
@@ -6,6 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
 
+using AvaloniaDialogs.Views;
+
 using CtrDxEditor.ViewModels;
 
 namespace CtrDxEditor.Views
@@ -65,6 +67,12 @@ namespace CtrDxEditor.Views
             SetDropOverlayVisible(false);
         }
 
+        // While a dialog is up it owns the drop, not the editor beneath it: the playtest locate dialog
+        // takes a dropped game bundle. Its handlers sit on the same TopLevel as these ones and Avalonia
+        // runs same-element handlers in registration order, this view's first, skipping the rest once the
+        // event is handled. So these must stand down entirely rather than mark the event handled.
+        private bool DialogOwnsDrop => this.FindControl<ReactiveDialogHost>("DialogHost")?.IsOpen == true;
+
         private void SetDropOverlayVisible(bool visible)
         {
             if (this.FindControl<Control>("DropOverlay") is { } overlay)
@@ -75,6 +83,12 @@ namespace CtrDxEditor.Views
 
         private void Host_DragOver(object? sender, DragEventArgs e)
         {
+            if (DialogOwnsDrop)
+            {
+                SetDropOverlayVisible(false);
+                return;
+            }
+
             bool accepted = DroppedLevelFile(e) is not null;
             e.DragEffects = accepted ? DragDropEffects.Copy : DragDropEffects.None;
             e.Handled = true;
@@ -90,6 +104,11 @@ namespace CtrDxEditor.Views
         // taken here and the load is continued afterwards.
         private async void Host_Drop(object? sender, DragEventArgs e)
         {
+            if (DialogOwnsDrop)
+            {
+                return;
+            }
+
             e.Handled = true;
             SetDropOverlayVisible(false);
 

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -85,11 +85,18 @@ namespace CtrDxEditor.Views
             }
         }
 
+        // Confirms the pick with a toast showing the path, the way saving a screenshot does: closing the
+        // dialog is otherwise the command's only visible effect, and the path is what tells the user they
+        // picked the bundle they meant. The toast lives here rather than in PickDxExecutableAsync so the
+        // first-run pick inside Play stays silent - it already reports itself by launching the game.
         private async void SetDxLocation_Click(object? sender, RoutedEventArgs e)
         {
-            if (DataContext is EditorViewModel vm)
+            if (DataContext is EditorViewModel vm && await PickDxExecutableAsync(vm) is { } path)
             {
-                _ = await PickDxExecutableAsync(vm);
+                Notifications()?.Show(new Notification(
+                    Localizer.Get("Notification.Playtest.LocationSet"),
+                    path,
+                    NotificationType.Success));
             }
         }
 

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -11,7 +11,7 @@
         xmlns:dialogs="using:AvaloniaDialogs.Views"
         x:Class="CtrDxEditor.Views.MainView"
         x:DataType="vm:EditorViewModel">
-  <dialogs:ReactiveDialogHost CloseOnClickAway="False">
+  <dialogs:ReactiveDialogHost x:Name="DialogHost" CloseOnClickAway="False">
     <Grid>
       <DockPanel>
     <Menu DockPanel.Dock="Top">

--- a/src/CtrDxEditor.Shared/Views/PlaytestLocateDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/PlaytestLocateDialog.axaml
@@ -46,9 +46,11 @@
                 HorizontalContentAlignment="Center"
                 VerticalContentAlignment="Center" />
       </Grid>
-      <TextBlock Classes="error" TextWrapping="Wrap" Text="{Binding ManualError}"
-                 IsVisible="{Binding ManualError, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}" />
     </StackPanel>
+
+    <!-- Outside the macOS-only block: a refused drop reports here too, and dropping works everywhere. -->
+    <TextBlock Classes="error" TextWrapping="Wrap" Text="{Binding ErrorMessage}"
+               IsVisible="{Binding ErrorMessage, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}" />
 
     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
       <Button Content="{loc:Tr Dialog.Common.Cancel}" Click="Cancel_Click"

--- a/src/CtrDxEditor.Shared/Views/PlaytestLocateDialog.axaml.cs
+++ b/src/CtrDxEditor.Shared/Views/PlaytestLocateDialog.axaml.cs
@@ -26,11 +26,17 @@ namespace CtrDxEditor.Views
     /// </remarks>
     public partial class PlaytestLocateDialog : BaseDialog<string?>
     {
-        /// <summary>The <see cref="ManualError"/> property.</summary>
-        public static readonly StyledProperty<string> ManualErrorProperty =
-            AvaloniaProperty.Register<PlaytestLocateDialog, string>(nameof(ManualError), "");
+        /// <summary>The <see cref="ErrorMessage"/> property.</summary>
+        public static readonly StyledProperty<string> ErrorMessageProperty =
+            AvaloniaProperty.Register<PlaytestLocateDialog, string>(nameof(ErrorMessage), "");
 
         private TopLevel? _dropHost;
+        private bool _hostAllowedDrop;
+
+        // DragOver fires continuously over the same item, and judging a folder means listing it. The last
+        // verdict is kept so that lands on one listing per dragged path rather than one per event.
+        private string? _lastJudgedPath;
+        private bool _lastJudgedAcceptable;
 
         /// <summary>Whether this platform uses the typed-path route instead of a file picker.</summary>
         public bool IsMacOS { get; } = OperatingSystem.IsMacOS();
@@ -43,11 +49,11 @@ namespace CtrDxEditor.Views
         public string DropHint { get; } = Localizer.Get(
             OperatingSystem.IsMacOS() ? "Dialog.Playtest.Locate.DropHintMac" : "Dialog.Playtest.Locate.DropHint");
 
-        /// <summary>Why the typed path was rejected, or empty when there is nothing to report.</summary>
-        public string ManualError
+        /// <summary>Why the typed or dropped path was rejected, or empty when there is nothing to report.</summary>
+        public string ErrorMessage
         {
-            get => GetValue(ManualErrorProperty);
-            set => SetValue(ManualErrorProperty, value);
+            get => GetValue(ErrorMessageProperty);
+            set => SetValue(ErrorMessageProperty, value);
         }
 
         /// <summary>Creates the locate dialog.</summary>
@@ -70,6 +76,7 @@ namespace CtrDxEditor.Views
             if (TopLevel.GetTopLevel(this) is { } top)
             {
                 _dropHost = top;
+                _hostAllowedDrop = DragDrop.GetAllowDrop(top);
                 DragDrop.SetAllowDrop(top, true);
                 top.AddHandler(DragDrop.DragOverEvent, Host_DragOver);
                 top.AddHandler(DragDrop.DropEvent, Host_Drop);
@@ -77,14 +84,18 @@ namespace CtrDxEditor.Views
         }
 
         /// <inheritdoc />
-        /// <remarks>Window-wide drop is only wanted while this dialog is up, so it is undone on close.</remarks>
+        /// <remarks>
+        /// Window-wide drop is only wanted while this dialog is up, so it is undone on close. The host's
+        /// own setting is restored rather than cleared: the editor underneath keeps a window-wide drop of
+        /// its own for level XML, and closing this dialog must not switch that off.
+        /// </remarks>
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             if (_dropHost is { } top)
             {
                 top.RemoveHandler(DragDrop.DragOverEvent, Host_DragOver);
                 top.RemoveHandler(DragDrop.DropEvent, Host_Drop);
-                DragDrop.SetAllowDrop(top, false);
+                DragDrop.SetAllowDrop(top, _hostAllowedDrop);
                 _dropHost = null;
             }
 
@@ -99,19 +110,57 @@ namespace CtrDxEditor.Views
             return items is { Length: 1 } ? items[0].TryGetLocalPath() : null;
         }
 
+        // macOS is held to a bundle because that is what the hint asks for and what every real install
+        // looks like there; a dropped plain file is far likelier to be a stray document than a dev build,
+        // and dev builds still go in by typing. Windows and Linux ship a plain executable, so the drop
+        // there is only asked to resolve.
+        private bool IsAcceptableDrop(string path, out string? error)
+        {
+            if (IsMacOS && !DxExecutableResolver.IsBundleOrBundleContainer(path))
+            {
+                error = Localizer.Get("Dialog.Playtest.Locate.DropNotBundle");
+                return false;
+            }
+
+            return DxExecutableResolver.TryResolve(path, out _, out error);
+        }
+
+        private bool IsAcceptableDrop(string path)
+        {
+            if (path != _lastJudgedPath)
+            {
+                _lastJudgedPath = path;
+                _lastJudgedAcceptable = IsAcceptableDrop(path, out _);
+            }
+
+            return _lastJudgedAcceptable;
+        }
+
         private void Host_DragOver(object? sender, DragEventArgs e)
         {
-            e.DragEffects = LocalPathOf(e) is null ? DragDropEffects.None : DragDropEffects.Link;
+            e.DragEffects = LocalPathOf(e) is { } path && IsAcceptableDrop(path)
+                ? DragDropEffects.Link
+                : DragDropEffects.None;
             e.Handled = true;
         }
 
+        // A refused drop reports why rather than doing nothing: the OS cursor says a release will not be
+        // taken, but not what was wrong with the item.
         private void Host_Drop(object? sender, DragEventArgs e)
         {
             e.Handled = true;
-            if (LocalPathOf(e) is { } path)
+            if (LocalPathOf(e) is not { } path)
+            {
+                return;
+            }
+
+            if (IsAcceptableDrop(path, out string? error))
             {
                 Close(path);
+                return;
             }
+
+            ErrorMessage = error ?? Localizer.Get("Dialog.Playtest.Locate.DropNotBundle");
         }
 
         private void ManualPath_KeyDown(object? sender, KeyEventArgs e)
@@ -136,7 +185,7 @@ namespace CtrDxEditor.Views
             string typed = this.FindControl<TextBox>("ManualPathBox")?.Text?.Trim() ?? "";
             if (typed.Length == 0)
             {
-                ManualError = Localizer.Get("Dialog.Playtest.Locate.ManualEmpty");
+                ErrorMessage = Localizer.Get("Dialog.Playtest.Locate.ManualEmpty");
                 return;
             }
 
@@ -146,7 +195,7 @@ namespace CtrDxEditor.Views
                 return;
             }
 
-            ManualError = error ?? Localizer.Get("Dialog.Playtest.Locate.ManualEmpty");
+            ErrorMessage = error ?? Localizer.Get("Dialog.Playtest.Locate.ManualEmpty");
         }
 
         private async void Browse_Click(object? sender, RoutedEventArgs e)

--- a/src/CtrDxEditor.Tests/DxExecutableResolverTests.cs
+++ b/src/CtrDxEditor.Tests/DxExecutableResolverTests.cs
@@ -222,5 +222,45 @@ namespace CtrDxEditor.Tests
             Assert.Equal("", resolved);
             Assert.False(string.IsNullOrWhiteSpace(error));
         }
+
+        /// <summary>A bundle counts, with or without the trailing separator Finder adds to a drop.</summary>
+        [Fact]
+        public void BundleCountsAsABundle()
+        {
+            string bundle = MakeBundle("CutTheRope-DX", null, "CutTheRope-DX");
+
+            Assert.True(DxExecutableResolver.IsBundleOrBundleContainer(bundle));
+            Assert.True(DxExecutableResolver.IsBundleOrBundleContainer(bundle + Path.DirectorySeparatorChar));
+        }
+
+        /// <summary>The folder a bundle sits in counts too, which is the other thing users drag over.</summary>
+        [Fact]
+        public void FolderHoldingABundleCountsAsABundleContainer()
+        {
+            _ = MakeBundle("CutTheRope-DX", null, "CutTheRope-DX");
+
+            Assert.True(DxExecutableResolver.IsBundleOrBundleContainer(_root));
+        }
+
+        /// <summary>
+        /// The macOS drop is held to a bundle, so a stray document cannot be stored as the game path.
+        /// A dev-build binary is refused here on purpose: it goes in through the typed path instead.
+        /// </summary>
+        [Fact]
+        public void PlainFilesAndBundlelessFoldersAreNotBundles()
+        {
+            string level = Path.Combine(_root, "level.xml");
+            File.WriteAllText(level, "<level />");
+            string empty = Path.Combine(_root, "empty");
+            _ = Directory.CreateDirectory(empty);
+            string devBuild = Path.Combine(_root, "CutTheRopeDX");
+            File.WriteAllText(devBuild, "#!/bin/sh\n");
+
+            Assert.False(DxExecutableResolver.IsBundleOrBundleContainer(level));
+            Assert.False(DxExecutableResolver.IsBundleOrBundleContainer(empty));
+            Assert.False(DxExecutableResolver.IsBundleOrBundleContainer(devBuild));
+            Assert.False(DxExecutableResolver.IsBundleOrBundleContainer(Path.Combine(_root, "nope")));
+            Assert.False(DxExecutableResolver.IsBundleOrBundleContainer("  "));
+        }
     }
 }

--- a/src/CtrDxEditor.Tests/MainViewLevelDropTests.cs
+++ b/src/CtrDxEditor.Tests/MainViewLevelDropTests.cs
@@ -71,6 +71,45 @@ namespace CtrDxEditor.Tests
             Assert.Contains("IsHitTestVisible=\"False\"", view[overlay..], StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// A dialog's own drop must reach it. Both sets of handlers live on the same TopLevel and this
+        /// view's run first, so handling the event unconditionally would stop the playtest locate dialog
+        /// from ever seeing a dropped game bundle.
+        /// </summary>
+        [Fact]
+        public void LevelDropStandsDownWhileADialogIsOpen()
+        {
+            string drop = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.DropCommands.cs"));
+            string view = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+
+            Assert.Contains("x:Name=\"DialogHost\"", view, StringComparison.Ordinal);
+            Assert.Contains("FindControl<ReactiveDialogHost>(\"DialogHost\")?.IsOpen", drop, StringComparison.Ordinal);
+
+            foreach (string handler in new[] { "Host_DragOver", "Host_Drop" })
+            {
+                int body = drop.IndexOf("void " + handler + "(", StringComparison.Ordinal);
+                Assert.True(body >= 0, handler + " should exist in MainView.DropCommands.cs.");
+
+                int guard = drop.IndexOf("if (DialogOwnsDrop)", body, StringComparison.Ordinal);
+                int handled = drop.IndexOf("e.Handled = true;", body, StringComparison.Ordinal);
+                Assert.True(guard >= 0 && guard < handled, handler + " should bail out before handling the event.");
+            }
+        }
+
+        /// <summary>
+        /// The locate dialog shares the window's drop with the editor, so its teardown restores what it
+        /// found instead of switching drop off for whatever else is still listening.
+        /// </summary>
+        [Fact]
+        public void LocateDialogRestoresTheHostsDropSetting()
+        {
+            string dialog = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "PlaytestLocateDialog.axaml.cs"));
+
+            Assert.Contains("GetAllowDrop(top)", dialog, StringComparison.Ordinal);
+            Assert.Contains("SetAllowDrop(top, _hostAllowedDrop)", dialog, StringComparison.Ordinal);
+            Assert.DoesNotContain("SetAllowDrop(top, false)", dialog, StringComparison.Ordinal);
+        }
+
         private static string SourcePath(params string[] parts)
         {
             string path = AppContext.BaseDirectory;

--- a/src/CtrDxEditor.Tests/PlaytestLocateDropTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestLocateDropTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>
+    /// The locate dialog's drop route. The rules it applies live in <see cref="CtrDxEditor.Playtest.DxExecutableResolver"/>
+    /// and are tested directly there; what is asserted here is that the dialog actually applies them,
+    /// which has to be read off the source because DragEventArgs cannot be constructed in a unit test.
+    /// </summary>
+    public class PlaytestLocateDropTests
+    {
+        /// <summary>
+        /// A dropped path clears the same bar as a typed one, and on macOS must additionally be a bundle.
+        /// Without this a dropped level XML would be accepted and stored as the game path, failing later
+        /// at launch rather than at the point the user got it wrong.
+        /// </summary>
+        [Fact]
+        public void DroppedPathIsValidatedBeforeItIsAccepted()
+        {
+            string dialog = SourceText("PlaytestLocateDialog.axaml.cs");
+
+            Assert.Contains("IsMacOS && !DxExecutableResolver.IsBundleOrBundleContainer(path)", dialog, StringComparison.Ordinal);
+            Assert.Contains("return DxExecutableResolver.TryResolve(path, out _, out error);", dialog, StringComparison.Ordinal);
+
+            int drop = dialog.IndexOf("void Host_Drop(", StringComparison.Ordinal);
+            Assert.True(drop >= 0, "Host_Drop should exist.");
+
+            int guard = dialog.IndexOf("if (IsAcceptableDrop(path, out string? error))", drop, StringComparison.Ordinal);
+            int close = dialog.IndexOf("Close(path);", drop, StringComparison.Ordinal);
+            Assert.True(guard >= 0 && guard < close, "Host_Drop should validate before closing with the path.");
+        }
+
+        /// <summary>A refused drop says why; the drag cursor alone does not explain the refusal.</summary>
+        [Fact]
+        public void RefusedDropReportsAnError()
+        {
+            string dialog = SourceText("PlaytestLocateDialog.axaml.cs");
+            string view = SourceText("PlaytestLocateDialog.axaml");
+
+            Assert.Contains("ErrorMessage = error ?? Localizer.Get(\"Dialog.Playtest.Locate.DropNotBundle\")", dialog, StringComparison.Ordinal);
+
+            // The error line has to sit outside the macOS-only block, or a drop refused on Windows or
+            // Linux would set a message that is never displayed.
+            int macOnly = view.IndexOf("IsVisible=\"{Binding IsMacOS}\"", StringComparison.Ordinal);
+            int endOfMacOnly = view.IndexOf("</StackPanel>", macOnly, StringComparison.Ordinal);
+            int error = view.IndexOf("Text=\"{Binding ErrorMessage}\"", StringComparison.Ordinal);
+
+            Assert.True(error > endOfMacOnly, "The error text should be outside the macOS-only panel.");
+        }
+
+        /// <summary>The refusal names what to drag instead, and points dev builds at the typed path.</summary>
+        [Fact]
+        public void NonBundleRefusalIsLocalized()
+        {
+            string path = SourcePath("CtrDxEditor.Shared", "Localization", "en.json");
+            Dictionary<string, string> strings = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                File.ReadAllText(path))!;
+
+            string message = strings["Dialog.Playtest.Locate.DropNotBundle"];
+            Assert.Contains("CutTheRope-DX.app", message, StringComparison.Ordinal);
+            Assert.Contains("development build", message, StringComparison.Ordinal);
+        }
+
+        private static string SourceText(string fileName)
+        {
+            return File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", fileName));
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string path = AppContext.BaseDirectory;
+            while (Path.GetFileName(path) != "src")
+            {
+                path = Directory.GetParent(path)?.FullName
+                       ?? throw new InvalidOperationException("Could not locate src directory.");
+            }
+
+            return Path.Combine(path, Path.Combine(parts));
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/PlaytestLocationToastTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestLocationToastTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>
+    /// The toast confirming a newly set Cut the Rope: DX location. Asserted against the source because
+    /// the command is a click handler with no headless harness to raise it in.
+    /// </summary>
+    public class PlaytestLocationToastTests
+    {
+        /// <summary>
+        /// Only the explicit command confirms. The first-run pick happens inside Play, which already
+        /// reports itself by launching, so hoisting this toast into the shared helper would stack two
+        /// toasts on one action.
+        /// </summary>
+        [Fact]
+        public void OnlyTheExplicitCommandToasts()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+
+            int command = source.IndexOf("void SetDxLocation_Click(", StringComparison.Ordinal);
+            Assert.True(command >= 0, "SetDxLocation_Click should exist.");
+
+            int toast = source.IndexOf("Notification.Playtest.LocationSet", StringComparison.Ordinal);
+            Assert.True(toast > command, "The location toast belongs in SetDxLocation_Click.");
+
+            int helper = source.IndexOf("Task<string?> PickDxExecutableAsync(", StringComparison.Ordinal);
+            Assert.True(helper > toast, "The toast should sit outside the helper Play also calls.");
+        }
+
+        /// <summary>A cancelled pick returns null and must not be announced as a location change.</summary>
+        [Fact]
+        public void CancelledPickDoesNotToast()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+
+            Assert.Contains(
+                "await PickDxExecutableAsync(vm) is { } path",
+                source,
+                StringComparison.Ordinal);
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string path = AppContext.BaseDirectory;
+            while (Path.GetFileName(path) != "src")
+            {
+                path = Directory.GetParent(path)?.FullName
+                       ?? throw new InvalidOperationException("Could not locate src directory.");
+            }
+
+            return Path.Combine(path, Path.Combine(parts));
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Fix a regression in #70 where `.app` can no longer be dropped on when the dialog shows.
- Add notification toast for setting Cut the Rope: DX location