### PR TITLE
chore: enable aot for browser for performance

### DIFF
--- a/src/CtrDxEditor.Browser/CtrDxEditor.Browser.csproj
+++ b/src/CtrDxEditor.Browser/CtrDxEditor.Browser.csproj
@@ -4,8 +4,7 @@
     <RootNamespace>CtrDxEditor.Browser</RootNamespace>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Browser uses the wasm SDK's own publish pipeline; never single-file/AOT-desktop. -->
-    <RunAOTCompilation>false</RunAOTCompilation>
+    <RunAOTCompilation>true</RunAOTCompilation>
     <WasmNativeStrip>true</WasmNativeStrip>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Use AOT for browser for improved performance, at the cost of larger initial loading size.