### PR TITLE
GridSize support on Level Settings

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -604,6 +604,8 @@
     "Dialog.LevelSettings.Custom": "Custom...",
     "Dialog.LevelSettings.Width": "Width",
     "Dialog.LevelSettings.Height": "Height",
+    "Dialog.LevelSettings.GridSize": "Grid size",
+    "Dialog.LevelSettings.GridSizeDescription": "How big the grid is in-editor. 32 is the default.",
     "Dialog.LevelSettings.RopePhysicsSpeed": "Rope physics speed",
     "Dialog.LevelSettings.RopePhysicsSpeedDescription": "Controls how quickly rope physics are simulated. 1 is the normal speed; higher positive values make ropes react faster.",
     "Dialog.LevelSettings.Gravity": "Gravity",

--- a/src/CtrDxEditor.Core/Document/LevelDocument.cs
+++ b/src/CtrDxEditor.Core/Document/LevelDocument.cs
@@ -57,7 +57,7 @@ namespace CtrDxEditor.Core.Document
             ApplyGravity(gameDesignEl, settings);
 
             XElement mapEl = new("map",
-                new XAttribute("gridSize", "32"),
+                new XAttribute("gridSize", settings.GridSize.ToString(CultureInfo.InvariantCulture)),
                 new XAttribute("width", settings.Width.ToString(CultureInfo.InvariantCulture)),
                 new XAttribute("height", settings.Height.ToString(CultureInfo.InvariantCulture)));
             ApplyLevelName(mapEl, settings);
@@ -160,7 +160,7 @@ namespace CtrDxEditor.Core.Document
         /// <summary>All editable level-wide settings read from the settings layer.</summary>
         public LevelSettings Settings =>
             new(Width, Height, RopePhysicsSpeed, Special, TwoParts, NightLevel, UseMobilePhysics, Water, WaterSpeed,
-                LevelName, GravityX, GravityY);
+                LevelName, GravityX, GravityY, GridSize);
 
         /// <summary>All object layers (every <c>&lt;layer&gt;</c> except <c>settings</c>), in document order.</summary>
         public IReadOnlyList<LevelLayer> Layers =>
@@ -353,7 +353,7 @@ namespace CtrDxEditor.Core.Document
             XElement map = settingsLayer.Element("map") ?? AddChild(settingsLayer, "map");
             XElement gameDesign = settingsLayer.Element("gameDesign") ?? AddChild(settingsLayer, "gameDesign");
 
-            map.SetAttributeValue("gridSize", "32");
+            map.SetAttributeValue("gridSize", settings.GridSize.ToString(CultureInfo.InvariantCulture));
             map.SetAttributeValue("width", settings.Width.ToString(CultureInfo.InvariantCulture));
             map.SetAttributeValue("height", settings.Height.ToString(CultureInfo.InvariantCulture));
             ApplyLevelName(map, settings);

--- a/src/CtrDxEditor.Core/Document/LevelSettings.cs
+++ b/src/CtrDxEditor.Core/Document/LevelSettings.cs
@@ -39,6 +39,7 @@ namespace CtrDxEditor.Core.Document
     /// Vertical gravity applied to the level, positive pulling downward;
     /// <see cref="LevelGravity.DefaultY"/> is normal Earth gravity and 0 is weightless.
     /// </param>
+    /// <param name="GridSize">Grid size used for the editor.</param>
     public sealed record LevelSettings(
         int Width,
         int Height,
@@ -51,5 +52,6 @@ namespace CtrDxEditor.Core.Document
         float WaterSpeed = 0f,
         string LevelName = "",
         float GravityX = LevelGravity.DefaultX,
-        float GravityY = LevelGravity.DefaultY);
+        float GravityY = LevelGravity.DefaultY,
+        int GridSize = 32);
 }

--- a/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/LevelSettingsViewModel.cs
@@ -107,6 +107,7 @@ namespace CtrDxEditor.ViewModels
 
         private const int MinWidth = 320;
         private const int MinHeight = 480;
+        private const int MinGridSize = 1;
         private const int MaxDimension = 9999;
         private const int MaxSpecial = 99;
         private const int MinRopeSpeed = -100;
@@ -166,6 +167,13 @@ namespace CtrDxEditor.ViewModels
         [NotifyPropertyChangedFor(nameof(HasCustomHeightError))]
         [NotifyPropertyChangedFor(nameof(CanConfirm))]
         public partial string CustomHeightText { get; set; } = Format(MinHeight);
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(GridSize))]
+        [NotifyPropertyChangedFor(nameof(GridSizeError))]
+        [NotifyPropertyChangedFor(nameof(HasGridSizeError))]
+        [NotifyPropertyChangedFor(nameof(CanConfirm))]
+        public partial string GridSizeText { get; set; } = Format(32);
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(RopePhysicsSpeed))]
@@ -233,6 +241,9 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Custom level height, or null when the box is empty or holds something unparseable.</summary>
         public decimal? CustomHeight { get => Parse(CustomHeightText); set => CustomHeightText = Format(value); }
 
+        /// <summary>Grid size, or null when the box is empty or holds something unparseable.</summary>
+        public decimal? GridSize { get => Parse(GridSizeText); set => GridSizeText = Format(value); }
+
         /// <summary>Rope simulation speed multiplier, or null when the box holds no usable number.</summary>
         public decimal? RopePhysicsSpeed { get => Parse(RopePhysicsSpeedText); set => RopePhysicsSpeedText = Format(value); }
 
@@ -257,6 +268,9 @@ namespace CtrDxEditor.ViewModels
         /// <summary>Why the height box is unusable, or empty text when it holds a valid height.</summary>
         public string CustomHeightError => Validate(CustomHeightText, MinHeight, MaxDimension);
 
+        /// <summary>Why the grid size box is unusable, or empty text when it holds a valid width.</summary>
+        public string GridSizeError => Validate(GridSizeText, MinGridSize, MaxDimension);
+
         /// <summary>Why the rope speed box is unusable, or empty text when it holds a valid speed.</summary>
         public string RopePhysicsSpeedError => Validate(RopePhysicsSpeedText, MinRopeSpeed, MaxRopeSpeed);
 
@@ -280,6 +294,9 @@ namespace CtrDxEditor.ViewModels
 
         /// <summary>Whether the height box has something to complain about.</summary>
         public bool HasCustomHeightError => CustomHeightError.Length > 0;
+
+        /// <summary>Whether the grid size box has something to complain about (bound to its message's visibility).</summary>
+        public bool HasGridSizeError => GridSizeError.Length > 0;
 
         /// <summary>Whether the rope speed box has something to complain about.</summary>
         public bool HasRopePhysicsSpeedError => RopePhysicsSpeedError.Length > 0;
@@ -369,7 +386,8 @@ namespace CtrDxEditor.ViewModels
             && GravityXError.Length == 0
             && GravityYError.Length == 0
             && (!IsCustom || (CustomWidthError.Length == 0 && CustomHeightError.Length == 0))
-            && (!IsSpecialCustom || CustomSpecialError.Length == 0);
+            && (!IsSpecialCustom || CustomSpecialError.Length == 0)
+            && GridSizeError.Length == 0;
 
         /// <summary>
         /// Reads a box's text as a number. Invariant culture because <c>NumericTextBox</c> only ever lets
@@ -588,6 +606,7 @@ namespace CtrDxEditor.ViewModels
                 GravityY = (decimal)current.GravityY,
                 CustomWidth = current.Width,
                 CustomHeight = current.Height,
+                GridSize = current.GridSize,
                 SelectedRopeSkin = ropeSkin,
                 SelectedBackground = background,
                 SelectedCandySkin = candySkin,
@@ -606,13 +625,15 @@ namespace CtrDxEditor.ViewModels
             int width = IsCustom ? ClampOrDefault(CustomWidth, MinWidth, MinWidth, MaxDimension) : SelectedPreset.Width;
             int height = IsCustom ? ClampOrDefault(CustomHeight, MinHeight, MinHeight, MaxDimension) : SelectedPreset.Height;
             int special = IsSpecialCustom ? ClampOrDefault(CustomSpecial, 0, 0, MaxSpecial) : SelectedSpecial.Value;
+            int gridSize = ClampOrDefault(GridSize, 32, MinGridSize, MaxDimension);
             float rope = (float)(RopePhysicsSpeed ?? 1.0m);
             return new LevelSettings(
                 width, height, rope, special, TwoParts, NightLevel, UseMobilePhysics,
                 (float)(Water ?? 0m), (float)(WaterSpeed ?? 0m),
                 LevelName?.Trim() ?? string.Empty,
                 (float)(GravityX ?? (decimal)LevelGravity.DefaultX),
-                (float)(GravityY ?? (decimal)LevelGravity.DefaultY));
+                (float)(GravityY ?? (decimal)LevelGravity.DefaultY),
+                gridSize);
         }
 
         private static RopeSkinOption[] BuildRopeSkinOptions()

--- a/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
+++ b/src/CtrDxEditor.Shared/Views/LevelSettingsDialog.axaml
@@ -161,6 +161,26 @@
 
         <StackPanel Spacing="4">
           <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{loc:Tr Dialog.LevelSettings.GridSize}"
+                       VerticalAlignment="Center" />
+            <ctrl:HelpButton Header="{loc:Tr Dialog.LevelSettings.GridSize}"
+                             Message="{loc:Tr Dialog.LevelSettings.GridSizeDescription}" />
+          </StackPanel>
+
+          <ctrl:NumericTextBox Minimum="1"
+                               Maximum="9999"
+                               AcceptDecimal="False"
+                               Text="{Binding GridSizeText, Mode=TwoWay}" />
+
+          <TextBlock Text="{Binding GridSizeError}"
+                     TextWrapping="Wrap"
+                     Foreground="{DynamicResource EditorBrush.DangerText}"
+                     FontSize="12"
+                     IsVisible="{Binding HasGridSizeError}" />
+        </StackPanel>
+
+        <StackPanel Spacing="4">
+          <StackPanel Orientation="Horizontal" Spacing="4">
             <TextBlock Text="{loc:Tr Dialog.LevelSettings.RopePhysicsSpeed}"
                        VerticalAlignment="Center" />
             <ctrl:HelpButton Header="{loc:Tr Dialog.LevelSettings.RopePhysicsSpeed}"


### PR DESCRIPTION
Adds a "Grid size" field into the level settings.
<img width="2269" height="1440" alt="imagen" src="https://github.com/user-attachments/assets/deef4ef8-6cfe-47a9-bf4b-6e98edabbfec" />
