### PR TITLE
feat: warn when rocket, water or snail is used without mobile physics

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -921,5 +921,8 @@
     "Validation.GrabVerticallyAligned": "A grab and what its rope binds to are both at x={0}. Offset one of them by a pixel or more.",
     "Validation.GhostIdle": "A ghost has no enabled states (grab/bubble/bouncer), it will sit idle and do nothing.",
     "Validation.CandyInHazard": "Candy {0} starts inside a spike and will break immediately.",
-    "Validation.CandyOnMouth": "Candy {0} starts on Om Nom's mouth and will be eaten immediately, winning the level."
+    "Validation.CandyOnMouth": "Candy {0} starts on Om Nom's mouth and will be eaten immediately, winning the level.",
+    "Validation.RocketWithoutMobilePhysics": "Level has a rocket but mobile physics is off; rockets are tuned for mobile physics and will feel off without it.",
+    "Validation.WaterWithoutMobilePhysics": "Level has water but mobile physics is off; water is tuned for mobile physics and will feel off without it.",
+    "Validation.SnailWithoutMobilePhysics": "Level has a snail but mobile physics is off; snails are tuned for mobile physics and will feel off without it."
 }

--- a/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
+++ b/src/CtrDxEditor.Core.Tests/LevelValidatorTests.cs
@@ -281,6 +281,55 @@ namespace CtrDxEditor.Core.Tests
                 w => w.Key == "Validation.GrabVerticallyAligned");
         }
 
+        /// <summary>Experiments features tuned for mobile physics warn when the level runs the PC model.</summary>
+        [Theory]
+        [InlineData("<rocket x=\"100\" y=\"100\" />", "", "Validation.RocketWithoutMobilePhysics")]
+        [InlineData("<load x=\"100\" y=\"100\" />", "", "Validation.SnailWithoutMobilePhysics")]
+        [InlineData("", "water=\"120\"", "Validation.WaterWithoutMobilePhysics")]
+        public void MobileTunedFeatureWithoutMobilePhysicsWarns(string objects, string flags, string key)
+        {
+            LevelDocument doc = Doc(flags,
+                $"<candy x=\"10\" y=\"10\" /><target x=\"300\" y=\"300\" />{objects}");
+
+            Assert.Contains(LevelValidator.Validate(doc), w => w.Key == key);
+        }
+
+        /// <summary>The same features are fine once the level opts into mobile physics.</summary>
+        [Theory]
+        [InlineData("<rocket x=\"100\" y=\"100\" />", "Validation.RocketWithoutMobilePhysics")]
+        [InlineData("<load x=\"100\" y=\"100\" />", "Validation.SnailWithoutMobilePhysics")]
+        public void MobileTunedObjectWithMobilePhysicsDoesNotWarn(string objects, string key)
+        {
+            LevelDocument doc = Doc("useMobilePhysics=\"true\"",
+                $"<candy x=\"10\" y=\"10\" /><target x=\"300\" y=\"300\" />{objects}");
+
+            Assert.DoesNotContain(LevelValidator.Validate(doc), w => w.Key == key);
+        }
+
+        /// <summary>Water at 0 means the level has no water at all, so there is nothing to warn about.</summary>
+        [Fact]
+        public void LevelWithoutWaterDoesNotWarnAboutPhysics()
+        {
+            LevelDocument doc = Doc("water=\"0\"",
+                "<candy x=\"10\" y=\"10\" /><target x=\"300\" y=\"300\" />");
+
+            Assert.DoesNotContain(
+                LevelValidator.Validate(doc),
+                w => w.Key == "Validation.WaterWithoutMobilePhysics");
+        }
+
+        /// <summary>Water is a setting, not an object, so mobile physics is what silences it.</summary>
+        [Fact]
+        public void WaterWithMobilePhysicsDoesNotWarn()
+        {
+            LevelDocument doc = Doc("water=\"120\" useMobilePhysics=\"true\"",
+                "<candy x=\"10\" y=\"10\" /><target x=\"300\" y=\"300\" />");
+
+            Assert.DoesNotContain(
+                LevelValidator.Validate(doc),
+                w => w.Key == "Validation.WaterWithoutMobilePhysics");
+        }
+
         /// <summary>A rope bound to a light bulb is checked against the bulb it actually binds to.</summary>
         [Fact]
         public void GrabVerticallyAlignedWithItsBulbWarns()

--- a/src/CtrDxEditor.Core/Editing/LevelValidator.cs
+++ b/src/CtrDxEditor.Core/Editing/LevelValidator.cs
@@ -123,6 +123,30 @@ namespace CtrDxEditor.Core.Editing
                 }
             }
 
+            // Rockets, water and snails were tuned against the mobile physics model: rockets and water
+            // read their own ActivePhysicsConstants entries (RocketImpulseScale, WaterDamping,
+            // WaterRocketImpulseDivisor, ...) whose values differ per model, and a snail applies a flat
+            // weight to the candy point, so its pull depends on the model's gravity and scale. Under the
+            // PC model they still load and play, they just feel off - advisory, not an error.
+            if (!document.UseMobilePhysics)
+            {
+                if (HasType("rocket"))
+                {
+                    warnings.Add(new LevelWarning("Validation.RocketWithoutMobilePhysics"));
+                }
+
+                if (document.Water > 0f)
+                {
+                    warnings.Add(new LevelWarning("Validation.WaterWithoutMobilePhysics"));
+                }
+
+                // "load" is the snail's element name; see DescriptorTable.
+                if (HasType("load"))
+                {
+                    warnings.Add(new LevelWarning("Validation.SnailWithoutMobilePhysics"));
+                }
+            }
+
             foreach (LevelObject ghost in objects.Where(o => o.Type == "ghost"))
             {
                 if (GhostStates.IsIdleOnly(ghost))


### PR DESCRIPTION
## Description

Rockets, water and snails are tuned against the mobile physics model - rockets and water read model-split `ActivePhysicsConstants` entries, and a snail's flat point weight depends on the model's gravity and scale.

This PR adds 3 advisory validation warnings when any of them is present while `useMobilePhysics` is off.