### PR TITLE
feat: warn when the playtest target is not a compatible Cut the Rope: DX

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -542,6 +542,7 @@
     "Notification.Playtest.Failed": "Could not play this level",
     "Notification.Playtest.LocationSet": "The location of Cut the Rope: DX has been set",
 
+    "Playtest.Unsupported.Header": "This may not be a compatible Cut the Rope: DX",
     "Playtest.Unsupported.Body": "This program did not identify itself as Cut the Rope: DX. It may be a different application, or a version too old to play test levels. Update the game, or pick the right program with File > Set DX Location.",
 
     "Playtest.Resolve.NothingSelected": "No Cut the Rope: DX executable has been selected.",

--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -542,6 +542,8 @@
     "Notification.Playtest.Failed": "Could not play this level",
     "Notification.Playtest.LocationSet": "The location of Cut the Rope: DX has been set",
 
+    "Playtest.Unsupported.Body": "This program did not identify itself as Cut the Rope: DX. It may be a different application, or a version too old to play test levels. Update the game, or pick the right program with File > Set DX Location.",
+
     "Playtest.Resolve.NothingSelected": "No Cut the Rope: DX executable has been selected.",
     "Playtest.Resolve.MissingFile": "The selected executable no longer exists:\n{0}",
     "Playtest.Resolve.NotExecutable": "This file is not marked executable:\n{0}\n\nMake it runnable with:\nchmod +x \"{0}\"",

--- a/src/CtrDxEditor.Desktop/CtrDxEditor.Desktop.csproj
+++ b/src/CtrDxEditor.Desktop/CtrDxEditor.Desktop.csproj
@@ -6,6 +6,8 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <DesktopPublish>true</DesktopPublish>
+    <!-- Required by the source-generated [LibraryImport] marshalling (SYSLIB1062). -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PublishAot>true</PublishAot>
     <TrimMode>full</TrimMode>
     <WindowsDistributionIcon>../../distribution/icons/CtrDxEditorIcon.ico</WindowsDistributionIcon>

--- a/src/CtrDxEditor.Desktop/Platform/NativeUserAttention.cs
+++ b/src/CtrDxEditor.Desktop/Platform/NativeUserAttention.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+
+using CtrDxEditor.Platform;
+
+namespace CtrDxEditor.Desktop.Platform
+{
+    /// <summary>
+    /// Alerts the user through the OS window manager: a flashing taskbar button on Windows
+    /// (<c>FlashWindowEx</c>) and a bouncing dock icon on macOS
+    /// (<c>-[NSApplication requestUserAttention:]</c>). Used when something the user must act on - the
+    /// incompatible-playtest dialog - appears while their focus is on the just-launched game window
+    /// instead of the editor.
+    /// </summary>
+    /// <remarks>
+    /// Linux is a deliberate no-op: raising the window-manager urgency hint reliably needs an X11/Wayland
+    /// dependency this app does not carry. Every path is best-effort and swallows a missing-library
+    /// failure - the alert is cosmetic and must never take the app down.
+    /// </remarks>
+    public sealed partial class NativeUserAttention : IUserAttention
+    {
+        /// <inheritdoc />
+        public void Demand()
+        {
+            try
+            {
+                switch (OperatingSystem.IsWindows(), OperatingSystem.IsMacOS())
+                {
+                    case (true, _):
+                        DemandWindows();
+                        break;
+                    case (_, true):
+                        DemandMacOS();
+                        break;
+                    default:
+                        // Other platforms: no dependency-free attention signal, so nothing to do.
+                        break;
+                }
+            }
+            catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException)
+            {
+                // The platform library or entry point is unavailable; the alert is simply skipped.
+            }
+        }
+
+        // Windows: flash the taskbar button until the editor is brought to the foreground.
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FlashInfo
+        {
+            public uint Size;
+            public IntPtr Handle;
+            public uint Flags;
+            public uint Count;
+            public uint Timeout;
+        }
+
+        private const uint FlashAll = 0x3;            // Flash both the caption and the taskbar button.
+        private const uint FlashTimerNoForeground = 0xC; // Keep flashing until the window is foregrounded.
+
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool FlashWindowEx(ref FlashInfo info);
+
+        private static void DemandWindows()
+        {
+            if (MainWindowHandle() is not { } hwnd || hwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            FlashInfo info = new()
+            {
+                Size = (uint)Marshal.SizeOf<FlashInfo>(),
+                Handle = hwnd,
+                Flags = FlashAll | FlashTimerNoForeground,
+                Count = uint.MaxValue,
+                Timeout = 0, // Use the system default flash rate.
+            };
+            _ = FlashWindowEx(ref info);
+        }
+
+        private static IntPtr? MainWindowHandle()
+        {
+            return (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?
+                .MainWindow?.TryGetPlatformHandle()?.Handle;
+        }
+
+        // macOS: bounce the dock icon until the app is activated. App-level, so no window is needed.
+
+        private const string LibObjC = "/usr/lib/libobjc.dylib";
+        private const long NSCriticalRequest = 0; // Bounce until the user switches to the app.
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_getClass")]
+        private static partial IntPtr GetClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [LibraryImport(LibObjC, EntryPoint = "sel_registerName")]
+        private static partial IntPtr RegisterName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial IntPtr SendMessage(IntPtr receiver, IntPtr selector);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial IntPtr SendMessage(IntPtr receiver, IntPtr selector, long arg);
+
+        private static void DemandMacOS()
+        {
+            IntPtr nsApplicationClass = GetClass("NSApplication");
+            if (nsApplicationClass == IntPtr.Zero)
+            {
+                return;
+            }
+
+            IntPtr sharedApplication = SendMessage(nsApplicationClass, RegisterName("sharedApplication"));
+            if (sharedApplication == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _ = SendMessage(sharedApplication, RegisterName("requestUserAttention:"), NSCriticalRequest);
+        }
+    }
+}

--- a/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 using CtrDxEditor.Playtest;
 
@@ -16,6 +17,12 @@ namespace CtrDxEditor.Desktop.Playtest
     /// <param name="tempRootOverride">Container for session directories; defaults to the system temp root.</param>
     public sealed class ProcessPlaytestLauncher(string? tempRootOverride = null) : IPlaytestLauncher
     {
+        // How long a freshly launched game has to emit its stdout handshake before it is judged not to
+        // be a compatible Cut the Rope: DX. The game prints the line before its run loop starts, so it
+        // normally arrives within about a second; the window is generous because a miss only warns - it
+        // never kills the process - so a slow cold start is never interrupted by mistake.
+        private static readonly TimeSpan HandshakeGracePeriod = TimeSpan.FromSeconds(10);
+
         private readonly PlaytestTempStore _temp = new(tempRootOverride);
         private readonly Lock _gate = new();
         private Process? _current;
@@ -23,6 +30,9 @@ namespace CtrDxEditor.Desktop.Playtest
 
         /// <inheritdoc />
         public event EventHandler<PlaytestExitedEventArgs>? Exited;
+
+        /// <inheritdoc />
+        public event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
 
         /// <inheritdoc />
         public bool Play(string executablePath, string levelXml)
@@ -58,6 +68,9 @@ namespace CtrDxEditor.Desktop.Playtest
                 ArgumentList = { "--level", levelPath },
                 UseShellExecute = false,
                 RedirectStandardError = true,
+                // Watched for the game's handshake line, which is how a compatible Cut the Rope: DX
+                // proves it understood --level. Also drained so a full pipe cannot block the game.
+                RedirectStandardOutput = true,
                 // The game resolves its content relative to its own location, so run it from there
                 // rather than inheriting the editor's working directory.
                 WorkingDirectory = Path.GetDirectoryName(binary) ?? "",
@@ -65,6 +78,11 @@ namespace CtrDxEditor.Desktop.Playtest
 
             Process process = new() { StartInfo = info, EnableRaisingEvents = true };
             StringBuilder stderr = new();
+
+            // Cancelled the moment the handshake arrives or the process ends, which stands the pending
+            // "unsupported" timeout down. Owned by this launch and captured by every handler below, so a
+            // later launch's timeout can never be cancelled by this one.
+            CancellationTokenSource handshake = new();
 
             // Drained asynchronously: a full stderr pipe would otherwise block the game once the OS
             // buffer fills.
@@ -76,11 +94,24 @@ namespace CtrDxEditor.Desktop.Playtest
                 }
             };
 
+            // The handshake is the positive signal that this build is Cut the Rope: DX and accepted the
+            // level. Seeing it cancels the timeout; anything else on stdout is ignored (and drained).
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is not null && PlaytestHandshakeLine.TryParse(e.Data, out int _, out string _))
+                {
+                    handshake.Cancel();
+                }
+            };
+
             process.Exited += (_, _) =>
             {
                 // Flushes the remaining redirected output; without it stderr can be truncated.
                 process.WaitForExit();
                 int code = process.ExitCode;
+                // An exit before the grace period elapses is not a missing handshake - stand the
+                // timeout down so a game the user simply closed early is never called unsupported.
+                handshake.Cancel();
                 lock (_gate)
                 {
                     // Only clear if this is still the current process.
@@ -110,9 +141,11 @@ namespace CtrDxEditor.Desktop.Playtest
             {
                 _ = process.Start();
                 process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
             }
             catch
             {
+                handshake.Cancel();
                 lock (_gate)
                 {
                     if (ReferenceEquals(_current, process))
@@ -123,6 +156,42 @@ namespace CtrDxEditor.Desktop.Playtest
                 process.Dispose();
                 throw;
             }
+
+            ArmHandshakeTimeout(process, binary, handshake);
+        }
+
+        // Warns, once the grace period passes with no handshake, that the launched program is not a
+        // compatible Cut the Rope: DX. Never kills the process: an old build has opened its normal menu
+        // and a genuine game may just be slow to start, so the safe move is to tell the user, not to
+        // yank a window away. The handshake token stands this down when the game identifies itself, ends,
+        // or the launcher is disposed.
+        private void ArmHandshakeTimeout(Process process, string binary, CancellationTokenSource handshake)
+        {
+            _ = Task.Delay(HandshakeGracePeriod, handshake.Token).ContinueWith(
+                task =>
+                {
+                    handshake.Dispose();
+                    if (task.IsCanceled)
+                    {
+                        return; // Handshake seen, process ended, or shutting down - nothing to report.
+                    }
+
+                    bool report;
+                    lock (_gate)
+                    {
+                        // Report only if this exact process is still the running one and we are not tearing
+                        // down. A reload never re-arms this, so the check also rejects a stale timeout.
+                        report = !_disposed && ReferenceEquals(_current, process);
+                    }
+
+                    if (report)
+                    {
+                        Unsupported?.Invoke(this, new PlaytestUnsupportedEventArgs(binary));
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         /// <inheritdoc />

--- a/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
@@ -170,7 +170,6 @@ namespace CtrDxEditor.Desktop.Playtest
             _ = Task.Delay(HandshakeGracePeriod, handshake.Token).ContinueWith(
                 task =>
                 {
-                    handshake.Dispose();
                     if (task.IsCanceled)
                     {
                         return; // Handshake seen, process ended, or shutting down - nothing to report.

--- a/src/CtrDxEditor.Desktop/Program.cs
+++ b/src/CtrDxEditor.Desktop/Program.cs
@@ -3,6 +3,7 @@ using System;
 using Avalonia;
 
 using CtrDxEditor.Content;
+using CtrDxEditor.Desktop.Platform;
 using CtrDxEditor.Desktop.Playtest;
 using CtrDxEditor.Playtest;
 using CtrDxEditor.Startup;
@@ -39,6 +40,7 @@ namespace CtrDxEditor.Desktop
                 DownloadSizeLabel = "310 MB",
                 ManualDownloadUrl = ContentDownloader.AssetsUrl,
                 Playtest = new ProcessPlaytestLauncher(),
+                Attention = new NativeUserAttention(),
                 CheckForUpdate = () => GitHubUpdateChecker.IsUpdateAvailableAsync(AppVersion.Display),
                 RepointContentLocation = async () =>
                 {

--- a/src/CtrDxEditor.Shared/App.axaml.cs
+++ b/src/CtrDxEditor.Shared/App.axaml.cs
@@ -253,7 +253,7 @@ namespace CtrDxEditor
                 SpriteCache sprites = new(store, _startup.SpriteImageExtension);
                 await Task.Run(sprites.PreloadAsync);
                 EditorSettings initial = await _startup.Settings.LoadAsync();
-                EditorViewModel editor = new(sprites, _startup.Settings, initial, _startup.Playtest);
+                EditorViewModel editor = new(sprites, _startup.Settings, initial, _startup.Playtest, _startup.Attention);
                 editor.InitializeDecorationFromSettings();
                 root.DataContext = editor;
                 return true;

--- a/src/CtrDxEditor.Shared/Platform/IUserAttention.cs
+++ b/src/CtrDxEditor.Shared/Platform/IUserAttention.cs
@@ -1,0 +1,15 @@
+namespace CtrDxEditor.Platform
+{
+    /// <summary>
+    /// Draws the user's attention to the editor window - a flashing taskbar button on Windows, a
+    /// bouncing dock icon on macOS. Absent on heads that have no such signal (the browser).
+    /// </summary>
+    public interface IUserAttention
+    {
+        /// <summary>
+        /// Asks the platform to alert the user that the editor needs them. Best-effort: it never steals
+        /// focus, and does nothing where the platform offers no attention signal. Call on the UI thread.
+        /// </summary>
+        void Demand();
+    }
+}

--- a/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
@@ -14,11 +14,26 @@ namespace CtrDxEditor.Playtest
         public string StandardError { get; } = standardError;
     }
 
+    /// <summary>Describes a launched program that never identified itself as a compatible Cut the Rope: DX.</summary>
+    /// <param name="executablePath">The resolved executable that was launched but produced no handshake.</param>
+    public sealed class PlaytestUnsupportedEventArgs(string executablePath) : EventArgs
+    {
+        /// <summary>The resolved executable that was launched but produced no handshake.</summary>
+        public string ExecutablePath { get; } = executablePath;
+    }
+
     /// <summary>Plays a level in Cut the Rope: DX. Absent on platforms that cannot spawn processes.</summary>
     public interface IPlaytestLauncher : IDisposable
     {
         /// <summary>Raised when the playtest process exits. Not raised on the UI thread.</summary>
         event EventHandler<PlaytestExitedEventArgs>? Exited;
+
+        /// <summary>
+        /// Raised when a freshly launched process produced no Cut the Rope: DX handshake within the grace
+        /// period - it is a different program, or a build too old to understand <c>--level</c>. Not raised
+        /// on the UI thread, and never raised for a reload (<see cref="Play"/> returning false).
+        /// </summary>
+        event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
 
         /// <summary>Writes <paramref name="levelXml"/> to the session level file, starting the game if it is not already running.</summary>
         /// <param name="executablePath">The user-picked executable or macOS .app bundle path.</param>

--- a/src/CtrDxEditor.Shared/Playtest/PlaytestHandshakeLine.cs
+++ b/src/CtrDxEditor.Shared/Playtest/PlaytestHandshakeLine.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Globalization;
+
+namespace CtrDxEditor.Playtest
+{
+    /// <summary>
+    /// Parses the handshake line Cut the Rope: DX writes to stdout the moment it accepts a
+    /// <c>--level</c> launch.
+    /// </summary>
+    /// <remarks>
+    /// The line is the editor's only positive proof that the launched program is Cut the Rope: DX and
+    /// new enough to understand <c>--level</c>: an older build, or an unrelated program, silently ignores
+    /// the switch and never emits it. The game writes <c>ctrdx-playtest &lt;protocol&gt; &lt;version&gt;</c>;
+    /// this mirrors that contract (see the game's <c>PlaytestHandshake</c> for the emitter).
+    /// </remarks>
+    public static class PlaytestHandshakeLine
+    {
+        /// <summary>Leading token that identifies a handshake line. Must match the game's emitter exactly.</summary>
+        public const string Signature = "ctrdx-playtest";
+
+        /// <summary>Attempts to parse one line of process output as a handshake.</summary>
+        /// <param name="line">A single line from the game's standard output.</param>
+        /// <param name="protocol">The handshake format version the game declared, or 0 on failure.</param>
+        /// <param name="version">The game's build version string, or an empty string on failure.</param>
+        /// <returns>True when <paramref name="line"/> is a well-formed handshake.</returns>
+        public static bool TryParse(string? line, out int protocol, out string version)
+        {
+            protocol = 0;
+            version = "";
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return false;
+            }
+
+            // At most three parts: signature, protocol, and the version, which is kept whole so a version
+            // string that ever carries a space survives intact.
+            string[] parts = line.Trim().Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 3
+                || !string.Equals(parts[0], Signature, StringComparison.Ordinal)
+                || !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedProtocol))
+            {
+                return false;
+            }
+
+            protocol = parsedProtocol;
+            version = parts[2].Trim();
+            return version.Length > 0;
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
+++ b/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Avalonia;
 
 using CtrDxEditor.Content;
+using CtrDxEditor.Platform;
 using CtrDxEditor.Playtest;
 
 namespace CtrDxEditor.Startup
@@ -37,6 +38,9 @@ namespace CtrDxEditor.Startup
 
         /// <summary>Plays levels in Cut the Rope: DX for playtesting; null where processes cannot be spawned (the browser).</summary>
         public IPlaytestLauncher? Playtest { get; init; }
+
+        /// <summary>Draws the user's attention to the editor window (taskbar flash / dock bounce); null where unavailable (the browser).</summary>
+        public IUserAttention? Attention { get; init; }
 
         /// <summary>
         /// Reports whether a newer release has been published, offering the user the release page at

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -15,6 +15,7 @@ using CtrDxEditor.Core.Document;
 using CtrDxEditor.Core.Editing;
 using CtrDxEditor.Core.Geometry;
 using CtrDxEditor.Localization;
+using CtrDxEditor.Platform;
 using CtrDxEditor.Playtest;
 using CtrDxEditor.Rendering;
 
@@ -25,11 +26,13 @@ namespace CtrDxEditor.ViewModels
     /// <param name="settings">Persisted editor settings store, or null in tests that don't exercise persistence.</param>
     /// <param name="initial">The editor settings snapshot loaded at startup (decoration defaults, content path).</param>
     /// <param name="playtest">Plays levels in Cut the Rope: DX, or null where playtesting is unavailable.</param>
+    /// <param name="attention">Draws attention to the editor window (taskbar flash / dock bounce), or null where unavailable.</param>
     public sealed partial class EditorViewModel(
         SpriteCache sprites,
         ISettingsStore? settings = null,
         EditorSettings? initial = null,
-        IPlaytestLauncher? playtest = null) : ViewModelBase
+        IPlaytestLauncher? playtest = null,
+        IUserAttention? attention = null) : ViewModelBase
     {
         private const int UndoHistoryLimit = 100;
         private static readonly LevelDocument EmptyDocument = LevelDocument.Parse("<map/>");
@@ -52,6 +55,9 @@ namespace CtrDxEditor.ViewModels
 
         /// <summary>Plays levels in Cut the Rope: DX; null on platforms without playtest support.</summary>
         public IPlaytestLauncher? Playtest { get; } = playtest;
+
+        /// <summary>Draws attention to the editor window (taskbar flash / dock bounce); null where unavailable.</summary>
+        public IUserAttention? Attention { get; } = attention;
 
         /// <summary>Whether this platform can play levels at all; hides the commands when false.</summary>
         public bool CanPlaytest => Playtest is not null;

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -129,6 +129,10 @@ namespace CtrDxEditor.Views
             {
                 Dispatcher.UIThread.Post(() =>
                 {
+                    // The game window has the user's focus right now, so a dialog behind it goes unseen.
+                    // Flash the taskbar / bounce the dock first, then raise the dialog to acknowledge.
+                    (DataContext as EditorViewModel)?.Attention?.Demand();
+
                     MessageDialog dialog = new()
                     {
                         Header = Localizer.Get("Playtest.Unsupported.Header"),

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -127,10 +127,15 @@ namespace CtrDxEditor.Views
 
             launcher.Unsupported += (_, _) =>
             {
-                Dispatcher.UIThread.Post(() => Notifications()?.Show(new Notification(
-                    Localizer.Get("Notification.Playtest.Failed"),
-                    Localizer.Get("Playtest.Unsupported.Body"),
-                    NotificationType.Error)));
+                Dispatcher.UIThread.Post(() =>
+                {
+                    MessageDialog dialog = new()
+                    {
+                        Header = Localizer.Get("Playtest.Unsupported.Header"),
+                        Message = Localizer.Get("Playtest.Unsupported.Body"),
+                    };
+                    _ = dialog.ShowAsync();
+                });
             };
         }
 

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -25,7 +25,7 @@ namespace CtrDxEditor.Views
     // user is not looking at.
     public partial class MainView
     {
-        private bool _playtestExitHooked;
+        private bool _playtestEventsHooked;
 
         private async void Playtest_Click(object? sender, RoutedEventArgs e)
         {
@@ -57,7 +57,7 @@ namespace CtrDxEditor.Views
                 return;
             }
 
-            HookPlaytestExit(launcher);
+            HookPlaytestEvents(launcher);
 
             try
             {
@@ -101,14 +101,15 @@ namespace CtrDxEditor.Views
         }
 
         // Subscribed once per view. A clean exit is silent; a non-zero one carries the game's own
-        // stderr diagnostic, which is how it reports a level it could not load.
-        private void HookPlaytestExit(IPlaytestLauncher launcher)
+        // stderr diagnostic, which is how it reports a level it could not load. An unsupported launch is
+        // the case a wrong or too-old program was picked: it never handshook, so the level never played.
+        private void HookPlaytestEvents(IPlaytestLauncher launcher)
         {
-            if (_playtestExitHooked)
+            if (_playtestEventsHooked)
             {
                 return;
             }
-            _playtestExitHooked = true;
+            _playtestEventsHooked = true;
 
             launcher.Exited += (_, args) =>
             {
@@ -121,6 +122,14 @@ namespace CtrDxEditor.Views
                     string.IsNullOrWhiteSpace(args.StandardError)
                         ? $"Cut the Rope: DX exited with code {args.ExitCode}."
                         : args.StandardError,
+                    NotificationType.Error)));
+            };
+
+            launcher.Unsupported += (_, _) =>
+            {
+                Dispatcher.UIThread.Post(() => Notifications()?.Show(new Notification(
+                    Localizer.Get("Notification.Playtest.Failed"),
+                    Localizer.Get("Playtest.Unsupported.Body"),
                     NotificationType.Error)));
             };
         }

--- a/src/CtrDxEditor.Tests/PlaytestHandshakeLineTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestHandshakeLineTests.cs
@@ -1,0 +1,63 @@
+using CtrDxEditor.Playtest;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests for parsing the game's stdout playtest handshake.</summary>
+    public class PlaytestHandshakeLineTests
+    {
+        /// <summary>Verifies a well-formed handshake yields its protocol and version.</summary>
+        [Fact]
+        public void WellFormedLineReturnsProtocolAndVersion()
+        {
+            bool ok = PlaytestHandshakeLine.TryParse("ctrdx-playtest 1 1.0.0", out int protocol, out string version);
+
+            Assert.True(ok);
+            Assert.Equal(1, protocol);
+            Assert.Equal("1.0.0", version);
+        }
+
+        /// <summary>Verifies a version carrying build metadata survives parsing intact.</summary>
+        [Fact]
+        public void InformationalVersionWithMetadataIsKeptWhole()
+        {
+            bool ok = PlaytestHandshakeLine.TryParse("ctrdx-playtest 1 1.0.0+abc1234", out _, out string version);
+
+            Assert.True(ok);
+            Assert.Equal("1.0.0+abc1234", version);
+        }
+
+        /// <summary>Verifies surrounding whitespace on the line is ignored.</summary>
+        [Fact]
+        public void SurroundingWhitespaceIsTrimmed()
+        {
+            bool ok = PlaytestHandshakeLine.TryParse("  ctrdx-playtest 2 1.2.3  ", out int protocol, out string version);
+
+            Assert.True(ok);
+            Assert.Equal(2, protocol);
+            Assert.Equal("1.2.3", version);
+        }
+
+        /// <summary>Verifies malformed lines and unrelated process output are rejected.</summary>
+        /// <param name="line">A line that is not a valid handshake.</param>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("some unrelated game log line")]
+        [InlineData("ctrdx-playtest")]              // signature only
+        [InlineData("ctrdx-playtest 1")]            // no version
+        [InlineData("ctrdx-playtest x 1.0.0")]      // non-integer protocol
+        [InlineData("CTRDX-PLAYTEST 1 1.0.0")]      // signature is case-sensitive
+        [InlineData("notctrdx-playtest 1 1.0.0")]   // near-miss signature
+        public void MalformedOrForeignLinesReturnFalse(string? line)
+        {
+            bool ok = PlaytestHandshakeLine.TryParse(line, out int protocol, out string version);
+
+            Assert.False(ok);
+            Assert.Equal(0, protocol);
+            Assert.Equal("", version);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Detect whether the CtRDX version is compatible with playtest feature, by watching the launched game's `stdout` for its playtest handshake.

When a cold launch produces no handshake within a grace period, the build is a different program or too old to understand `--level`, so warn instead of silently opening its main menu. It does not kill the process, so a slow-but-valid launch is not interrupted.