### PR TITLE
chore: Bump xunit to v4 and run tests on Microsoft.Testing.Platform

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,6 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
     <PackageVersion Include="Material.Icons.Avalonia" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
     "sdk": {
         "version": "10.0.302",
         "rollForward": "latestFeature"
+    },
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
     }
 }

--- a/src/CtrDxEditor.Core.Tests/CtrDxEditor.Core.Tests.csproj
+++ b/src/CtrDxEditor.Core.Tests/CtrDxEditor.Core.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CtrDxEditor.Core\CtrDxEditor.Core.csproj" />

--- a/src/CtrDxEditor.Tests/CtrDxEditor.Tests.csproj
+++ b/src/CtrDxEditor.Tests/CtrDxEditor.Tests.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CtrDxEditor.Shared\CtrDxEditor.Shared.csproj" />


### PR DESCRIPTION
## Description

Bumps xunit from 3.2.2 to 4.0.0 and moves both test projects off VSTest onto Microsoft.Testing.Platform.

The two are one change rather than two. xunit 4.0.0 ships as `xunit.v3.mtp-v2` and discontinues MTP v1, and MTP v2 removes the VSTest-bridge path on the .NET 10 SDK, so bumping the version and picking a runner are the same decision.