### PR TITLE
fix: use 20 as default value for rocket impulse

### DIFF
--- a/src/CtrDxEditor.Core.Tests/RocketDescriptorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/RocketDescriptorTests.cs
@@ -39,7 +39,7 @@ namespace CtrDxEditor.Core.Tests
 
             AttributeSpec impulse = rocket.Attributes.Single(a => a.Name == "impulse");
             Assert.Equal(AttrType.Number, impulse.Type);
-            Assert.Equal("0", impulse.Default);
+            Assert.Equal("20", impulse.Default);
 
             AttributeSpec impulseFactor = rocket.Attributes.Single(a => a.Name == "impulseFactor");
             Assert.Equal(AttrType.Number, impulseFactor.Type);

--- a/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
+++ b/src/CtrDxEditor.Core/Descriptors/DescriptorTable.cs
@@ -210,7 +210,7 @@ namespace CtrDxEditor.Core.Descriptors
             new ObjectDescriptor("rocket", "Rocket",
             [
                 new AttributeSpec("angle", AttrType.Number, "0"),
-                new AttributeSpec("impulse", AttrType.Number, "0"),
+                new AttributeSpec("impulse", AttrType.Number, "20"),
                 new AttributeSpec("impulseFactor", AttrType.Number, "0.6"),
                 new AttributeSpec("time", AttrType.Number, "-1"),
                 new AttributeSpec("isRotatable", AttrType.Bool, "false"),


### PR DESCRIPTION
## Description

Fix a case when the rocket's default impulse value is 0, causing it unable to fly in the game.