### PR TITLE
feat: gate playtest on a set DX location and add a Ctrl/⌘ P shortcut

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -380,7 +380,7 @@
 
     "Guide.Article.keyboard-shortcuts.Title": "Keyboard shortcuts",
     "Guide.Article.keyboard-shortcuts.Summary": "Use the editor's global file, editing, preview, and zoom commands.",
-    "Guide.Article.keyboard-shortcuts.SearchTerms": "ctrl shift p|command shift p|hotkeys|keys|space|delete|f2|tutorial text",
+    "Guide.Article.keyboard-shortcuts.SearchTerms": "ctrl shift p|command shift p|ctrl p|command p|hotkeys|keys|space|delete|f2|tutorial text",
     "Guide.Article.keyboard-shortcuts.Platform.Note": "Use Command instead of Ctrl on macOS. Ctrl/Command-Shift-Z is redo everywhere; Ctrl-Y is an extra redo binding on Windows and Linux only. These chords are ignored while a dialog is open, so the dialog's own text fields keep them.",
     "Guide.Article.keyboard-shortcuts.Shortcut.New.Action": "New level",
     "Guide.Article.keyboard-shortcuts.Shortcut.New.Keys": "Ctrl/⌘ N",
@@ -390,6 +390,8 @@
     "Guide.Article.keyboard-shortcuts.Shortcut.Save.Keys": "Ctrl/⌘ S",
     "Guide.Article.keyboard-shortcuts.Shortcut.SaveAs.Action": "Save As",
     "Guide.Article.keyboard-shortcuts.Shortcut.SaveAs.Keys": "Ctrl/⌘ Shift S",
+    "Guide.Article.keyboard-shortcuts.Shortcut.Playtest.Action": "Play this level",
+    "Guide.Article.keyboard-shortcuts.Shortcut.Playtest.Keys": "Ctrl/⌘ P",
     "Guide.Article.keyboard-shortcuts.Shortcut.Screenshot.Action": "Screenshot",
     "Guide.Article.keyboard-shortcuts.Shortcut.Screenshot.Keys": "Ctrl/⌘ Shift P",
     "Guide.Article.keyboard-shortcuts.Shortcut.Close.Action": "Close level",

--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -479,7 +479,7 @@
     "Guide.Article.save-export-playtest.Summary": "Save XML, export a rendered image, and launch the level in Cut the Rope: DX.",
     "Guide.Article.save-export-playtest.SearchTerms": "save as|screenshot|png|playtest|dx location|export",
     "Guide.Article.save-export-playtest.Save": "**Save** writes to the current file when the platform supports it; **Save As** chooses a new destination. **Screenshot** exports the rendered level as a PNG.",
-    "Guide.Article.save-export-playtest.Playtest": "On desktop, point the editor at the game once with **File > Set DX Location**, then use **File > Play This Level**. The editor validates the level and writes a temporary playtest copy before launching, so you can try unsaved work.",
+    "Guide.Article.save-export-playtest.Playtest": "On desktop, point the editor at the game once with **File > Set DX Location**, then use **File > Play This Level**, which stays disabled until a location is set. The editor validates the level and writes a temporary playtest copy before launching, so you can try unsaved work.",
     "Guide.Article.save-export-playtest.Browser.Warning": "The browser cannot launch a local game executable. This is by design to minimize security risks. Download or save the level, then open it with your desktop workflow.",
 
     "Guide.Article.troubleshooting.Title": "Troubleshooting",

--- a/src/CtrDxEditor.Shared/UsageGuide/UsageGuideCatalog.cs
+++ b/src/CtrDxEditor.Shared/UsageGuide/UsageGuideCatalog.cs
@@ -48,7 +48,7 @@ namespace CtrDxEditor.UsageGuide
                 ["keyboard-shortcuts", "know-the-editor"]),
             Article("keyboard-shortcuts", "Reference",
                 [Note("keyboard-shortcuts", "Platform"), ShortcutTable("keyboard-shortcuts",
-                    "New", "Open", "Save", "SaveAs", "Screenshot", "Close", "Undo", "Redo",
+                    "New", "Open", "Save", "SaveAs", "Playtest", "Screenshot", "Close", "Undo", "Redo",
                     "Clipboard", "SelectAll", "Delete", "Zoom", "Animation", "TutorialText",
                     "RemovePoint")],
                 ["modifier-keys", "menus-commands", "pointer-gestures"]),

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -62,6 +62,27 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Whether this platform can play levels at all; hides the commands when false.</summary>
         public bool CanPlaytest => Playtest is not null;
 
+        /// <summary>Whether a Cut the Rope: DX location has been picked; false until the user sets one.</summary>
+        /// <remarks>
+        /// Answers to the stored path only, not to whether it still resolves on disk. A game that has moved
+        /// or been deleted since is recovered by the launch path re-prompting, which keeps a temporarily
+        /// unreachable path (external drive, network share) from silently disabling the command.
+        /// </remarks>
+        public bool HasDxLocation => !string.IsNullOrWhiteSpace(CurrentSettingsSnapshot.DxExecutablePath);
+
+        /// <summary>True when a level can actually be handed to the game; enables the playtest commands.</summary>
+        public bool CanLaunchPlaytest => HasDocument && HasDxLocation;
+
+        /// <summary>
+        /// Re-reads <see cref="HasDxLocation"/> after the settings snapshot's path is written. The snapshot
+        /// is a plain settings record rather than an observable, so the writer has to say when it changed.
+        /// </summary>
+        public void NotifyDxLocationChanged()
+        {
+            OnPropertyChanged(nameof(HasDxLocation));
+            OnPropertyChanged(nameof(CanLaunchPlaytest));
+        }
+
         /// <summary>
         /// Whether this platform can overwrite the file a level was opened from; hides Save when false.
         /// </summary>
@@ -1894,6 +1915,7 @@ namespace CtrDxEditor.ViewModels
             OnPropertyChanged(nameof(Selection));
             OnPropertyChanged(nameof(SelectedObject));
             OnPropertyChanged(nameof(HasDocument));
+            OnPropertyChanged(nameof(CanLaunchPlaytest));
             NotifyEditCommandCapabilities();
         }
 

--- a/src/CtrDxEditor.Shared/Views/EditorShortcuts.cs
+++ b/src/CtrDxEditor.Shared/Views/EditorShortcuts.cs
@@ -23,6 +23,9 @@ namespace CtrDxEditor.Views
         /// <summary>Save a screenshot of the level.</summary>
         Screenshot,
 
+        /// <summary>Play the current level in Cut the Rope: DX.</summary>
+        Playtest,
+
         /// <summary>Close the current level.</summary>
         Close,
 
@@ -98,6 +101,7 @@ namespace CtrDxEditor.Views
                 Key.S when !shift => EditorShortcut.Save,
                 Key.S when shift => EditorShortcut.SaveAs,
                 Key.P when shift => EditorShortcut.Screenshot,
+                Key.P when !shift => EditorShortcut.Playtest,
                 Key.W when !shift => EditorShortcut.Close,
                 Key.Z when !shift => EditorShortcut.Undo,
                 Key.Z when shift => EditorShortcut.Redo,

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -16,8 +16,9 @@ using CtrDxEditor.ViewModels;
 namespace CtrDxEditor.Views
 {
     // Playtest commands: hand the open level to Cut the Rope: DX via --level. The launcher owns the
-    // temp file and the macOS .app resolution, so this file only deals with confirmation, the
-    // first-run executable picker, and reporting failures.
+    // temp file and the macOS .app resolution, so this file only deals with confirmation, recovering a
+    // stored path that no longer resolves, and reporting failures. Play stays disabled until a location
+    // is set (EditorViewModel.CanLaunchPlaytest), so the picker here is recovery, not first run.
     //
     // Clicking Play while a game is already running is not an error: the launcher rewrites the level
     // file, the game's own watcher notices, and it reloads in place. No second process, no toast -
@@ -167,6 +168,7 @@ namespace CtrDxEditor.Views
             }
 
             vm.CurrentSettingsSnapshot.DxExecutablePath = path;
+            vm.NotifyDxLocationChanged();
             if (vm.Settings is { } store)
             {
                 await store.SaveAsync(vm.CurrentSettingsSnapshot);

--- a/src/CtrDxEditor.Shared/Views/MainView.Shortcuts.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.Shortcuts.cs
@@ -85,6 +85,11 @@ namespace CtrDxEditor.Views
                 case EditorShortcut.Screenshot when DataContext is EditorViewModel { HasDocument: true }:
                     Screenshot_Click(this, new RoutedEventArgs());
                     return true;
+                // Guarded by the same gate as the menu item, so the chord cannot reach the locate dialog
+                // through a command the user can see is disabled.
+                case EditorShortcut.Playtest when DataContext is EditorViewModel { CanPlaytest: true, CanLaunchPlaytest: true }:
+                    Playtest_Click(this, new RoutedEventArgs());
+                    return true;
                 case EditorShortcut.Close when DataContext is EditorViewModel { HasDocument: true }:
                     Close_Click(this, new RoutedEventArgs());
                     return true;
@@ -137,6 +142,7 @@ namespace CtrDxEditor.Views
                 case EditorShortcut.Save:
                 case EditorShortcut.SaveAs:
                 case EditorShortcut.Screenshot:
+                case EditorShortcut.Playtest:
                 case EditorShortcut.Close:
                 case EditorShortcut.Undo:
                 case EditorShortcut.Redo:

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -64,7 +64,7 @@
         </MenuItem>
         <Separator />
         <MenuItem Header="{loc:Tr Menu.File.Playtest}" Click="Playtest_Click"
-                  IsVisible="{Binding CanPlaytest}" IsEnabled="{Binding HasDocument}">
+                  IsVisible="{Binding CanPlaytest}" IsEnabled="{Binding CanLaunchPlaytest}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="Play" />
           </MenuItem.Icon>
@@ -898,7 +898,7 @@
                 </Grid>
               </Button>
               <Button Classes="drawerRow" Click="DrawerPlaytest_Click"
-                      IsVisible="{Binding CanPlaytest}" IsEnabled="{Binding HasDocument}">
+                      IsVisible="{Binding CanPlaytest}" IsEnabled="{Binding CanLaunchPlaytest}">
                 <Grid ColumnDefinitions="Auto,*">
                   <icons:MaterialIcon Grid.Column="0" Kind="Play" Width="20" Height="20"
                                       VerticalAlignment="Center" />

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -63,11 +63,17 @@
           </MenuItem.Header>
         </MenuItem>
         <Separator />
-        <MenuItem Header="{loc:Tr Menu.File.Playtest}" Click="Playtest_Click"
+        <MenuItem Click="Playtest_Click"
                   IsVisible="{Binding CanPlaytest}" IsEnabled="{Binding CanLaunchPlaytest}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="Play" />
           </MenuItem.Icon>
+          <MenuItem.Header>
+            <Grid ColumnDefinitions="*,Auto" MinWidth="170">
+              <AccessText Grid.Column="0" Text="{loc:Tr Menu.File.Playtest}" VerticalAlignment="Center" />
+              <TextBlock Grid.Column="1" Text="{x:Static views:ShortcutHint.Playtest}" Opacity="0.6" Margin="24,0,0,0" VerticalAlignment="Center" />
+            </Grid>
+          </MenuItem.Header>
         </MenuItem>
         <MenuItem Header="{loc:Tr Menu.File.SetDxLocation}" Click="SetDxLocation_Click"
                   IsVisible="{Binding CanPlaytest}">

--- a/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
+++ b/src/CtrDxEditor.Shared/Views/ShortcutHint.cs
@@ -22,6 +22,9 @@ namespace CtrDxEditor.Views
         /// <summary>Localized platform shortcut text for saving the level under a new name.</summary>
         public static string SaveAs { get; } = $"{Mod} Shift S";
 
+        /// <summary>Localized platform shortcut text for playing the level in Cut the Rope: DX.</summary>
+        public static string Playtest { get; } = $"{Mod} P";
+
         /// <summary>Localized platform shortcut text for taking a screenshot.</summary>
         public static string Screenshot { get; } = $"{Mod} Shift P";
 

--- a/src/CtrDxEditor.Tests/EditorShortcutsTests.cs
+++ b/src/CtrDxEditor.Tests/EditorShortcutsTests.cs
@@ -16,6 +16,7 @@ namespace CtrDxEditor.Tests
         [InlineData(Key.S, KeyModifiers.Control, EditorShortcut.Save)]
         [InlineData(Key.S, KeyModifiers.Control | KeyModifiers.Shift, EditorShortcut.SaveAs)]
         [InlineData(Key.P, KeyModifiers.Control | KeyModifiers.Shift, EditorShortcut.Screenshot)]
+        [InlineData(Key.P, KeyModifiers.Control, EditorShortcut.Playtest)]
         [InlineData(Key.W, KeyModifiers.Control, EditorShortcut.Close)]
         [InlineData(Key.Z, KeyModifiers.Control, EditorShortcut.Undo)]
         [InlineData(Key.Z, KeyModifiers.Control | KeyModifiers.Shift, EditorShortcut.Redo)]
@@ -99,6 +100,18 @@ namespace CtrDxEditor.Tests
         {
             Assert.Equal(EditorShortcut.Redo, EditorShortcuts.ResolveCommand(Key.Y, KeyModifiers.Control, KeyModifiers.Control, isMacOS: false, dialogOpen: false));
             Assert.Equal(EditorShortcut.None, EditorShortcuts.ResolveCommand(Key.Y, KeyModifiers.Meta, KeyModifiers.Meta, isMacOS: true, dialogOpen: false));
+        }
+
+        /// <summary>P splits on Shift: playtest without it, screenshot with it, so neither shadows the other.</summary>
+        [Fact]
+        public void ShiftSeparatesPlaytestFromScreenshot()
+        {
+            Assert.Equal(
+                EditorShortcut.Playtest,
+                EditorShortcuts.ResolveCommand(Key.P, KeyModifiers.Meta, KeyModifiers.Meta, isMacOS: true, dialogOpen: false));
+            Assert.Equal(
+                EditorShortcut.Screenshot,
+                EditorShortcuts.ResolveCommand(Key.P, KeyModifiers.Meta | KeyModifiers.Shift, KeyModifiers.Meta, isMacOS: true, dialogOpen: false));
         }
 
         /// <summary>Delete and unmodified Space resolve to their editor actions.</summary>

--- a/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+
+using CtrDxEditor.Content;
+using CtrDxEditor.ViewModels;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>
+    /// Gating for the playtest commands: a level has to be open and a Cut the Rope: DX location has to
+    /// have been picked. The view bindings are asserted against the XAML source, which is where the
+    /// enabled state actually lives.
+    /// </summary>
+    public class PlaytestGatingTests
+    {
+        private const string Level = """
+        <map>
+            <layer name="settings"><map gridSize="32" width="320" height="480" /></layer>
+            <layer name="Objects"><candy x="10" y="10" /></layer>
+        </map>
+        """;
+
+        private static EditorViewModel Vm(string? dxPath)
+        {
+            return new EditorViewModel(
+                new SpriteCache(new EmptyContentStore()),
+                initial: new EditorSettings { DxExecutablePath = dxPath });
+        }
+
+        /// <summary>A fresh install has no location, so playing is off even with a level open.</summary>
+        [Fact]
+        public void OpenLevelWithoutADxLocationCannotPlaytest()
+        {
+            EditorViewModel vm = Vm(null);
+            vm.LoadLevelXml(Level);
+
+            Assert.False(vm.HasDxLocation);
+            Assert.False(vm.CanLaunchPlaytest);
+        }
+
+        /// <summary>A location alone is not enough; there has to be something to play.</summary>
+        [Fact]
+        public void DxLocationWithoutALevelCannotPlaytest()
+        {
+            EditorViewModel vm = Vm("/Applications/Cut the Rope DX.app");
+
+            Assert.True(vm.HasDxLocation);
+            Assert.False(vm.CanLaunchPlaytest);
+        }
+
+        /// <summary>Both present is the only combination that enables the command.</summary>
+        [Fact]
+        public void LevelAndDxLocationCanPlaytest()
+        {
+            EditorViewModel vm = Vm("/Applications/Cut the Rope DX.app");
+            vm.LoadLevelXml(Level);
+
+            Assert.True(vm.CanLaunchPlaytest);
+        }
+
+        /// <summary>Whitespace is a path nobody set, not a location.</summary>
+        [Fact]
+        public void BlankDxPathDoesNotCount()
+        {
+            Assert.False(Vm("   ").HasDxLocation);
+        }
+
+        /// <summary>
+        /// The snapshot is a plain settings object, so setting a location has to be announced by hand for
+        /// the menu item to enable itself without reopening the level.
+        /// </summary>
+        [Fact]
+        public void NotifyingALocationChangeRaisesTheGate()
+        {
+            EditorViewModel vm = Vm(null);
+            vm.LoadLevelXml(Level);
+
+            bool raised = false;
+            vm.PropertyChanged += (_, e) =>
+                raised |= e.PropertyName == nameof(EditorViewModel.CanLaunchPlaytest);
+
+            vm.CurrentSettingsSnapshot.DxExecutablePath = "/Applications/Cut the Rope DX.app";
+            vm.NotifyDxLocationChanged();
+
+            Assert.True(raised);
+            Assert.True(vm.CanLaunchPlaytest);
+        }
+
+        /// <summary>Opening a level after the location was set has to enable the command too.</summary>
+        [Fact]
+        public void LoadingALevelRaisesTheGate()
+        {
+            EditorViewModel vm = Vm("/Applications/Cut the Rope DX.app");
+
+            bool raised = false;
+            vm.PropertyChanged += (_, e) =>
+                raised |= e.PropertyName == nameof(EditorViewModel.CanLaunchPlaytest);
+
+            vm.LoadLevelXml(Level);
+
+            Assert.True(raised);
+        }
+
+        /// <summary>Both the menu item and the compact drawer row bind the same gate.</summary>
+        [Fact]
+        public void BothPlaytestEntryPointsBindTheGate()
+        {
+            string xaml = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.axaml"));
+
+            int menu = xaml.IndexOf("Click=\"Playtest_Click\"", StringComparison.Ordinal);
+            int drawer = xaml.IndexOf("Click=\"DrawerPlaytest_Click\"", StringComparison.Ordinal);
+            Assert.True(menu >= 0 && drawer >= 0, "Both playtest entry points should exist.");
+
+            foreach (int start in new[] { menu, drawer })
+            {
+                Assert.Contains(
+                    "IsEnabled=\"{Binding CanLaunchPlaytest}\"",
+                    xaml[start..(start + 200)],
+                    StringComparison.Ordinal);
+            }
+        }
+
+        /// <summary>Setting the location must tell the view, or the command stays greyed out until reload.</summary>
+        [Fact]
+        public void PickingALocationNotifiesTheViewModel()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+
+            int assignment = source.IndexOf("vm.CurrentSettingsSnapshot.DxExecutablePath = path;", StringComparison.Ordinal);
+            Assert.True(assignment >= 0, "The pick should store the path on the snapshot.");
+
+            int notify = source.IndexOf("vm.NotifyDxLocationChanged();", StringComparison.Ordinal);
+            Assert.True(notify > assignment, "The notification belongs after the path is stored.");
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string path = AppContext.BaseDirectory;
+            while (Path.GetFileName(path) != "src")
+            {
+                path = Directory.GetParent(path)?.FullName
+                       ?? throw new InvalidOperationException("Could not locate src directory.");
+            }
+
+            return Path.Combine(path, Path.Combine(parts));
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
@@ -122,6 +122,18 @@ namespace CtrDxEditor.Tests
             }
         }
 
+        /// <summary>The keyboard chord runs behind the same gate, so it cannot bypass a disabled menu item.</summary>
+        [Fact]
+        public void ThePlaytestChordRespectsTheGate()
+        {
+            string shortcuts = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.Shortcuts.cs"));
+
+            Assert.Contains(
+                "EditorShortcut.Playtest when DataContext is EditorViewModel { CanPlaytest: true, CanLaunchPlaytest: true }",
+                shortcuts,
+                StringComparison.Ordinal);
+        }
+
         /// <summary>Setting the location must tell the view, or the command stays greyed out until reload.</summary>
         [Fact]
         public void PickingALocationNotifiesTheViewModel()


### PR DESCRIPTION
## Description

- `Play This Level` is now disabled until a `Cut the Rope: DX location` has been set, in both the File menu and the compact command drawer. It was previously enabled whenever a level was open, and clicking it opened the locate dialog as a surprise first step.
- Gating is `CanLaunchPlaytest` = a level is open and a location is stored. It answers to the stored path only, not to whether it still resolves on disk - a game on an unmounted drive keeps the command available, and the launch path re-prompts if the path has gone stale.
- Added `Ctrl P` / `⌘ P` for `Play This Level`.