### PR TITLE
fix: enforce numeric input in the level settings dialog

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -125,6 +125,7 @@
     "Dialog.LevelSettings.Special.None": "None",
     "Dialog.LevelSettings.Special.Default": "Default",
     "Dialog.LevelSettings.EnterNumber": "Enter a number",
+    "Dialog.LevelSettings.OutOfRange": "Must be between {0} and {1}",
     "Dialog.LevelSettings.HalfCandy": "Half candy",
     "Dialog.LevelSettings.NightLevel": "Night level",
     "Dialog.LevelSettings.HalfCandyDescription": "Enable the usage of split candy mechanic, as demonstrated in Valentine's Box.",

--- a/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
@@ -102,10 +102,16 @@ namespace CtrDxEditor.ViewModels
         private static readonly CompositeFormat WaterDrainHintFormat =
             CompositeFormat.Parse(Localizer.Get("Dialog.LevelSettings.WaterDrainHint"));
 
+        private static readonly CompositeFormat RangeErrorFormat =
+            CompositeFormat.Parse(Localizer.Get("Dialog.LevelSettings.OutOfRange"));
+
         private const int MinWidth = 320;
         private const int MinHeight = 480;
         private const int MaxDimension = 9999;
         private const int MaxSpecial = 99;
+        private const int MinRopeSpeed = -100;
+        private const int MaxRopeSpeed = 100;
+        private const int MaxWater = 10000;
 
         /// <summary>Available resolutions; the last entry is the custom sentinel.</summary>
         public ObservableCollection<ResolutionPreset> Presets { get; } =
@@ -134,50 +140,122 @@ namespace CtrDxEditor.ViewModels
             new(Localizer.Get("Dialog.LevelSettings.Custom"), 0, IsCustom: true),
         ];
 
-        // NumericUpDown.Value is decimal?, so these bind as decimal? (an exact match avoids the
-        // raw "could not convert (null)" cast errors, and an empty box is a valid null that
-        // CanConfirm rejects so the level can't be created with a blank number).
+        // The numeric fields are stored as the raw text the box holds, because NumericTextBox filters
+        // input character by character and so has to bind a string. Each one exposes a decimal? view
+        // over that text: null means "empty or not a number", which CanConfirm rejects. The bounds
+        // below are only enforced by CanConfirm, not by the box - the box has to accept an out-of-range
+        // prefix ("6" on the way to "640") for a value above its minimum to be typeable at all.
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CustomWidth))]
+        [NotifyPropertyChangedFor(nameof(CustomWidthError))]
+        [NotifyPropertyChangedFor(nameof(HasCustomWidthError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
-        public partial decimal? CustomWidth { get; set; } = MinWidth;
+        public partial string CustomWidthText { get; set; } = Format(MinWidth);
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CustomHeight))]
+        [NotifyPropertyChangedFor(nameof(CustomHeightError))]
+        [NotifyPropertyChangedFor(nameof(HasCustomHeightError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
-        public partial decimal? CustomHeight { get; set; } = MinHeight;
+        public partial string CustomHeightText { get; set; } = Format(MinHeight);
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(RopePhysicsSpeed))]
+        [NotifyPropertyChangedFor(nameof(RopePhysicsSpeedError))]
+        [NotifyPropertyChangedFor(nameof(HasRopePhysicsSpeedError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
-        public partial decimal? RopePhysicsSpeed { get; set; } = 1.0m;
+        public partial string RopePhysicsSpeedText { get; set; } = Format(1.0m);
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(IsSpecialCustom))]
+        [NotifyPropertyChangedFor(nameof(HasCustomSpecialError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
         public partial SpecialOption SelectedSpecial { get; set; }
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(CustomSpecial))]
+        [NotifyPropertyChangedFor(nameof(CustomSpecialError))]
+        [NotifyPropertyChangedFor(nameof(HasCustomSpecialError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
-        public partial decimal? CustomSpecial { get; set; } = 0m;
+        public partial string CustomSpecialText { get; set; } = Format(0m);
+
         [ObservableProperty] public partial bool TwoParts { get; set; }
         [ObservableProperty] public partial bool NightLevel { get; set; }
         [ObservableProperty] public partial bool UseMobilePhysics { get; set; }
 
-        // Nullable so clearing the box or typing a non-number reads back as null rather than failing to
-        // convert (which surfaces a raw exception instead of the field's own "enter a number" message).
-        // CanConfirm rejects null, as it does for the other numeric fields.
-
         /// <summary>Height of the water pool in level units; 0 means the level has no water.</summary>
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Water))]
+        [NotifyPropertyChangedFor(nameof(WaterError))]
+        [NotifyPropertyChangedFor(nameof(HasWaterError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
         [NotifyPropertyChangedFor(nameof(WaterDrainHint))]
         [NotifyPropertyChangedFor(nameof(HasWaterDrainHint))]
-        public partial decimal? Water { get; set; } = 0m;
+        public partial string WaterText { get; set; } = Format(0m);
 
         /// <summary>Rate at which the water drains, in level units per second; 0 is a static pool.</summary>
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(WaterSpeed))]
+        [NotifyPropertyChangedFor(nameof(WaterSpeedError))]
+        [NotifyPropertyChangedFor(nameof(HasWaterSpeedError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
         [NotifyPropertyChangedFor(nameof(WaterDrainHint))]
         [NotifyPropertyChangedFor(nameof(HasWaterDrainHint))]
-        public partial decimal? WaterSpeed { get; set; } = 0m;
+        public partial string WaterSpeedText { get; set; } = Format(0m);
+
+        /// <summary>Custom level width, or null when the box is empty or holds something unparseable.</summary>
+        public decimal? CustomWidth { get => Parse(CustomWidthText); set => CustomWidthText = Format(value); }
+
+        /// <summary>Custom level height, or null when the box is empty or holds something unparseable.</summary>
+        public decimal? CustomHeight { get => Parse(CustomHeightText); set => CustomHeightText = Format(value); }
+
+        /// <summary>Rope simulation speed multiplier, or null when the box holds no usable number.</summary>
+        public decimal? RopePhysicsSpeed { get => Parse(RopePhysicsSpeedText); set => RopePhysicsSpeedText = Format(value); }
+
+        /// <summary>Manually entered special value, or null when the box holds no usable number.</summary>
+        public decimal? CustomSpecial { get => Parse(CustomSpecialText); set => CustomSpecialText = Format(value); }
+
+        /// <summary>Water height, or null when the box holds no usable number.</summary>
+        public decimal? Water { get => Parse(WaterText); set => WaterText = Format(value); }
+
+        /// <summary>Water drain speed, or null when the box holds no usable number.</summary>
+        public decimal? WaterSpeed { get => Parse(WaterSpeedText); set => WaterSpeedText = Format(value); }
+
+        /// <summary>Why the width box is unusable, or empty text when it holds a valid width.</summary>
+        public string CustomWidthError => Validate(CustomWidthText, MinWidth, MaxDimension);
+
+        /// <summary>Why the height box is unusable, or empty text when it holds a valid height.</summary>
+        public string CustomHeightError => Validate(CustomHeightText, MinHeight, MaxDimension);
+
+        /// <summary>Why the rope speed box is unusable, or empty text when it holds a valid speed.</summary>
+        public string RopePhysicsSpeedError => Validate(RopePhysicsSpeedText, MinRopeSpeed, MaxRopeSpeed);
+
+        /// <summary>Why the special box is unusable, or empty text when it holds a valid special value.</summary>
+        public string CustomSpecialError => Validate(CustomSpecialText, 0, MaxSpecial);
+
+        /// <summary>Why the water box is unusable, or empty text when it holds a valid height.</summary>
+        public string WaterError => Validate(WaterText, 0, MaxWater);
+
+        /// <summary>Why the water speed box is unusable, or empty text when it holds a valid speed.</summary>
+        public string WaterSpeedError => Validate(WaterSpeedText, 0, MaxWater);
+
+        /// <summary>Whether the width box has something to complain about (bound to its message's visibility).</summary>
+        public bool HasCustomWidthError => CustomWidthError.Length > 0;
+
+        /// <summary>Whether the height box has something to complain about.</summary>
+        public bool HasCustomHeightError => CustomHeightError.Length > 0;
+
+        /// <summary>Whether the rope speed box has something to complain about.</summary>
+        public bool HasRopePhysicsSpeedError => RopePhysicsSpeedError.Length > 0;
+
+        /// <summary>Whether the special box has something to complain about. Hidden while the box itself is.</summary>
+        public bool HasCustomSpecialError => IsSpecialCustom && CustomSpecialError.Length > 0;
+
+        /// <summary>Whether the water box has something to complain about.</summary>
+        public bool HasWaterError => WaterError.Length > 0;
+
+        /// <summary>Whether the water speed box has something to complain about.</summary>
+        public bool HasWaterSpeedError => WaterSpeedError.Length > 0;
 
         /// <summary>
         /// How long the pool takes to empty, or empty text when there is no water or no drain. Derived so
@@ -238,13 +316,46 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Whether the manual width/height inputs are active.</summary>
         public bool IsCustom => SelectedPreset.IsCustom;
 
-        /// <summary>Whether every currently-required numeric field has a value (gates the confirm button).</summary>
+        /// <summary>
+        /// Whether every currently-required numeric field holds a number within its bounds (gates the
+        /// confirm button). The hidden custom inputs are exempt, since a preset supplies their values.
+        /// </summary>
         public bool CanConfirm =>
-            RopePhysicsSpeed is not null
-            && Water is not null
-            && WaterSpeed is not null
-            && (!IsCustom || (CustomWidth is not null && CustomHeight is not null))
-            && (!IsSpecialCustom || CustomSpecial is not null);
+            RopePhysicsSpeedError.Length == 0
+            && WaterError.Length == 0
+            && WaterSpeedError.Length == 0
+            && (!IsCustom || (CustomWidthError.Length == 0 && CustomHeightError.Length == 0))
+            && (!IsSpecialCustom || CustomSpecialError.Length == 0);
+
+        /// <summary>
+        /// Reads a box's text as a number. Invariant culture because <c>NumericTextBox</c> only ever lets
+        /// "." through as the decimal separator, whatever the current locale would otherwise use.
+        /// </summary>
+        private static decimal? Parse(string? text)
+        {
+            return decimal.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal value)
+                ? value
+                : null;
+        }
+
+        /// <summary>Renders a value back into box text; null (no value) becomes an empty box.</summary>
+        private static string Format(decimal? value)
+        {
+            return value?.ToString("0.####", CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// The message to show under a box: empty text when it holds a number within
+        /// [<paramref name="min"/>, <paramref name="max"/>], and otherwise a prompt to fix it.
+        /// </summary>
+        private static string Validate(string? text, int min, int max)
+        {
+            return Parse(text) is not { } value
+                ? Localizer.Get("Dialog.LevelSettings.EnterNumber")
+                : value < min || value > max
+                    ? string.Format(CultureInfo.CurrentCulture, RangeErrorFormat, min, max)
+                    : string.Empty;
+        }
 
         private LevelSettingsViewModel(bool isNewMode)
         {

--- a/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
@@ -96,13 +96,13 @@
                 RowDefinitions="Auto,Auto"
                 Margin="0,4,0,0"
                 IsVisible="{Binding IsCustom}">
-            <NumericUpDown Grid.Row="0"
-                           Grid.Column="0"
-                           Minimum="320"
-                           Maximum="9999"
-                           Increment="1"
-                           FormatString="0"
-                           Value="{Binding CustomWidth, Mode=TwoWay}" />
+            <!-- Minimum is 0 rather than the real 320 so a longer number can be typed a digit at a
+                 time; the actual bound is enforced by CanConfirm and reported below the box. -->
+            <ctrl:NumericTextBox Grid.Row="0"
+                                 Grid.Column="0"
+                                 Minimum="0"
+                                 Maximum="9999"
+                                 Text="{Binding CustomWidthText, Mode=TwoWay}" />
 
             <TextBlock Grid.Row="0"
                        Grid.Column="1"
@@ -110,29 +110,29 @@
                        VerticalAlignment="Center"
                        Margin="8,0" />
 
-            <NumericUpDown Grid.Row="0"
-                           Grid.Column="2"
-                           Minimum="480"
-                           Maximum="9999"
-                           Increment="1"
-                           FormatString="0"
-                           Value="{Binding CustomHeight, Mode=TwoWay}" />
+            <ctrl:NumericTextBox Grid.Row="0"
+                                 Grid.Column="2"
+                                 Minimum="0"
+                                 Maximum="9999"
+                                 Text="{Binding CustomHeightText, Mode=TwoWay}" />
 
             <TextBlock Grid.Row="1"
                        Grid.Column="0"
-                       Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+                       Text="{Binding CustomWidthError}"
+                       TextWrapping="Wrap"
                        Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
                        Margin="0,2,0,0"
-                       IsVisible="{Binding CustomWidth, Converter={x:Static ObjectConverters.IsNull}}" />
+                       IsVisible="{Binding HasCustomWidthError}" />
 
             <TextBlock Grid.Row="1"
                        Grid.Column="2"
-                       Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+                       Text="{Binding CustomHeightError}"
+                       TextWrapping="Wrap"
                        Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
                        Margin="0,2,0,0"
-                       IsVisible="{Binding CustomHeight, Converter={x:Static ObjectConverters.IsNull}}" />
+                       IsVisible="{Binding HasCustomHeightError}" />
           </Grid>
         </StackPanel>
 
@@ -140,16 +140,16 @@
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.RopePhysicsSpeed}" />
 
           <!-- Negatives are permitted (DX parses them without clamping), though only positive speeds are meaningful. -->
-          <NumericUpDown Minimum="-100"
-                         Maximum="100"
-                         Increment="0.1"
-                         FormatString="0.0#"
-                         Value="{Binding RopePhysicsSpeed, Mode=TwoWay}" />
+          <ctrl:NumericTextBox Minimum="-100"
+                               Maximum="100"
+                               AcceptDecimal="True"
+                               Text="{Binding RopePhysicsSpeedText, Mode=TwoWay}" />
 
-          <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+          <TextBlock Text="{Binding RopePhysicsSpeedError}"
+                     TextWrapping="Wrap"
                      Foreground="{DynamicResource EditorBrush.DangerText}"
                      FontSize="12"
-                     IsVisible="{Binding RopePhysicsSpeed, Converter={x:Static ObjectConverters.IsNull}}" />
+                     IsVisible="{Binding HasRopePhysicsSpeedError}" />
         </StackPanel>
 
         <StackPanel Spacing="4">
@@ -170,16 +170,15 @@
           <!-- The manual value input only appears when the "Custom…" option is selected. -->
           <StackPanel Spacing="2"
                       IsVisible="{Binding IsSpecialCustom}">
-            <NumericUpDown Minimum="0"
-                           Maximum="99"
-                           Increment="1"
-                           FormatString="0"
-                           Value="{Binding CustomSpecial, Mode=TwoWay}" />
+            <ctrl:NumericTextBox Minimum="0"
+                                 Maximum="99"
+                                 Text="{Binding CustomSpecialText, Mode=TwoWay}" />
 
-            <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+            <TextBlock Text="{Binding CustomSpecialError}"
+                       TextWrapping="Wrap"
                        Foreground="{DynamicResource EditorBrush.DangerText}"
                        FontSize="12"
-                       IsVisible="{Binding CustomSpecial, Converter={x:Static ObjectConverters.IsNull}}" />
+                       IsVisible="{Binding HasCustomSpecialError}" />
           </StackPanel>
         </StackPanel>
 
@@ -220,32 +219,32 @@
 
         <StackPanel Spacing="4">
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.Water}" />
-          <NumericUpDown Minimum="0"
-                         Maximum="10000"
-                         Increment="1"
-                         FormatString="0.##"
-                         Value="{Binding Water, Mode=TwoWay}" />
+          <ctrl:NumericTextBox Minimum="0"
+                               Maximum="10000"
+                               AcceptDecimal="True"
+                               Text="{Binding WaterText, Mode=TwoWay}" />
 
-          <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+          <TextBlock Text="{Binding WaterError}"
+                     TextWrapping="Wrap"
                      Foreground="{DynamicResource EditorBrush.DangerText}"
                      FontSize="12"
-                     IsVisible="{Binding Water, Converter={x:Static ObjectConverters.IsNull}}" />
+                     IsVisible="{Binding HasWaterError}" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.WaterDescription}"
                      TextWrapping="Wrap"
                      Opacity="0.7" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.WaterSpeed}" />
-          <NumericUpDown Minimum="0"
-                         Maximum="10000"
-                         Increment="1"
-                         FormatString="0.##"
-                         Value="{Binding WaterSpeed, Mode=TwoWay}" />
+          <ctrl:NumericTextBox Minimum="0"
+                               Maximum="10000"
+                               AcceptDecimal="True"
+                               Text="{Binding WaterSpeedText, Mode=TwoWay}" />
 
-          <TextBlock Text="{loc:Tr Dialog.LevelSettings.EnterNumber}"
+          <TextBlock Text="{Binding WaterSpeedError}"
+                     TextWrapping="Wrap"
                      Foreground="{DynamicResource EditorBrush.DangerText}"
                      FontSize="12"
-                     IsVisible="{Binding WaterSpeed, Converter={x:Static ObjectConverters.IsNull}}" />
+                     IsVisible="{Binding HasWaterSpeedError}" />
 
           <TextBlock Text="{loc:Tr Dialog.LevelSettings.WaterSpeedDescription}"
                      TextWrapping="Wrap"

--- a/src/CtrDxEditor.Tests/LevelSettingsViewModelTests.cs
+++ b/src/CtrDxEditor.Tests/LevelSettingsViewModelTests.cs
@@ -130,6 +130,53 @@ namespace CtrDxEditor.Tests
             Assert.True(vm.CanConfirm);
         }
 
+        /// <summary>
+        /// Confirm is blocked while a box holds a number outside its bounds. The box itself has to accept
+        /// out-of-range text (its minimum is relaxed so longer numbers can be typed a digit at a time), so
+        /// this is the only thing standing between a stray value and a level built from it.
+        /// </summary>
+        [Fact]
+        public void CanConfirmRejectsOutOfRangeValues()
+        {
+            LevelSettingsViewModel vm = LevelSettingsViewModel.ForNew();
+            vm.SelectedPreset = vm.Presets.Single(p => p.IsCustom);
+
+            vm.CustomWidthText = "100"; // below the 320 minimum
+            Assert.False(vm.CanConfirm);
+            Assert.True(vm.HasCustomWidthError);
+
+            vm.CustomWidthText = "640";
+            Assert.True(vm.CanConfirm);
+            Assert.False(vm.HasCustomWidthError);
+        }
+
+        /// <summary>Non-numeric text reads back as no value at all, and says so rather than blowing up.</summary>
+        [Fact]
+        public void UnparseableTextReadsAsNull()
+        {
+            LevelSettingsViewModel vm = LevelSettingsViewModel.ForNew();
+            vm.RopePhysicsSpeedText = "abc";
+
+            Assert.Null(vm.RopePhysicsSpeed);
+            Assert.False(vm.CanConfirm);
+            Assert.True(vm.HasRopePhysicsSpeedError);
+        }
+
+        /// <summary>Decimal rope speeds survive the text round-trip, in invariant form.</summary>
+        [Fact]
+        public void RopePhysicsSpeedKeepsDecimals()
+        {
+            LevelSettingsViewModel vm = LevelSettingsViewModel.ForNew();
+            vm.RopePhysicsSpeedText = "1.5";
+
+            Assert.Equal(1.5m, vm.RopePhysicsSpeed);
+            Assert.True(vm.CanConfirm);
+            Assert.Equal(1.5f, vm.ToSettings().RopePhysicsSpeed);
+
+            vm.RopePhysicsSpeed = 2.25m;
+            Assert.Equal("2.25", vm.RopePhysicsSpeedText);
+        }
+
         /// <summary>A hidden custom field being null does not block confirm (only visible required fields count).</summary>
         [Fact]
         public void CanConfirmIgnoresHiddenCustomFields()


### PR DESCRIPTION
## Description

Enforce numeric input in the level settings dialog to avoid adding unexpected characters. Mimicking the fields in the Properties panel.