### PR TITLE
feat: Playtest levels in the browser build

### DIFF
--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -544,6 +544,7 @@
     "Dialog.Playtest.Picker.Title": "Select the Cut the Rope: DX executable",
     "Dialog.FileType.Executable": "Application",
     "Notification.Playtest.Launching": "Launching Cut the Rope: DX…",
+    "Notification.Playtest.Reloaded": "Level sent to Cut the Rope: DX",
     "Notification.Playtest.Failed": "Could not play this level",
     "Notification.Playtest.LocationSet": "The location of Cut the Rope: DX has been set",
     "Notification.Playtest.Rejected": "Cut the Rope: DX could not load this level",

--- a/resources/localization/en.json
+++ b/resources/localization/en.json
@@ -481,8 +481,8 @@
     "Guide.Article.save-export-playtest.Summary": "Save XML, export a rendered image, and launch the level in Cut the Rope: DX.",
     "Guide.Article.save-export-playtest.SearchTerms": "save as|screenshot|png|playtest|dx location|export",
     "Guide.Article.save-export-playtest.Save": "**Save** writes to the current file when the platform supports it; **Save As** chooses a new destination. **Screenshot** exports the rendered level as a PNG.",
-    "Guide.Article.save-export-playtest.Playtest": "On desktop, point the editor at the game once with **File > Set DX Location**, then use **File > Play This Level**, which stays disabled until a location is set. The editor validates the level and writes a temporary playtest copy before launching, so you can try unsaved work.",
-    "Guide.Article.save-export-playtest.Browser.Warning": "The browser cannot launch a local game executable. This is by design to minimize security risks. Download or save the level, then open it with your desktop workflow.",
+    "Guide.Article.save-export-playtest.Playtest": "Use **File > Play This Level** to try unsaved work after the editor validates it. On desktop, first point the editor at the game with **File > Set DX Location**; in the browser, the game opens in a new browser tab or window, so allow pop-ups for the site.",
+    "Guide.Article.save-export-playtest.Browser.Warning": "Browser playtest requires the editor and game to be hosted on the same site, with pop-ups allowed.",
 
     "Guide.Article.troubleshooting.Title": "Troubleshooting",
     "Guide.Article.troubleshooting.Summary": "Resolve missing assets, disabled objects, unexpected selection, and playtest problems.",
@@ -546,6 +546,9 @@
     "Notification.Playtest.Launching": "Launching Cut the Rope: DX…",
     "Notification.Playtest.Failed": "Could not play this level",
     "Notification.Playtest.LocationSet": "The location of Cut the Rope: DX has been set",
+    "Notification.Playtest.Rejected": "Cut the Rope: DX could not load this level",
+    "Notification.Playtest.Blocked": "Your browser blocked the playtest",
+    "Notification.Playtest.BlockedBody": "Allow pop-ups for this site, or select this notification to open the playtest.",
 
     "Playtest.Unsupported.Header": "This may not be a compatible Cut the Rope: DX",
     "Playtest.Unsupported.Body": "This program did not identify itself as Cut the Rope: DX. It may be a different application, or a version too old to play test levels. Update the game, or pick the right program with File > Set DX Location.",

--- a/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
@@ -72,7 +72,10 @@ namespace CtrDxEditor.Browser.Playtest
         /// <para>
         /// This method is synchronous, and a cold launch cannot wait for the game to boot. So the XML
         /// is stashed and posted when the game announces itself; a second Play arriving first replaces
-        /// the stash rather than queueing, because only the newest level is worth sending.
+        /// the stash rather than queueing, because only the newest level is worth sending. The same
+        /// stash-and-replace applies to a reload that lands before the game has handshaken: the window
+        /// exists but nothing on the other end is subscribed to the channel yet, so a post made in that
+        /// window would be silently dropped rather than queued.
         /// </para>
         /// <para>
         /// <b>The window must be opened without an intervening await.</b> Browsers only allow
@@ -89,7 +92,19 @@ namespace CtrDxEditor.Browser.Playtest
 
             if (PlaytestInterop.IsGameOpen())
             {
-                PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, levelXml));
+                // Post directly only once the game has announced itself. Between window.open and the
+                // game's own subscribe there is a gap of seconds while its runtime boots, and a
+                // BroadcastChannel drops messages nobody is listening for yet - so during that window
+                // the newest level replaces the stash and OnReady delivers it instead.
+                if (_handshook)
+                {
+                    PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, levelXml));
+                }
+                else
+                {
+                    _pendingXml = levelXml;
+                }
+
                 return false;
             }
 

--- a/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
@@ -158,11 +158,15 @@ namespace CtrDxEditor.Browser.Playtest
                         break;
                     case PlaytestMessageKind.Ready:
                         break;
-                    case PlaytestMessageKind.Error:
+                    case PlaytestMessageKind.Error when IsOurs(nonce):
                         LevelRejected?.Invoke(this, new PlaytestLevelRejectedEventArgs(payload));
                         break;
-                    case PlaytestMessageKind.Bye:
+                    case PlaytestMessageKind.Error:
+                        break;
+                    case PlaytestMessageKind.Bye when IsOurs(nonce):
                         Exited?.Invoke(this, new PlaytestExitedEventArgs(0, string.Empty));
+                        break;
+                    case PlaytestMessageKind.Bye:
                         break;
                     case PlaytestMessageKind.Unknown:
                     case PlaytestMessageKind.Level:
@@ -180,6 +184,20 @@ namespace CtrDxEditor.Browser.Playtest
                 _sessionXml = null;
                 Unsupported?.Invoke(this, new PlaytestUnsupportedEventArgs("cuttherope-dx (browser)"));
             }
+        }
+
+        /// <summary>Whether a message belongs to this launcher's playtest session.</summary>
+        /// <param name="nonce">The nonce the message carried, empty when it carried none.</param>
+        /// <returns><see langword="true"/> when this launcher should act on the message.</returns>
+        /// <remarks>
+        /// Deliberately lenient about an absent nonce. A game build that predates per-session
+        /// addressing sends none, and dropping its messages would silently stop reporting rejected
+        /// levels; treating them as ours preserves exactly today's behaviour. Once both sides carry a
+        /// nonce, two concurrent playtests stop crossing wires.
+        /// </remarks>
+        private bool IsOurs(string nonce)
+        {
+            return nonce.Length == 0 || string.Equals(nonce, _nonce, StringComparison.Ordinal);
         }
 
         /// <summary>Answers a session that has announced itself, handing over the level it is waiting for.</summary>

--- a/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
@@ -1,0 +1,185 @@
+using System;
+
+using Avalonia.Threading;
+
+using CtrDxEditor.Playtest;
+
+namespace CtrDxEditor.Browser.Playtest
+{
+    /// <summary>Plays levels in the browser build of Cut the Rope: DX over a BroadcastChannel.</summary>
+    /// <remarks>
+    /// The browser counterpart of the desktop process launcher, and it keeps that type's contract
+    /// exactly: <see cref="Play"/> returns true for a cold launch and false for a reload, so the
+    /// shared view layer needs no per-platform branch.
+    /// <para>
+    /// The level travels in the message rather than through any storage. That matches desktop, where
+    /// the temp level file is deleted when the editor session ends - level availability is tied to
+    /// editor liveness on both heads - and it avoids leaving a stale copy of somebody's level sitting
+    /// in browser storage forever.
+    /// </para>
+    /// </remarks>
+    public sealed class BroadcastPlaytestLauncher : IPlaytestLauncher
+    {
+        /// <summary>
+        /// How long a freshly opened game has to announce itself before it is judged not to be a
+        /// compatible build. Generous, but it does not have to cover the game's ~56 MB content
+        /// download: the game announces itself before it starts loading content.
+        /// </summary>
+        private static readonly TimeSpan HandshakeGracePeriod = TimeSpan.FromSeconds(15);
+
+        /// <summary>How often to check the channel for replies.</summary>
+        private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
+        // A dispatcher timer rather than a System.Timers one: this head is single-threaded, and the
+        // events raised from Drain land straight on the UI thread the view already marshals to.
+        private readonly DispatcherTimer _poll = new() { Interval = PollInterval };
+        private string _nonce = "";
+        private string? _pendingXml;
+        private DateTime _handshakeDeadline = DateTime.MaxValue;
+        private bool _handshook;
+        private bool _disposed;
+
+        /// <summary>Creates a launcher and opens the channel.</summary>
+        public BroadcastPlaytestLauncher()
+        {
+            PlaytestInterop.Open();
+            _poll.Tick += (_, _) => Drain();
+            _poll.Start();
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<PlaytestExitedEventArgs>? Exited;
+
+        /// <inheritdoc />
+        public event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
+
+        /// <inheritdoc />
+        public event EventHandler<PlaytestLevelRejectedEventArgs>? LevelRejected;
+
+        /// <inheritdoc />
+        /// <remarks>False: the game is a URL on this origin, not a program the user picks.</remarks>
+        public bool RequiresLocation => false;
+
+        /// <summary>Whether the launch attempt was blocked by the browser's popup blocker.</summary>
+        /// <remarks>
+        /// Read by the view straight after <see cref="Play"/> so it can offer the user a fresh click.
+        /// See the remarks on <see cref="Play"/> for when this can happen.
+        /// </remarks>
+        public bool LastLaunchBlocked { get; private set; }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <para>
+        /// This method is synchronous, and a cold launch cannot wait for the game to boot. So the XML
+        /// is stashed and posted when the game announces itself; a second Play arriving first replaces
+        /// the stash rather than queueing, because only the newest level is worth sending.
+        /// </para>
+        /// <para>
+        /// <b>The window must be opened without an intervening await.</b> Browsers only allow
+        /// <c>window.open</c> while a user gesture is still on the stack. Awaiting an already-completed
+        /// task continues synchronously and keeps the gesture, which is why the warning-free path works;
+        /// awaiting a real dialog does not, and <see cref="LastLaunchBlocked"/> is how the caller
+        /// recovers. Adding an await ahead of this call breaks the common path silently.
+        /// </para>
+        /// </remarks>
+        public bool Play(string? executablePath, string levelXml)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            LastLaunchBlocked = false;
+
+            if (PlaytestInterop.IsGameOpen())
+            {
+                PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, levelXml));
+                return false;
+            }
+
+            _nonce = Guid.NewGuid().ToString("N")[..8];
+            _pendingXml = levelXml;
+            _handshook = false;
+            _handshakeDeadline = DateTime.UtcNow + HandshakeGracePeriod;
+
+            if (!PlaytestInterop.Launch(_nonce))
+            {
+                LastLaunchBlocked = true;
+                _handshakeDeadline = DateTime.MaxValue;
+                _pendingXml = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            _poll.Stop();
+        }
+
+        /// <summary>Reads whatever the game has said and acts on it.</summary>
+        private void Drain()
+        {
+            foreach (string json in PlaytestInterop.Drain())
+            {
+                if (!PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload))
+                {
+                    continue;
+                }
+
+                switch (kind)
+                {
+                    case PlaytestMessageKind.Ready when string.Equals(nonce, _nonce, StringComparison.Ordinal):
+                        OnReady(payload);
+                        break;
+                    case PlaytestMessageKind.Ready:
+                        break;
+                    case PlaytestMessageKind.Error:
+                        LevelRejected?.Invoke(this, new PlaytestLevelRejectedEventArgs(payload));
+                        break;
+                    case PlaytestMessageKind.Bye:
+                        Exited?.Invoke(this, new PlaytestExitedEventArgs(0, string.Empty));
+                        break;
+                    case PlaytestMessageKind.Unknown:
+                    case PlaytestMessageKind.Level:
+                    default:
+                        break;
+                }
+            }
+
+            // A game that never announces itself is a build too old to understand ?playtest=, which
+            // ignores the parameter and opens the normal game. That is exactly what the desktop head
+            // reports when no stdout handshake arrives.
+            if (!_handshook && DateTime.UtcNow > _handshakeDeadline)
+            {
+                _handshakeDeadline = DateTime.MaxValue;
+                _pendingXml = null;
+                Unsupported?.Invoke(this, new PlaytestUnsupportedEventArgs("cuttherope-dx (browser)"));
+            }
+        }
+
+        /// <summary>Answers a session that has announced itself, handing over the level it is waiting for.</summary>
+        /// <param name="handshakeLine">The <c>ctrdx-playtest</c> line the game announced.</param>
+        private void OnReady(string handshakeLine)
+        {
+            // Parsed with the same parser that reads the desktop game's stdout: a build that greets us
+            // with something malformed is no more trustworthy than one that says nothing.
+            if (!PlaytestHandshakeLine.TryParse(handshakeLine, out _, out _))
+            {
+                return;
+            }
+
+            _handshook = true;
+            _handshakeDeadline = DateTime.MaxValue;
+
+            if (_pendingXml is { } xml)
+            {
+                _pendingXml = null;
+                PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, xml));
+            }
+        }
+    }
+}

--- a/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
@@ -18,7 +18,7 @@ namespace CtrDxEditor.Browser.Playtest
     /// in browser storage forever.
     /// </para>
     /// </remarks>
-    public sealed class BroadcastPlaytestLauncher : IPlaytestLauncher
+    public sealed class BroadcastPlaytestLauncher : IPlaytestLauncher, IBlockableLauncher
     {
         /// <summary>
         /// How long a freshly opened game has to announce itself before it is judged not to be a

--- a/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Browser/Playtest/BroadcastPlaytestLauncher.cs
@@ -34,7 +34,12 @@ namespace CtrDxEditor.Browser.Playtest
         // events raised from Drain land straight on the UI thread the view already marshals to.
         private readonly DispatcherTimer _poll = new() { Interval = PollInterval };
         private string _nonce = "";
-        private string? _pendingXml;
+
+        /// <summary>
+        /// The level the current session is playing. Kept after delivery rather than cleared, so a
+        /// game window the user reloads can be answered when it announces itself a second time.
+        /// </summary>
+        private string? _sessionXml;
         private DateTime _handshakeDeadline = DateTime.MaxValue;
         private bool _handshook;
         private bool _disposed;
@@ -92,24 +97,25 @@ namespace CtrDxEditor.Browser.Playtest
 
             if (PlaytestInterop.IsGameOpen())
             {
+                // Remembered on every Play, not just the cold launch: after a few hot reloads this
+                // is what a refreshed window must be given, and the level from the original launch
+                // would be the wrong one.
+                _sessionXml = levelXml;
+
                 // Post directly only once the game has announced itself. Between window.open and the
                 // game's own subscribe there is a gap of seconds while its runtime boots, and a
-                // BroadcastChannel drops messages nobody is listening for yet - so during that window
-                // the newest level replaces the stash and OnReady delivers it instead.
+                // BroadcastChannel drops messages nobody is listening for yet - during that window
+                // OnReady delivers it instead.
                 if (_handshook)
                 {
                     PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, levelXml));
-                }
-                else
-                {
-                    _pendingXml = levelXml;
                 }
 
                 return false;
             }
 
             _nonce = Guid.NewGuid().ToString("N")[..8];
-            _pendingXml = levelXml;
+            _sessionXml = levelXml;
             _handshook = false;
             _handshakeDeadline = DateTime.UtcNow + HandshakeGracePeriod;
 
@@ -117,7 +123,7 @@ namespace CtrDxEditor.Browser.Playtest
             {
                 LastLaunchBlocked = true;
                 _handshakeDeadline = DateTime.MaxValue;
-                _pendingXml = null;
+                _sessionXml = null;
                 return false;
             }
 
@@ -171,7 +177,7 @@ namespace CtrDxEditor.Browser.Playtest
             if (!_handshook && DateTime.UtcNow > _handshakeDeadline)
             {
                 _handshakeDeadline = DateTime.MaxValue;
-                _pendingXml = null;
+                _sessionXml = null;
                 Unsupported?.Invoke(this, new PlaytestUnsupportedEventArgs("cuttherope-dx (browser)"));
             }
         }
@@ -190,9 +196,11 @@ namespace CtrDxEditor.Browser.Playtest
             _handshook = true;
             _handshakeDeadline = DateTime.MaxValue;
 
-            if (_pendingXml is { } xml)
+            // Deliberately not cleared after sending. A playtest window the user refreshes boots
+            // again and announces itself a second time; answering that with the level this session is
+            // playing is what stops a refresh dropping the user into the normal game.
+            if (_sessionXml is { } xml)
             {
-                _pendingXml = null;
                 PlaytestInterop.Post(PlaytestChannelMessage.FormatLevel(_nonce, xml));
             }
         }

--- a/src/CtrDxEditor.Browser/Playtest/PlaytestInterop.cs
+++ b/src/CtrDxEditor.Browser/Playtest/PlaytestInterop.cs
@@ -1,0 +1,41 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+
+namespace CtrDxEditor.Browser.Playtest
+{
+    /// <summary>Thin managed wrapper over the playtest.js BroadcastChannel module.</summary>
+    internal static partial class PlaytestInterop
+    {
+        /// <summary>Imports playtest.js. Must be awaited once before any other call.</summary>
+        /// <returns>A task that completes when the module is available.</returns>
+        public static Task ImportAsync()
+        {
+            return JSHost.ImportAsync("playtest", "../playtest.js");
+        }
+
+        /// <summary>Opens the channel and begins queueing incoming messages.</summary>
+        [JSImport("open", "playtest")]
+        public static partial void Open();
+
+        /// <summary>Posts one JSON message on the channel.</summary>
+        /// <param name="json">Message text from <see cref="CtrDxEditor.Playtest.PlaytestChannelMessage"/>.</param>
+        [JSImport("post", "playtest")]
+        public static partial void Post(string json);
+
+        /// <summary>Takes every message queued since the previous call.</summary>
+        /// <returns>The queued messages, oldest first; empty when none arrived.</returns>
+        [JSImport("drain", "playtest")]
+        public static partial string[] Drain();
+
+        /// <summary>Opens the game in a new window with a playtest nonce.</summary>
+        /// <param name="nonce">The session nonce to launch with.</param>
+        /// <returns>False when the browser blocked the popup.</returns>
+        [JSImport("launch", "playtest")]
+        public static partial bool Launch(string nonce);
+
+        /// <summary>Whether a launched game window is still open.</summary>
+        /// <returns>True while the window exists and has not been closed.</returns>
+        [JSImport("isGameOpen", "playtest")]
+        public static partial bool IsGameOpen();
+    }
+}

--- a/src/CtrDxEditor.Browser/Program.cs
+++ b/src/CtrDxEditor.Browser/Program.cs
@@ -5,6 +5,7 @@ using Avalonia.Browser;
 
 using CtrDxEditor;
 using CtrDxEditor.Browser.Content;
+using CtrDxEditor.Browser.Playtest;
 using CtrDxEditor.Content;
 using CtrDxEditor.Startup;
 
@@ -13,6 +14,7 @@ using CtrDxEditor.Startup;
 await IndexedDb.ImportAsync();
 await WebCrypto.ImportAsync();
 await SafeAreaInterop.ImportAsync();
+await PlaytestInterop.ImportAsync();
 await BuildAvaloniaApp().StartBrowserAppAsync("out");
 
 AppBuilder BuildAvaloniaApp()
@@ -37,6 +39,7 @@ AppBuilder BuildAvaloniaApp()
             double[] i = SafeAreaInterop.ReadInsets();
             return new Thickness(i[0], i[1], i[2], i[3]);
         },
+        Playtest = new BroadcastPlaytestLauncher(),
     };
     return AppBuilder.Configure(() => new App(startup)).WithBundledInterFont();
 }

--- a/src/CtrDxEditor.Browser/wwwroot/playtest.js
+++ b/src/CtrDxEditor.Browser/wwwroot/playtest.js
@@ -1,0 +1,59 @@
+// Playtest transport. The game ships to the same origin as the editor, so a BroadcastChannel
+// reaches it and window.open starts it. Avalonia's own Launcher cannot be used for the launch: its
+// browser implementation is `openUri(u, t) { return !!window.open(u, t); }`, which throws the window
+// handle away, and the handle is the only reliable way to tell whether the game is still open.
+
+const CHANNEL = "ctrdx-playtest";
+
+let channel = null;
+let inbox = [];
+let gameWindow = null;
+
+/** Opens the channel and starts queueing messages. Safe to call more than once. */
+export function open() {
+    if (channel) {
+        return;
+    }
+    channel = new BroadcastChannel(CHANNEL);
+    channel.onmessage = (event) => {
+        if (typeof event.data === "string") {
+            inbox.push(event.data);
+        }
+    };
+}
+
+/** Posts one JSON message. A no-op before open(). */
+export function post(json) {
+    channel?.postMessage(json);
+}
+
+/** Takes every message queued since the last call. */
+export function drain() {
+    if (inbox.length === 0) {
+        return [];
+    }
+    const taken = inbox;
+    inbox = [];
+    return taken;
+}
+
+/**
+ * Opens the game with a playtest nonce and keeps the handle.
+ *
+ * The URL is derived from this page's own location rather than configured, so the same-origin rule
+ * the channel depends on cannot silently drift: if the game were ever served from somewhere else,
+ * the channel would be dead too.
+ *
+ * @returns {boolean} false when the browser blocked the popup.
+ */
+export function launch(nonce) {
+    const url = new URL("../cuttherope-dx/", globalThis.location.href);
+    url.searchParams.set("playtest", nonce);
+    gameWindow = globalThis.open(url.href, "ctrdx-playtest");
+    return gameWindow !== null;
+}
+
+/** Whether a game window opened by launch() is still open. */
+export function isGameOpen() {
+    return gameWindow !== null && !gameWindow.closed;
+}

--- a/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Desktop/Playtest/ProcessPlaytestLauncher.cs
@@ -35,9 +35,23 @@ namespace CtrDxEditor.Desktop.Playtest
         public event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
 
         /// <inheritdoc />
-        public bool Play(string executablePath, string levelXml)
+        /// <remarks>
+        /// Never raised here. A desktop game reports a level it cannot load by writing to standard
+        /// error and exiting non-zero, which already surfaces through <see cref="Exited"/>.
+        /// </remarks>
+#pragma warning disable CS0067 // Raised only by heads whose transport carries diagnostics back.
+        public event EventHandler<PlaytestLevelRejectedEventArgs>? LevelRejected;
+#pragma warning restore CS0067
+
+        /// <inheritdoc />
+        /// <remarks>True: there is no way to find an arbitrary user's game install.</remarks>
+        public bool RequiresLocation => true;
+
+        /// <inheritdoc />
+        public bool Play(string? executablePath, string levelXml)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
+            ArgumentNullException.ThrowIfNull(executablePath);
 
             // Resolved before the write so an unusable executable fails without leaving a level file
             // behind that a later, valid launch would silently inherit.

--- a/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
@@ -47,13 +47,17 @@ namespace CtrDxEditor.Playtest
     /// <summary>Plays a level in Cut the Rope: DX. Absent on platforms that cannot spawn processes.</summary>
     public interface IPlaytestLauncher : IDisposable
     {
-        /// <summary>Raised when the playtest process exits. Not raised on the UI thread.</summary>
+        /// <summary>
+        /// Raised when the playtest process exits. The raising thread is not guaranteed to be the UI
+        /// thread - implementations differ - so handlers must marshal to it themselves.
+        /// </summary>
         event EventHandler<PlaytestExitedEventArgs>? Exited;
 
         /// <summary>
         /// Raised when a freshly launched process produced no Cut the Rope: DX handshake within the grace
-        /// period - it is a different program, or a build too old to understand <c>--level</c>. Not raised
-        /// on the UI thread, and never raised for a reload (<see cref="Play"/> returning false).
+        /// period - it is a different program, or a build too old to understand <c>--level</c>. The
+        /// raising thread is not guaranteed to be the UI thread, so handlers must marshal to it
+        /// themselves; never raised for a reload (<see cref="Play"/> returning false).
         /// </summary>
         event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
 
@@ -69,7 +73,8 @@ namespace CtrDxEditor.Playtest
         bool RequiresLocation { get; }
 
         /// <summary>
-        /// Raised when a running game reports a level it could not load. Not raised on the UI thread.
+        /// Raised when a running game reports a level it could not load. The raising thread is not
+        /// guaranteed to be the UI thread, so handlers must marshal to it themselves.
         /// </summary>
         /// <remarks>
         /// Deliberately separate from <see cref="Exited"/>: the game has not exited, it is still

--- a/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
@@ -22,6 +22,14 @@ namespace CtrDxEditor.Playtest
         public string ExecutablePath { get; } = executablePath;
     }
 
+    /// <summary>Describes a level a running game refused to load.</summary>
+    /// <param name="message">The game's own description of what was wrong with the level.</param>
+    public sealed class PlaytestLevelRejectedEventArgs(string message) : EventArgs
+    {
+        /// <summary>The game's own description of what was wrong with the level.</summary>
+        public string Message { get; } = message;
+    }
+
     /// <summary>Plays a level in Cut the Rope: DX. Absent on platforms that cannot spawn processes.</summary>
     public interface IPlaytestLauncher : IDisposable
     {
@@ -35,8 +43,33 @@ namespace CtrDxEditor.Playtest
         /// </summary>
         event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
 
+        /// <summary>
+        /// Whether <see cref="Play"/> needs a user-picked executable. False on heads that always know
+        /// where the game is - the browser, which opens a URL rather than a program.
+        /// </summary>
+        /// <remarks>
+        /// Callers use this to decide whether to gate Play on a stored location and whether to offer a
+        /// "set location" command at all. A head that answers false must accept null for
+        /// <c>executablePath</c>.
+        /// </remarks>
+        bool RequiresLocation { get; }
+
+        /// <summary>
+        /// Raised when a running game reports a level it could not load. Not raised on the UI thread.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately separate from <see cref="Exited"/>: the game has not exited, it is still
+        /// running the level it had before, so reporting this as an exit would misdescribe it. Only
+        /// heads whose transport carries diagnostics back raise this; desktop reports the equivalent
+        /// through <see cref="Exited"/>'s standard error.
+        /// </remarks>
+        event EventHandler<PlaytestLevelRejectedEventArgs>? LevelRejected;
+
         /// <summary>Writes <paramref name="levelXml"/> to the session level file, starting the game if it is not already running.</summary>
-        /// <param name="executablePath">The user-picked executable or macOS .app bundle path.</param>
+        /// <param name="executablePath">
+        /// The user-picked executable or macOS .app bundle path; null on heads where
+        /// <see cref="RequiresLocation"/> is false.
+        /// </param>
         /// <param name="levelXml">Serialized level XML to play.</param>
         /// <returns>
         /// True when a new game process was started; false when a already-running game was handed the
@@ -48,6 +81,6 @@ namespace CtrDxEditor.Playtest
         /// reloads itself, so a second process would be wrong rather than merely wasteful.
         /// </remarks>
         /// <exception cref="InvalidOperationException">The executable could not be resolved.</exception>
-        bool Play(string executablePath, string levelXml);
+        bool Play(string? executablePath, string levelXml);
     }
 }

--- a/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
+++ b/src/CtrDxEditor.Shared/Playtest/IPlaytestLauncher.cs
@@ -30,6 +30,20 @@ namespace CtrDxEditor.Playtest
         public string Message { get; } = message;
     }
 
+    /// <summary>
+    /// Implemented by launchers whose launch can be refused by the environment rather than failing.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="IPlaytestLauncher"/> because only the browser can experience it: a
+    /// pop-up blocker rejects <c>window.open</c> when the user gesture that authorized it has been
+    /// spent on an intervening dialog. Desktop has no equivalent and does not implement this.
+    /// </remarks>
+    public interface IBlockableLauncher
+    {
+        /// <summary>Whether the most recent launch attempt was refused by the environment.</summary>
+        bool LastLaunchBlocked { get; }
+    }
+
     /// <summary>Plays a level in Cut the Rope: DX. Absent on platforms that cannot spawn processes.</summary>
     public interface IPlaytestLauncher : IDisposable
     {

--- a/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
+++ b/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
@@ -40,7 +40,7 @@ namespace CtrDxEditor.Playtest
         public const int Version = 1;
 
         // Relaxed escaping keeps a level from ballooning: the default encoder escapes '<' and '>' as
-        // < and >, and level XML is mostly those two characters. (The double quote is not a
+        // \u003C and \u003E, and level XML is mostly those two characters. (The double quote is not a
         // reason to relax - JSON escapes it as \" under either encoder.) Relaxing is safe here because
         // these strings are never interpolated into HTML: they go to postMessage and back through
         // JSON.parse.

--- a/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
+++ b/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
@@ -1,0 +1,197 @@
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace CtrDxEditor.Playtest
+{
+    /// <summary>The kinds of message the browser playtest channel carries.</summary>
+    public enum PlaytestMessageKind
+    {
+        /// <summary>Not a message this protocol version understands.</summary>
+        Unknown = 0,
+
+        /// <summary>Game to editor: a playtest session booted and is waiting for its level.</summary>
+        Ready,
+
+        /// <summary>Editor to game: the level XML to run.</summary>
+        Level,
+
+        /// <summary>Game to editor: the level could not be loaded.</summary>
+        Error,
+
+        /// <summary>Game to editor: the playtest window is going away.</summary>
+        Bye,
+    }
+
+    /// <summary>
+    /// Encodes and decodes the JSON the editor and the browser build of Cut the Rope: DX exchange
+    /// over the <c>ctrdx-playtest</c> BroadcastChannel.
+    /// </summary>
+    /// <remarks>
+    /// A browser tab has no command line, so this channel replaces <c>--level</c>. The launch URL's
+    /// <c>?playtest=</c> parameter only marks the session; the level itself arrives as a
+    /// <see cref="PlaytestMessageKind.Level"/> message. The game implements the same format, and the
+    /// literal wire strings asserted by both repositories' tests are the contract between them.
+    /// </remarks>
+    public static class PlaytestChannelMessage
+    {
+        /// <summary>Protocol version stamped on, and required of, every message.</summary>
+        public const int Version = 1;
+
+        // Relaxed escaping keeps a level from ballooning: the default encoder escapes '<' and '>' as
+        // < and >, and level XML is mostly those two characters. (The double quote is not a
+        // reason to relax - JSON escapes it as \" under either encoder.) Relaxing is safe here because
+        // these strings are never interpolated into HTML: they go to postMessage and back through
+        // JSON.parse.
+        private static readonly JsonWriterOptions WriterOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        /// <summary>Builds the handshake a booting playtest session announces itself with.</summary>
+        /// <param name="nonce">Session nonce from the launch URL, echoed so only its own editor answers.</param>
+        /// <param name="handshakeLine">A <c>ctrdx-playtest &lt;protocol&gt; &lt;version&gt;</c> line.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatReady(string nonce, string handshakeLine)
+        {
+            return Write("ready", nonce, "line", handshakeLine);
+        }
+
+        /// <summary>Builds the message carrying a level to a playtest session.</summary>
+        /// <param name="nonce">Session nonce the target window announced.</param>
+        /// <param name="xml">Serialized level XML.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatLevel(string nonce, string xml)
+        {
+            return Write("level", nonce, "xml", xml);
+        }
+
+        /// <summary>Builds the message reporting a level the game could not load.</summary>
+        /// <param name="message">Human-readable failure reason.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatError(string message)
+        {
+            return Write("error", null, "message", message);
+        }
+
+        /// <summary>Builds the message announcing that a playtest window is going away.</summary>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatBye()
+        {
+            return Write("bye", null, null, null);
+        }
+
+        /// <summary>Decodes one channel message.</summary>
+        /// <param name="json">The raw string received on the channel.</param>
+        /// <param name="kind">Receives the message kind, or <see cref="PlaytestMessageKind.Unknown"/> on failure.</param>
+        /// <param name="nonce">Receives the session nonce, or an empty string when absent.</param>
+        /// <param name="payload">Receives the kind's single string field, or an empty string when absent.</param>
+        /// <returns><see langword="true"/> for a message this build understands.</returns>
+        /// <remarks>
+        /// A wrong version, an unknown type and malformed JSON all return <see langword="false"/> rather
+        /// than throwing, so a future protocol talking to this build degrades to silence.
+        /// </remarks>
+        public static bool TryParse(string? json, out PlaytestMessageKind kind, out string nonce, out string payload)
+        {
+            kind = PlaytestMessageKind.Unknown;
+            nonce = "";
+            payload = "";
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    return false;
+                }
+
+                if (!root.TryGetProperty("v", out JsonElement version)
+                    || version.ValueKind != JsonValueKind.Number
+                    || !version.TryGetInt32(out int parsedVersion)
+                    || parsedVersion != Version)
+                {
+                    return false;
+                }
+
+                if (!root.TryGetProperty("type", out JsonElement type) || type.ValueKind != JsonValueKind.String)
+                {
+                    return false;
+                }
+
+                switch (type.GetString())
+                {
+                    case "ready":
+                        kind = PlaytestMessageKind.Ready;
+                        payload = ReadString(root, "line");
+                        break;
+                    case "level":
+                        kind = PlaytestMessageKind.Level;
+                        payload = ReadString(root, "xml");
+                        break;
+                    case "error":
+                        kind = PlaytestMessageKind.Error;
+                        payload = ReadString(root, "message");
+                        break;
+                    case "bye":
+                        kind = PlaytestMessageKind.Bye;
+                        break;
+                    default:
+                        return false;
+                }
+
+                nonce = ReadString(root, "nonce");
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Reads an optional string property, treating absence and wrong type alike.</summary>
+        /// <param name="root">The message object.</param>
+        /// <param name="name">Property name.</param>
+        /// <returns>The value, or an empty string.</returns>
+        private static string ReadString(JsonElement root, string name)
+        {
+            return root.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString() ?? ""
+                : "";
+        }
+
+        /// <summary>Serializes one message. Property order is the wire contract, so it is fixed here.</summary>
+        /// <param name="type">The <c>type</c> discriminator.</param>
+        /// <param name="nonce">Session nonce, or null to omit the property.</param>
+        /// <param name="fieldName">Name of the kind's single payload property, or null to omit it.</param>
+        /// <param name="fieldValue">Value for <paramref name="fieldName"/>.</param>
+        /// <returns>The JSON text.</returns>
+        private static string Write(string type, string? nonce, string? fieldName, string? fieldValue)
+        {
+            using MemoryStream stream = new();
+            using (Utf8JsonWriter writer = new(stream, WriterOptions))
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("v", Version);
+                writer.WriteString("type", type);
+                if (nonce != null)
+                {
+                    writer.WriteString("nonce", nonce);
+                }
+                if (fieldName != null)
+                {
+                    writer.WriteString(fieldName, fieldValue);
+                }
+                writer.WriteEndObject();
+            }
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+    }
+}

--- a/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
+++ b/src/CtrDxEditor.Shared/Playtest/PlaytestChannelMessage.cs
@@ -68,18 +68,20 @@ namespace CtrDxEditor.Playtest
         }
 
         /// <summary>Builds the message reporting a level the game could not load.</summary>
+        /// <param name="nonce">Session nonce, so only the editor that opened that window reacts.</param>
         /// <param name="message">Human-readable failure reason.</param>
         /// <returns>JSON to post on the channel.</returns>
-        public static string FormatError(string message)
+        public static string FormatError(string nonce, string message)
         {
-            return Write("error", null, "message", message);
+            return Write("error", nonce, "message", message);
         }
 
         /// <summary>Builds the message announcing that a playtest window is going away.</summary>
+        /// <param name="nonce">Session nonce, so only the editor that opened that window reacts.</param>
         /// <returns>JSON to post on the channel.</returns>
-        public static string FormatBye()
+        public static string FormatBye(string nonce)
         {
-            return Write("bye", null, null, null);
+            return Write("bye", nonce, null, null);
         }
 
         /// <summary>Decodes one channel message.</summary>

--- a/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
+++ b/src/CtrDxEditor.Shared/Startup/PlatformStartup.cs
@@ -36,7 +36,7 @@ namespace CtrDxEditor.Startup
         /// <summary>Whether the in-app direct download is offered; false where a cross-origin fetch is blocked (the browser), leaving only manual download + zip upload.</summary>
         public bool AllowDirectDownload { get; init; } = true;
 
-        /// <summary>Plays levels in Cut the Rope: DX for playtesting; null where processes cannot be spawned (the browser).</summary>
+        /// <summary>Plays levels in Cut the Rope: DX for playtesting; null where no launcher is available for the head.</summary>
         public IPlaytestLauncher? Playtest { get; init; }
 
         /// <summary>Draws the user's attention to the editor window (taskbar flash / dock bounce); null where unavailable (the browser).</summary>

--- a/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
+++ b/src/CtrDxEditor.Shared/ViewModels/EditorViewModel.cs
@@ -70,8 +70,15 @@ namespace CtrDxEditor.ViewModels
         /// </remarks>
         public bool HasDxLocation => !string.IsNullOrWhiteSpace(CurrentSettingsSnapshot.DxExecutablePath);
 
-        /// <summary>True when a level can actually be handed to the game; enables the playtest commands.</summary>
-        public bool CanLaunchPlaytest => HasDocument && HasDxLocation;
+        /// <summary>Whether Play can run now: a level is open, and a location is set if one is needed.</summary>
+        public bool CanLaunchPlaytest =>
+            HasDocument && (Playtest is { RequiresLocation: false } || HasDxLocation);
+
+        /// <summary>
+        /// Whether to offer the "set DX location" command. False where the launcher needs no
+        /// executable, since a file picker would there ask for something that is never used.
+        /// </summary>
+        public bool CanSetDxLocation => Playtest is { RequiresLocation: true };
 
         /// <summary>
         /// Re-reads <see cref="HasDxLocation"/> after the settings snapshot's path is written. The snapshot
@@ -81,6 +88,7 @@ namespace CtrDxEditor.ViewModels
         {
             OnPropertyChanged(nameof(HasDxLocation));
             OnPropertyChanged(nameof(CanLaunchPlaytest));
+            OnPropertyChanged(nameof(CanSetDxLocation));
         }
 
         /// <summary>

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -15,10 +15,10 @@ using CtrDxEditor.ViewModels;
 
 namespace CtrDxEditor.Views
 {
-    // Playtest commands: hand the open level to Cut the Rope: DX via --level. The launcher owns the
-    // temp file and the macOS .app resolution, so this file only deals with confirmation, recovering a
-    // stored path that no longer resolves, and reporting failures. Play stays disabled until a location
-    // is set (EditorViewModel.CanLaunchPlaytest), so the picker here is recovery, not first run.
+    // Playtest commands: hand the open level to Cut the Rope: DX through the active head's launcher.
+    // The desktop launcher owns the temp file and executable resolution; the browser launcher owns its
+    // game window and channel. This file deals with confirmation, location recovery where applicable,
+    // and reporting failures.
     //
     // Clicking Play while a game is already running is not an error: the launcher rewrites the level
     // file, the game's own watcher notices, and it reloads in place. No second process, no toast -
@@ -47,10 +47,18 @@ namespace CtrDxEditor.Views
                 }
             }
 
-            string? executable = await EnsureDxExecutableAsync(vm);
-            if (executable is null)
+            // Only a head that needs an executable is asked for one. Beyond being meaningless in a
+            // browser, this call must not happen there for a second reason: it awaits a dialog, and
+            // window.open is only permitted while the user's click is still on the stack. Keeping
+            // the browser's warning-free path free of any real await is what makes launching work.
+            string? executable = null;
+            if (launcher.RequiresLocation)
             {
-                return; // No path chosen; the user cancelled.
+                executable = await EnsureDxExecutableAsync(vm);
+                if (executable is null)
+                {
+                    return; // No path chosen; the user cancelled.
+                }
             }
 
             if (vm.ToXml() is not { } xml)
@@ -71,6 +79,17 @@ namespace CtrDxEditor.Views
                         Localizer.Get("Notification.Playtest.Launching"),
                         string.Empty,
                         NotificationType.Information));
+                }
+                else if (WasLaunchBlocked(launcher))
+                {
+                    // Only reachable when a validation dialog was confirmed first: awaiting a real
+                    // dialog spends the user gesture that window.open needs, and the browser refuses.
+                    // Selecting this notification is a fresh gesture, so the retry succeeds.
+                    Notifications()?.Show(new Notification(
+                        Localizer.Get("Notification.Playtest.Blocked"),
+                        Localizer.Get("Notification.Playtest.BlockedBody"),
+                        NotificationType.Warning,
+                        onClick: () => _ = launcher.Play(executable, xml)));
                 }
             }
             // Catch-all on purpose: this is an async void handler, so anything that escapes is an
@@ -142,6 +161,25 @@ namespace CtrDxEditor.Views
                     _ = dialog.ShowAsync();
                 });
             };
+
+            // The game is still running the level it had before, so this is a notification rather
+            // than the dialog an unsupported launch raises: nothing needs acknowledging, and the
+            // user is looking at the game window anyway.
+            launcher.LevelRejected += (_, args) =>
+            {
+                Dispatcher.UIThread.Post(() => Notifications()?.Show(new Notification(
+                    Localizer.Get("Notification.Playtest.Rejected"),
+                    args.Message,
+                    NotificationType.Error)));
+            };
+        }
+
+        // Asked through a narrow capability interface: only the browser head can have a launch
+        // blocked, and widening IPlaytestLauncher for it would put a browser concern in every head's
+        // contract.
+        private static bool WasLaunchBlocked(IPlaytestLauncher launcher)
+        {
+            return launcher is IBlockableLauncher { LastLaunchBlocked: true };
         }
 
         // Returns a usable executable path, prompting on first use or when the stored one has gone

--- a/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
+++ b/src/CtrDxEditor.Shared/Views/MainView.PlaytestCommands.cs
@@ -70,9 +70,11 @@ namespace CtrDxEditor.Views
 
             try
             {
-                // Only a cold launch is announced. A reload returns false: the game flashes its own
-                // restart dim, and a toast in a window the user has just switched away from would
-                // report something they cannot see.
+                // Both a cold launch and a reload are announced. The game is never raised on a
+                // reload - deliberately, since desktop does not raise it either - so the user is
+                // still looking at the editor, where the game's own restart dim is invisible to
+                // them. Without this toast, pressing Play on a running game looks like nothing
+                // happened at all.
                 if (launcher.Play(executable, xml))
                 {
                     Notifications()?.Show(new Notification(
@@ -90,6 +92,15 @@ namespace CtrDxEditor.Views
                         Localizer.Get("Notification.Playtest.BlockedBody"),
                         NotificationType.Warning,
                         onClick: () => _ = launcher.Play(executable, xml)));
+                }
+                else
+                {
+                    // "Sent" rather than "reloaded" on purpose: the level either went to a live game
+                    // or was stashed for one that is still booting, and this wording is true of both.
+                    Notifications()?.Show(new Notification(
+                        Localizer.Get("Notification.Playtest.Reloaded"),
+                        string.Empty,
+                        NotificationType.Success));
                 }
             }
             // Catch-all on purpose: this is an async void handler, so anything that escapes is an

--- a/src/CtrDxEditor.Shared/Views/MainView.axaml
+++ b/src/CtrDxEditor.Shared/Views/MainView.axaml
@@ -76,7 +76,7 @@
           </MenuItem.Header>
         </MenuItem>
         <MenuItem Header="{loc:Tr Menu.File.SetDxLocation}" Click="SetDxLocation_Click"
-                  IsVisible="{Binding CanPlaytest}">
+                  IsVisible="{Binding CanSetDxLocation}">
           <MenuItem.Icon>
             <icons:MaterialIcon Kind="FolderCogOutline" />
           </MenuItem.Icon>
@@ -912,7 +912,7 @@
                              Text="{loc:Tr Menu.File.Playtest, Plain=True}" />
                 </Grid>
               </Button>
-              <Button Classes="drawerRow" Click="DrawerSetDxLocation_Click" IsVisible="{Binding CanPlaytest}">
+              <Button Classes="drawerRow" Click="DrawerSetDxLocation_Click" IsVisible="{Binding CanSetDxLocation}">
                 <Grid ColumnDefinitions="Auto,*">
                   <icons:MaterialIcon Grid.Column="0" Kind="FolderCogOutline" Width="20" Height="20"
                                       VerticalAlignment="Center" />

--- a/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
@@ -73,7 +73,7 @@ namespace CtrDxEditor.Tests
         [Fact]
         public void ErrorRoundTrips()
         {
-            string json = PlaytestChannelMessage.FormatError("Level file contains no root element.");
+            string json = PlaytestChannelMessage.FormatError("abc", "Level file contains no root element.");
 
             bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out _, out string payload);
 
@@ -86,7 +86,7 @@ namespace CtrDxEditor.Tests
         [Fact]
         public void ByeRoundTrips()
         {
-            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye(),
+            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye("abc"),
                 out PlaytestMessageKind kind, out _, out _);
 
             Assert.True(ok);
@@ -134,13 +134,13 @@ namespace CtrDxEditor.Tests
         [Fact]
         public void WireFormatIsStable()
         {
-            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\",\"nonce\":\"abc\"}", PlaytestChannelMessage.FormatBye("abc"));
             Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
                 PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
             Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
                 PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
-            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
-                PlaytestChannelMessage.FormatError("boom"));
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"nonce\":\"abc\",\"message\":\"boom\"}",
+                PlaytestChannelMessage.FormatError("abc", "boom"));
         }
     }
 }

--- a/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
@@ -1,0 +1,144 @@
+using System.Linq;
+
+using CtrDxEditor.Playtest;
+
+using Xunit;
+
+namespace CtrDxEditor.Tests
+{
+    /// <summary>Tests for the browser playtest channel's message format.</summary>
+    public class PlaytestChannelMessageTests
+    {
+        /// <summary>Verifies a ready message survives a round trip.</summary>
+        [Fact]
+        public void ReadyRoundTrips()
+        {
+            string json = PlaytestChannelMessage.FormatReady("a1b2c3d4", "ctrdx-playtest 1 1.0.0");
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Ready, kind);
+            Assert.Equal("a1b2c3d4", nonce);
+            Assert.Equal("ctrdx-playtest 1 1.0.0", payload);
+        }
+
+        /// <summary>Verifies a ready payload is parsable by the desktop handshake parser.</summary>
+        [Fact]
+        public void ReadyPayloadIsADesktopHandshakeLine()
+        {
+            // One handshake contract across both transports: whatever arrives over the channel must
+            // go through the same parser that reads the game's stdout on desktop.
+            string json = PlaytestChannelMessage.FormatReady("n", "ctrdx-playtest 1 2.3.4");
+            _ = PlaytestChannelMessage.TryParse(json, out _, out _, out string line);
+
+            bool parsed = PlaytestHandshakeLine.TryParse(line, out int protocol, out string version);
+
+            Assert.True(parsed);
+            Assert.Equal(1, protocol);
+            Assert.Equal("2.3.4", version);
+        }
+
+        /// <summary>Verifies a level message survives a round trip.</summary>
+        [Fact]
+        public void LevelRoundTrips()
+        {
+            string xml = "<map><candy x=\"1\" y=\"2\" /></map>";
+            string json = PlaytestChannelMessage.FormatLevel("nonce123", xml);
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Level, kind);
+            Assert.Equal("nonce123", nonce);
+            Assert.Equal(xml, payload);
+        }
+
+        /// <summary>Verifies a level far larger than any shipped map survives a round trip.</summary>
+        [Fact]
+        public void LevelRoundTripsALargeCommunityScaleLevel()
+        {
+            // Real community levels reach ~112 KB, and the editor caps nothing.
+            string xml = "<map>" + string.Concat(Enumerable.Repeat(
+                "<grab x=\"159\" y=\"337\" length=\"90\" wheel=\"false\" gun=\"false\" />", 20000)) + "</map>";
+            string json = PlaytestChannelMessage.FormatLevel("n", xml);
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out _, out _, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(xml, payload);
+        }
+
+        /// <summary>Verifies an error message survives a round trip.</summary>
+        [Fact]
+        public void ErrorRoundTrips()
+        {
+            string json = PlaytestChannelMessage.FormatError("Level file contains no root element.");
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out _, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Error, kind);
+            Assert.Equal("Level file contains no root element.", payload);
+        }
+
+        /// <summary>Verifies a bye message survives a round trip.</summary>
+        [Fact]
+        public void ByeRoundTrips()
+        {
+            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye(),
+                out PlaytestMessageKind kind, out _, out _);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Bye, kind);
+        }
+
+        /// <summary>Verifies malformed input is rejected rather than throwing.</summary>
+        /// <param name="json">Input that is not a valid message.</param>
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not json at all")]
+        [InlineData("[1,2,3]")]
+        [InlineData("\"a string\"")]
+        [InlineData("{}")]
+        [InlineData("{\"type\":\"bye\"}")]
+        [InlineData("{\"v\":\"1\",\"type\":\"bye\"}")]
+        public void MalformedInputIsRejected(string json)
+        {
+            Assert.False(PlaytestChannelMessage.TryParse(json, out _, out _, out _));
+        }
+
+        /// <summary>Verifies an unrecognised type degrades to silence.</summary>
+        [Fact]
+        public void UnknownTypeIsIgnoredRatherThanThrowing()
+        {
+            Assert.False(PlaytestChannelMessage.TryParse(
+                "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
+        }
+
+        /// <summary>Verifies a message from another protocol version is ignored.</summary>
+        [Fact]
+        public void MismatchedVersionIsIgnored()
+        {
+            Assert.False(PlaytestChannelMessage.TryParse(
+                "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
+        }
+
+        /// <summary>
+        /// Pins the exact wire strings. These literals are the contract with cuttherope-dx, whose
+        /// PlaytestChannelMessageTests asserts the identical set. Changing one side fails the other.
+        /// </summary>
+        [Fact]
+        public void WireFormatIsStable()
+        {
+            Assert.Equal("{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal("{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
+                PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
+            Assert.Equal("{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
+                PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
+            Assert.Equal("{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
+                PlaytestChannelMessage.FormatError("boom"));
+        }
+    }
+}

--- a/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestChannelMessageTests.cs
@@ -102,8 +102,8 @@ namespace CtrDxEditor.Tests
         [InlineData("[1,2,3]")]
         [InlineData("\"a string\"")]
         [InlineData("{}")]
-        [InlineData("{\"type\":\"bye\"}")]
-        [InlineData("{\"v\":\"1\",\"type\":\"bye\"}")]
+        [InlineData(/*lang=json,strict*/ "{\"type\":\"bye\"}")]
+        [InlineData(/*lang=json,strict*/ "{\"v\":\"1\",\"type\":\"bye\"}")]
         public void MalformedInputIsRejected(string json)
         {
             Assert.False(PlaytestChannelMessage.TryParse(json, out _, out _, out _));
@@ -114,7 +114,8 @@ namespace CtrDxEditor.Tests
         public void UnknownTypeIsIgnoredRatherThanThrowing()
         {
             Assert.False(PlaytestChannelMessage.TryParse(
-                "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
+                                     /*lang=json,strict*/
+                                     "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
         }
 
         /// <summary>Verifies a message from another protocol version is ignored.</summary>
@@ -122,7 +123,8 @@ namespace CtrDxEditor.Tests
         public void MismatchedVersionIsIgnored()
         {
             Assert.False(PlaytestChannelMessage.TryParse(
-                "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
+                                     /*lang=json,strict*/
+                                     "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
         }
 
         /// <summary>
@@ -132,12 +134,12 @@ namespace CtrDxEditor.Tests
         [Fact]
         public void WireFormatIsStable()
         {
-            Assert.Equal("{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
-            Assert.Equal("{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
                 PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
-            Assert.Equal("{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
                 PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
-            Assert.Equal("{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
                 PlaytestChannelMessage.FormatError("boom"));
         }
     }

--- a/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 
 using CtrDxEditor.Content;
+using CtrDxEditor.Playtest;
 using CtrDxEditor.ViewModels;
 
 using Xunit;
@@ -145,6 +146,113 @@ namespace CtrDxEditor.Tests
 
             int notify = source.IndexOf("vm.NotifyDxLocationChanged();", StringComparison.Ordinal);
             Assert.True(notify > assignment, "The notification belongs after the path is stored.");
+        }
+
+        /// <summary>Builds a view model around a specific launcher, which the existing helper never sets.</summary>
+        /// <param name="launcher">The launcher to install, or null for a head without playtest.</param>
+        /// <param name="dxPath">Stored executable path, if any.</param>
+        /// <returns>A view model with no level loaded.</returns>
+        private static EditorViewModel VmWith(IPlaytestLauncher? launcher, string? dxPath = null)
+        {
+            return new EditorViewModel(
+                new SpriteCache(new EmptyContentStore()),
+                initial: new EditorSettings { DxExecutablePath = dxPath },
+                playtest: launcher);
+        }
+
+        /// <summary>
+        /// A head whose launcher needs no executable can play as soon as a level is open, and offers
+        /// no "set location" command. The browser has nothing to point at, so gating on a stored path
+        /// there would disable Play permanently.
+        /// </summary>
+        [Fact]
+        public void LauncherWithoutLocationRequirementCanPlayWithNoStoredPath()
+        {
+            EditorViewModel vm = VmWith(new StubLauncher { RequiresLocation = false });
+            vm.LoadLevelXml(Level);
+
+            Assert.True(vm.CanPlaytest);
+            Assert.True(vm.CanLaunchPlaytest);
+            Assert.False(vm.CanSetDxLocation);
+        }
+
+        /// <summary>A head that does need an executable still gates Play on having picked one.</summary>
+        [Fact]
+        public void LauncherRequiringLocationStillGatesOnStoredPath()
+        {
+            EditorViewModel vm = VmWith(new StubLauncher { RequiresLocation = true });
+            vm.LoadLevelXml(Level);
+
+            Assert.False(vm.CanLaunchPlaytest);
+            Assert.True(vm.CanSetDxLocation);
+
+            vm.CurrentSettingsSnapshot.DxExecutablePath = "/Applications/Cut the Rope DX.app";
+            vm.NotifyDxLocationChanged();
+
+            Assert.True(vm.CanLaunchPlaytest);
+        }
+
+        /// <summary>A head with no launcher at all offers neither command, whatever is stored.</summary>
+        [Fact]
+        public void NoLauncherOffersNeitherCommand()
+        {
+            EditorViewModel vm = VmWith(null, "/Applications/Cut the Rope DX.app");
+            vm.LoadLevelXml(Level);
+
+            Assert.False(vm.CanPlaytest);
+            Assert.False(vm.CanSetDxLocation);
+        }
+
+        /// <summary>
+        /// Setting a location has to announce the set-location gate as well as the play gate, or the
+        /// menu item's visibility goes stale.
+        /// </summary>
+        [Fact]
+        public void NotifyingALocationChangeRaisesTheSetLocationGate()
+        {
+            EditorViewModel vm = VmWith(new StubLauncher { RequiresLocation = true });
+
+            bool raised = false;
+            vm.PropertyChanged += (_, e) =>
+                raised |= e.PropertyName == nameof(EditorViewModel.CanSetDxLocation);
+
+            vm.NotifyDxLocationChanged();
+
+            Assert.True(raised);
+        }
+
+        /// <summary>A launcher that records calls and launches nothing.</summary>
+        private sealed class StubLauncher : IPlaytestLauncher
+        {
+            /// <inheritdoc />
+            public event EventHandler<PlaytestExitedEventArgs>? Exited;
+
+            /// <inheritdoc />
+            public event EventHandler<PlaytestUnsupportedEventArgs>? Unsupported;
+
+            /// <inheritdoc />
+            public event EventHandler<PlaytestLevelRejectedEventArgs>? LevelRejected;
+
+            /// <inheritdoc />
+            public bool RequiresLocation { get; init; }
+
+            /// <summary>The XML handed to the most recent <see cref="Play"/> call.</summary>
+            public string? LastXml { get; private set; }
+
+            /// <inheritdoc />
+            public bool Play(string? executablePath, string levelXml)
+            {
+                LastXml = levelXml;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+                Exited = null;
+                Unsupported = null;
+                LevelRejected = null;
+            }
         }
 
         private static string SourcePath(params string[] parts)

--- a/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json;
 
 using CtrDxEditor.Content;
 using CtrDxEditor.Playtest;
@@ -219,6 +220,71 @@ namespace CtrDxEditor.Tests
             vm.NotifyDxLocationChanged();
 
             Assert.True(raised);
+        }
+
+        /// <summary>
+        /// A browser launcher must reach Play without opening the desktop-only location dialog first.
+        /// Besides being meaningless in a browser, that await would spend the gesture needed by
+        /// window.open and make the normal launch path popup-blocked.
+        /// </summary>
+        [Fact]
+        public void LocationLookupIsGatedByTheLaunchersRequirement()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+
+            int gate = source.IndexOf("if (launcher.RequiresLocation)", StringComparison.Ordinal);
+            int lookup = source.IndexOf("await EnsureDxExecutableAsync(vm)", StringComparison.Ordinal);
+
+            Assert.True(gate >= 0, "Location lookup should be guarded by RequiresLocation.");
+            Assert.True(lookup > gate, "The guarded block should contain the location lookup.");
+        }
+
+        /// <summary>A blocked browser launch offers a fresh user gesture that retries the same level.</summary>
+        [Fact]
+        public void BlockedLaunchOffersAnInAppRetry()
+        {
+            Assert.NotNull(typeof(IBlockableLauncher).GetProperty(nameof(IBlockableLauncher.LastLaunchBlocked)));
+
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+            Assert.Contains("else if (WasLaunchBlocked(launcher))", source, StringComparison.Ordinal);
+            Assert.Contains("onClick: () => _ = launcher.Play(executable, xml)", source, StringComparison.Ordinal);
+        }
+
+        /// <summary>A rejected level is surfaced with localized copy and the game's diagnostic.</summary>
+        [Fact]
+        public void RejectedLevelHasLocalizedNotificationWiring()
+        {
+            string source = File.ReadAllText(SourcePath("CtrDxEditor.Shared", "Views", "MainView.PlaytestCommands.cs"));
+            Assert.Contains("launcher.LevelRejected +=", source, StringComparison.Ordinal);
+            Assert.Contains("Localizer.Get(\"Notification.Playtest.Rejected\")", source, StringComparison.Ordinal);
+            Assert.Contains("args.Message", source, StringComparison.Ordinal);
+
+            string sourceDirectory = Directory.GetParent(SourcePath("CtrDxEditor.Shared"))?.FullName
+                ?? throw new InvalidOperationException("Could not locate source directory.");
+            string repositoryRoot = Directory.GetParent(sourceDirectory)?.FullName
+                ?? throw new InvalidOperationException("Could not locate repository root.");
+            string localizationPath = Path.Combine(
+                repositoryRoot,
+                "resources",
+                "localization",
+                "en.json");
+            using JsonDocument localization = JsonDocument.Parse(File.ReadAllText(localizationPath));
+            JsonElement root = localization.RootElement;
+            Assert.True(root.TryGetProperty("Notification.Playtest.Rejected", out _));
+            Assert.Equal(
+                "Your browser blocked the playtest",
+                root.GetProperty("Notification.Playtest.Blocked").GetString());
+            Assert.Equal(
+                "Allow pop-ups for this site, or select this notification to open the playtest.",
+                root.GetProperty("Notification.Playtest.BlockedBody").GetString());
+            Assert.False(root.TryGetProperty("Notification.Playtest.BlockedAction", out _));
+            Assert.Contains(
+                "the game opens in a new browser tab or window",
+                root.GetProperty("Guide.Article.save-export-playtest.Playtest").GetString(),
+                StringComparison.Ordinal);
+            Assert.Equal(
+                "Browser playtest requires the editor and game to be hosted on the same site, with pop-ups allowed.",
+                root.GetProperty("Guide.Article.save-export-playtest.Browser.Warning").GetString());
         }
 
         /// <summary>A launcher that records calls and launches nothing.</summary>

--- a/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
+++ b/src/CtrDxEditor.Tests/PlaytestGatingTests.cs
@@ -224,6 +224,8 @@ namespace CtrDxEditor.Tests
         /// <summary>A launcher that records calls and launches nothing.</summary>
         private sealed class StubLauncher : IPlaytestLauncher
         {
+#pragma warning disable CS0067
+            // Declared to satisfy IPlaytestLauncher; a stub that launches nothing never raises them.
             /// <inheritdoc />
             public event EventHandler<PlaytestExitedEventArgs>? Exited;
 
@@ -232,6 +234,7 @@ namespace CtrDxEditor.Tests
 
             /// <inheritdoc />
             public event EventHandler<PlaytestLevelRejectedEventArgs>? LevelRejected;
+#pragma warning restore CS0067
 
             /// <inheritdoc />
             public bool RequiresLocation { get; init; }
@@ -249,9 +252,6 @@ namespace CtrDxEditor.Tests
             /// <inheritdoc />
             public void Dispose()
             {
-                Exited = null;
-                Unsupported = null;
-                LevelRejected = null;
             }
         }
 


### PR DESCRIPTION
## Description

Adds playtest to the browser build of the editor. Press Play and the level opens in the browser build of *Cut the Rope: DX*; press it again and the running game reloads in place, the same loop desktop build already has.

### How it works

Both apps ship to the same origin, so the editor opens the game with `window.open` and sends the level over a `BroadcastChannel`. The game's URL is derived from `location.href` rather than configured, which keeps the same-origin requirement self-enforcing: if the game were served elsewhere the channel would be dead too, so a configurable URL would only hide the breakage.

`Play` keeps desktop's exact contract - `true` = cold launch (announce it), `false` = reload (stay silent) - so the shared view layer needs no per-platform branch.

### Changes

- `IPlaytestLauncher` gains `RequiresLocation`: The browser has no executable to point at, so it declares as much and Play stops gating on a stored path. "Set DX Location" is hidden there rather than offering a file picker for something that cannot exist.

- `LevelRejected` is a separate event, not folded into `Exited`: When the game refuses a level it has not exited - it is still running the previous one, so reporting it as an exit would misdescribe it.

- `window.open` must not sit behind a real `await`: Browsers only permit it while a user gesture is on the stack. `Playtest_Click` therefore skips the executable lookup entirely when the launcher does not need one, keeping the warning-free path synchronous from click to launch. When a validation dialog does spend the gesture, `IBlockableLauncher` surfaces the refusal and the editor offers a notification whose click supplies a fresh one.

- Avalonia's own `Launcher.LaunchUriAsync` is not used: Its browser implementation is `openUri(u, t) { return !!window.open(u, t); }` - it discards the window handle, and that handle is the only reliable way to tell whether the game is still open.

- The level travels in the message, not in storage: see [this PR](https://github.com/yell0wsuit/cuttherope-dx/pull/328).