### PR TITLE
perf: parse level XML once and off the UI thread when opening

### DIFF
--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -281,7 +281,16 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Loads a level from its XML text into the editor.</summary>
         public void LoadLevelXml(string xml)
         {
-            LevelDocument loaded = LevelDocument.Parse(xml);
+            LoadLevel(LevelDocument.Parse(xml));
+        }
+
+        /// <summary>
+        /// Loads an already-parsed level into the editor. Callers that had to parse the document
+        /// ahead of time (the Open path validates before loading) pass it here rather than handing
+        /// back XML for a second parse. Must run on the UI thread: it refreshes bound collections.
+        /// </summary>
+        public void LoadLevel(LevelDocument loaded)
+        {
             StopAnimationPreview();
             ResetDocumentSessionState();
             Document = loaded;

--- a/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
@@ -175,15 +175,27 @@ namespace CtrDxEditor.Views
         // this working in the browser build, where IStorageFile exposes no filesystem path.
         private async Task OpenLevelFileAsync(EditorViewModel vm, IStorageFile file)
         {
-            string xml;
+            LevelDocument document;
             IReadOnlyList<LevelWarning> warnings;
             try
             {
-                await using Stream stream = await file.OpenReadAsync();
-                using StreamReader reader = new(stream);
-                xml = await reader.ReadToEndAsync();
+                // The read stays here: it is async I/O that never blocks the thread, and on the
+                // browser build the storage stream is JS interop that has to run on this thread.
+                string xml;
+                await using (Stream stream = await file.OpenReadAsync())
+                {
+                    using StreamReader reader = new(stream);
+                    xml = await reader.ReadToEndAsync();
+                }
 
-                warnings = LevelValidator.Validate(LevelDocument.Parse(xml));
+                // Parse and validation are pure CPU over the text and are the part that actually
+                // stalls the UI on a large level, so they go off-thread on desktop. The browser is
+                // single-threaded (no WasmEnableThreads), where this simply runs inline.
+                (document, warnings) = await Task.Run(() =>
+                {
+                    LevelDocument parsed = LevelDocument.Parse(xml);
+                    return (parsed, LevelValidator.Validate(parsed));
+                });
             }
             catch (Exception ex)
             {
@@ -206,7 +218,7 @@ namespace CtrDxEditor.Views
             {
                 return;
             }
-            vm.LoadLevelXml(xml);
+            vm.LoadLevel(document);
             _currentLevelFile = file;
         }
 


### PR DESCRIPTION
## Description

Improve the performance of XML reading by only parsing it once.

Previously, the XML open path parsed the document twice: once to validate, again inside LoadLevelXml, and did both on the UI thread.

This PR introduces a fix that split `LoadLevel(LevelDocument)` out of `LoadLevelXml` so the validated instance is reused, and move the parse and validation into a `Task.Run`.