### PR TITLE
fix: Defer level validation until save or playtest

### DIFF
--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -331,9 +331,9 @@ namespace CtrDxEditor.ViewModels
         }
 
         /// <summary>
-        /// Loads an already-parsed level into the editor. Callers that had to parse the document
-        /// ahead of time (the Open path validates before loading) pass it here rather than handing
-        /// back XML for a second parse. Must run on the UI thread: it refreshes bound collections.
+        /// Loads an already-parsed level into the editor. The Open path parses ahead of time and passes
+        /// the document here rather than handing back XML for a second parse. Must run on the UI thread:
+        /// it refreshes bound collections.
         /// </summary>
         public void LoadLevel(LevelDocument loaded)
         {

--- a/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.FileCommands.cs
@@ -170,13 +170,12 @@ namespace CtrDxEditor.Views
             }
         }
 
-        // The shared load path behind both the Open dialog and a window drop: read, parse, warn, confirm,
-        // then hand the XML to the view model. Reading through the stream rather than a local path keeps
+        // The shared load path behind both the Open dialog and a window drop: read, parse, then hand the
+        // document to the view model. Reading through the stream rather than a local path keeps
         // this working in the browser build, where IStorageFile exposes no filesystem path.
         private async Task OpenLevelFileAsync(EditorViewModel vm, IStorageFile file)
         {
             LevelDocument document;
-            IReadOnlyList<LevelWarning> warnings;
             try
             {
                 // The read stays here: it is async I/O that never blocks the thread, and on the
@@ -188,14 +187,10 @@ namespace CtrDxEditor.Views
                     xml = await reader.ReadToEndAsync();
                 }
 
-                // Parse and validation are pure CPU over the text and are the part that actually
-                // stalls the UI on a large level, so they go off-thread on desktop. The browser is
+                // Parsing is pure CPU over the text and is the part that actually stalls the UI on
+                // a large level, so it goes off-thread on desktop. The browser is
                 // single-threaded (no WasmEnableThreads), where this simply runs inline.
-                (document, warnings) = await Task.Run(() =>
-                {
-                    LevelDocument parsed = LevelDocument.Parse(xml);
-                    return (parsed, LevelValidator.Validate(parsed));
-                });
+                document = await Task.Run(() => LevelDocument.Parse(xml));
             }
             catch (Exception ex)
             {
@@ -209,11 +204,6 @@ namespace CtrDxEditor.Views
                 return;
             }
 
-            if (warnings.Count > 0
-                && !await ConfirmValidationAsync(warnings, "Dialog.Validation.EditPrompt", "Dialog.Validation.EditProceed"))
-            {
-                return;
-            }
             if (vm.IsModified && !await UnsavedChangesPrompt.ConfirmDiscardAsync("Dialog.Unsaved.Open"))
             {
                 return;

--- a/src/CtrDxEditor.Tests/LevelValidationTimingTests.cs
+++ b/src/CtrDxEditor.Tests/LevelValidationTimingTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Guards which user actions trigger level validation.</summary>
+    public sealed class LevelValidationTimingTests
+    {
+        /// <summary>Opening only parses; validation remains at the save and playtest boundaries.</summary>
+        [Fact]
+        public void ValidationRunsForSaveAndPlaytestButNotOpen()
+        {
+            string fileCommands = File.ReadAllText(SourcePath(
+                "CtrDxEditor.Shared", "Views", "MainView.FileCommands.cs"));
+            string playtestCommands = File.ReadAllText(SourcePath(
+                "CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+
+            string open = SliceBetween(fileCommands, "private async Task OpenLevelFileAsync", "private async void Close_Click");
+            string save = SliceBetween(fileCommands, "private static async Task<bool> CanSaveAsync", "private static async Task WriteXmlAsync");
+
+            Assert.DoesNotContain("LevelValidator.Validate(", open, StringComparison.Ordinal);
+            Assert.Contains("LevelValidator.Validate(doc)", save, StringComparison.Ordinal);
+            Assert.Contains("LevelValidator.Validate(doc)", playtestCommands, StringComparison.Ordinal);
+        }
+
+        private static string SliceBetween(string source, string startMarker, string endMarker)
+        {
+            int start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            int end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(start >= 0 && end > start);
+            return source[start..end];
+        }
+
+        private static string SourcePath(params string[] parts)
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir is not null && !Directory.Exists(Path.Combine(dir, "CtrDxEditor.Shared")))
+            {
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            Assert.NotNull(dir);
+            return Path.Combine([dir, .. parts]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Remove validation warnings upon opening a level
- Keep malformed-file errors and unsaved-change confirmation unchanged