### PR TITLE
fix: Match the game's background tiling and overlay placement

### DIFF
--- a/src/CtrDxEditor.Core.Tests/BackgroundLayoutCacheTests.cs
+++ b/src/CtrDxEditor.Core.Tests/BackgroundLayoutCacheTests.cs
@@ -32,7 +32,7 @@ namespace CtrDxEditor.Core.Tests
         public void CachedValueIsReturnedOnHit()
         {
             BackgroundLayoutCache cache = new();
-            BackgroundLayout expected = new(12, 34, 56, 78, 1.0, [], []);
+            BackgroundLayout expected = new(12, 34, 56, 78, 1.0, [], null);
 
             BackgroundLayout first = cache.Get(800, 600, 0, 0.5, 0.25, () => expected);
             BackgroundLayout second = cache.Get(800, 600, 0, 0.5, 0.25, Empty);
@@ -109,7 +109,7 @@ namespace CtrDxEditor.Core.Tests
 
         private static BackgroundLayout Empty()
         {
-            return new BackgroundLayout(0, 0, 0, 0, 1.0, [], []);
+            return new BackgroundLayout(0, 0, 0, 0, 1.0, [], null);
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/BackgroundLayoutCacheTests.cs
+++ b/src/CtrDxEditor.Core.Tests/BackgroundLayoutCacheTests.cs
@@ -32,7 +32,7 @@ namespace CtrDxEditor.Core.Tests
         public void CachedValueIsReturnedOnHit()
         {
             BackgroundLayoutCache cache = new();
-            BackgroundLayout expected = new(12, 34, 56, null, []);
+            BackgroundLayout expected = new(12, 34, 56, 78, 1.0, [], []);
 
             BackgroundLayout first = cache.Get(800, 600, 0, 0.5, 0.25, () => expected);
             BackgroundLayout second = cache.Get(800, 600, 0, 0.5, 0.25, Empty);
@@ -109,7 +109,7 @@ namespace CtrDxEditor.Core.Tests
 
         private static BackgroundLayout Empty()
         {
-            return new BackgroundLayout(0, 0, 0, null, []);
+            return new BackgroundLayout(0, 0, 0, 0, 1.0, [], []);
         }
     }
 }

--- a/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
+++ b/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
@@ -9,7 +9,8 @@ namespace CtrDxEditor.Core.Tests
     /// Tests for placing the level-decoration background the way the game does: the p1 texture is given a
     /// cover fit against the internal screen (2560x1440, i.e. 2560/3 x 1440/3 in level space) and repeated
     /// on both axes from a grid anchored on that screen's centre; a p2 layer dresses each seam between p1
-    /// sections; and the cosmic box's earth rides along with a single copy per oversized axis.
+    /// sections; and the p2 band and the cosmic box's earth ride that repeat rather than being anchored
+    /// to one section.
     /// </summary>
     public class BackgroundPlacementTests
     {
@@ -198,90 +199,53 @@ namespace CtrDxEditor.Core.Tests
             BackgroundLayout layout = BackgroundPlacement.Compute(
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9);
 
-            Assert.Empty(layout.EarthCenters);
+            Assert.Null(layout.EarthOffset);
         }
 
-        /// <summary>A single-screen cosmic box draws one earth at earthBgPosition ÷ MapScale, grid-offset.</summary>
+        /// <summary>
+        /// The earth is placed within its p1 tile, not within the map: the offset is earthBgPosition
+        /// scaled into level units, which the renderer adds to each tile's own corner.
+        /// </summary>
         [Fact]
-        public void EarthCenteredAtScaledPosition()
+        public void EarthIsOffsetWithinItsTile()
         {
             BackgroundLayout layout = BackgroundPlacement.Compute(
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9,
                 earthPosition: new Vec2(1284, 724));
 
-            Vec2 earth = Assert.Single(layout.EarthCenters);
-            Assert.Equal(layout.Left + (1284.0 / 3.0), earth.X, precision: 9);
+            Vec2 earth = Assert.NotNull(layout.EarthOffset);
+            Assert.Equal(1284.0 / 3.0, earth.X, precision: 9);
             Assert.Equal(724.0 / 3.0, earth.Y, precision: 9);
         }
 
         /// <summary>The earth's authored position is in texture pixels too, so it takes the cover scale.</summary>
         [Fact]
-        public void EarthPositionTakesTheCoverScale()
+        public void EarthOffsetTakesTheCoverScale()
         {
             BackgroundLayout layout = BackgroundPlacement.Compute(
                 levelWidth: 320, levelHeight: 480, p1Aspect: Bgr11Aspect, p1TextureWidth: Bgr11Width,
                 earthPosition: new Vec2(1284, 724));
 
-            Vec2 earth = Assert.Single(layout.EarthCenters);
-            Assert.Equal(layout.Left + (1284.0 * 1.25 / 3.0), earth.X, precision: 9);
-            Assert.Equal(layout.Top + (724.0 * 1.25 / 3.0), earth.Y, precision: 9);
-        }
-
-        /// <summary>Maps wider than one screen (mapWidth &gt; 2560) get a second earth one tile right.</summary>
-        [Fact]
-        public void WideMapDuplicatesEarthHorizontally()
-        {
-            // levelWidth 1000 -> mapWidth 3000 > 2560, so a horizontal copy is added; height stays 1 screen.
-            BackgroundLayout layout = BackgroundPlacement.Compute(
-                levelWidth: 1000, levelHeight: 480, p1Aspect: P1Aspect16By9,
-                earthPosition: new Vec2(1284, 724));
-
-            Assert.Equal(2, layout.EarthCenters.Count);
-            Vec2 baseEarth = layout.EarthCenters[0];
-            Vec2 copy = layout.EarthCenters[1];
-            Assert.Equal(baseEarth.X + layout.Width, copy.X, precision: 9);
-            Assert.Equal(baseEarth.Y, copy.Y, precision: 9);
-        }
-
-        /// <summary>Maps taller than one screen (mapHeight &gt; 1440) get a second earth one tile down.</summary>
-        [Fact]
-        public void TallMapDuplicatesEarthVertically()
-        {
-            // levelHeight 960 -> mapHeight 2880 > 1440, so a vertical copy is added; width stays 1 screen.
-            BackgroundLayout layout = BackgroundPlacement.Compute(
-                levelWidth: 320, levelHeight: 960, p1Aspect: P1Aspect16By9,
-                earthPosition: new Vec2(1284, 724));
-
-            Assert.Equal(2, layout.EarthCenters.Count);
-            Vec2 baseEarth = layout.EarthCenters[0];
-            Vec2 copy = layout.EarthCenters[1];
-            Assert.Equal(baseEarth.X, copy.X, precision: 9);
-            Assert.Equal(baseEarth.Y + layout.TileHeight, copy.Y, precision: 9);
-        }
-
-        /// <summary>A map larger than one screen in both axes gets all three earths (base + two copies).</summary>
-        [Fact]
-        public void LargeMapDrawsThreeEarths()
-        {
-            BackgroundLayout layout = BackgroundPlacement.Compute(
-                levelWidth: 1000, levelHeight: 960, p1Aspect: P1Aspect16By9,
-                earthPosition: new Vec2(1284, 724));
-
-            Assert.Equal(3, layout.EarthCenters.Count);
+            Vec2 earth = Assert.NotNull(layout.EarthOffset);
+            Assert.Equal(1284.0 * 1.25 / 3.0, earth.X, precision: 9);
+            Assert.Equal(724.0 * 1.25 / 3.0, earth.Y, precision: 9);
         }
 
         /// <summary>
-        /// However far a map runs on, the earth still gets only one copy per axis: the p1 grid repeats
-        /// without limit, the earth does not (GameScene.LoadMetadata's map case).
+        /// The offset does not depend on the map: a wide or tall level repeats the same tile-relative
+        /// earth over its extra sections rather than being given a different placement.
         /// </summary>
         [Fact]
-        public void EarthNeverExceedsThreeCopies()
+        public void EarthOffsetIsIndependentOfMapSize()
         {
-            BackgroundLayout layout = BackgroundPlacement.Compute(
+            BackgroundLayout small = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9,
+                earthPosition: new Vec2(1284, 724));
+            BackgroundLayout large = BackgroundPlacement.Compute(
                 levelWidth: 4000, levelHeight: 4000, p1Aspect: P1Aspect16By9,
                 earthPosition: new Vec2(1284, 724));
 
-            Assert.Equal(3, layout.EarthCenters.Count);
+            Assert.Equal(small.EarthOffset, large.EarthOffset);
         }
 
         /// <summary>A missing p2 (no p2Y) yields no p2 even for tall maps.</summary>

--- a/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
+++ b/src/CtrDxEditor.Core.Tests/BackgroundPlacementTests.cs
@@ -6,18 +6,23 @@ using Xunit;
 namespace CtrDxEditor.Core.Tests
 {
     /// <summary>
-    /// Tests for placing the level-decoration background the way the game does: the p1 texture is
-    /// scaled to the internal screen width (2560, i.e. 2560/3 in level space), centered on the map,
-    /// and repeated vertically; a p2 layer is drawn once for maps taller than one screen.
+    /// Tests for placing the level-decoration background the way the game does: the p1 texture is given a
+    /// cover fit against the internal screen (2560x1440, i.e. 2560/3 x 1440/3 in level space) and repeated
+    /// on both axes from a grid anchored on that screen's centre; a p2 layer dresses each seam between p1
+    /// sections; and the cosmic box's earth rides along with a single copy per oversized axis.
     /// </summary>
     public class BackgroundPlacementTests
     {
-        // A 16:9 p1 background (2560x1440 -> aspect 0.5625) fills one screen height exactly.
+        // A 16:9 p1 background (2560x1440 -> aspect 0.5625) fills one screen exactly, at scale 1.
         private const double P1Aspect16By9 = 9.0 / 16.0;
 
-        /// <summary>The p1 column is the internal screen width in level units, centered on the map.</summary>
+        // bgr_11 is authored at 2048x1153: a quarter under the design width, so its cover scale is 1.25.
+        private const double Bgr11Width = 2048.0;
+        private const double Bgr11Aspect = 1153.0 / 2048.0;
+
+        /// <summary>A design-width p1 tile is the internal screen width in level units, centered on the map.</summary>
         [Fact]
-        public void P1ColumnIsScreenWidthCenteredOnMap()
+        public void P1TileIsScreenWidthCenteredOnMap()
         {
             BackgroundLayout layout = BackgroundPlacement.Compute(
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9);
@@ -27,7 +32,7 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal((320 - screenW) / 2.0, layout.Left, precision: 9);
         }
 
-        /// <summary>A 16:9 p1 tile is exactly one screen (480 level units) tall.</summary>
+        /// <summary>A 16:9 p1 tile is exactly one screen (480 level units) tall, and needs no vertical offset.</summary>
         [Fact]
         public void P1TileHeightPreservesAspect()
         {
@@ -35,9 +40,40 @@ namespace CtrDxEditor.Core.Tests
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9);
 
             Assert.Equal(480, layout.TileHeight, precision: 9);
+            Assert.Equal(0, layout.Top, precision: 9);
+            Assert.Equal(1.0, layout.Scale, precision: 9);
         }
 
-        /// <summary>Single-screen maps (height 480 -> internal 1440, not &gt; SCREEN_HEIGHT) get no p2.</summary>
+        /// <summary>
+        /// Art authored below the design width still draws one screen wide - the cover fit scales it up -
+        /// and reports that scale for the overlays drawn in the background's matrix.
+        /// </summary>
+        [Fact]
+        public void UnderWidthArtIsCoverScaledToTheScreen()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 480, p1Aspect: Bgr11Aspect, p1TextureWidth: Bgr11Width);
+
+            Assert.Equal(2560.0 / 3.0, layout.Width, precision: 9);
+            Assert.Equal(1.25, layout.Scale, precision: 9);
+            Assert.Equal(1153.0 * 1.25 / 3.0, layout.TileHeight, precision: 9);
+        }
+
+        /// <summary>
+        /// The tile grid is centered on the design screen vertically, so art slightly off 16:9 starts just
+        /// above the map's top edge rather than flush with it.
+        /// </summary>
+        [Fact]
+        public void GridIsCenteredOnTheDesignScreenVertically()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 480, p1Aspect: Bgr11Aspect, p1TextureWidth: Bgr11Width);
+
+            Assert.Equal((480.0 - layout.TileHeight) / 2.0, layout.Top, precision: 9);
+            Assert.True(layout.Top < 0);
+        }
+
+        /// <summary>Single-screen maps (height 480 -> internal 1440) have no seam, so no p2.</summary>
         [Fact]
         public void NoP2ForSingleScreenMaps()
         {
@@ -45,10 +81,10 @@ namespace CtrDxEditor.Core.Tests
                 levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9,
                 p2Aspect: 884.0 / 2559.0, p2Y: 1120);
 
-            Assert.Null(layout.P2);
+            Assert.Empty(layout.P2);
         }
 
-        /// <summary>Tall maps draw p2 once, full screen width, at p2Y/MapScale, aspect-preserved.</summary>
+        /// <summary>Tall maps draw p2 at the seam, full tile width, aspect-preserved.</summary>
         [Fact]
         public void P2ForTallMapsPlacedAtP2Y()
         {
@@ -57,12 +93,102 @@ namespace CtrDxEditor.Core.Tests
                 levelWidth: 320, levelHeight: 960, p1Aspect: P1Aspect16By9,
                 p2Aspect: p2Aspect, p2Y: 1120);
 
-            LevelBounds p2 = Assert.NotNull(layout.P2);
+            LevelBounds p2 = Assert.Single(layout.P2);
             double screenW = 2560.0 / 3.0;
             Assert.Equal(layout.Left, p2.X, precision: 9);
             Assert.Equal(1120.0 / 3.0, p2.Y, precision: 9);
             Assert.Equal(screenW, p2.W, precision: 9);
             Assert.Equal(screenW * p2Aspect, p2.H, precision: 9);
+        }
+
+        /// <summary>
+        /// p2Y is authored in p1 texture pixels, which the cover scale stretches along with the art: on
+        /// bgr_11 that is the difference between sitting on the seam and a sixth of a screen above it.
+        /// </summary>
+        [Fact]
+        public void P2YTakesTheCoverScale()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 960, p1Aspect: Bgr11Aspect, p1TextureWidth: Bgr11Width,
+                p2Aspect: 980.0 / 2048.0, p2Y: 802);
+
+            LevelBounds p2 = Assert.Single(layout.P2);
+            Assert.Equal(layout.Top + (802.0 * 1.25 / 3.0), p2.Y, precision: 9);
+        }
+
+        /// <summary>
+        /// A map spanning three p1 sections has two seams, so p2 is drawn twice, one p1 tile apart
+        /// (BackgroundTiling.GetP2Count / ResolveP2Y).
+        /// </summary>
+        [Fact]
+        public void P2RepeatsAtEverySeam()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 1440, p1Aspect: P1Aspect16By9,
+                p2Aspect: 884.0 / 2559.0, p2Y: 1120);
+
+            Assert.Equal(2, layout.P2.Count);
+            Assert.Equal(layout.P2[0].Y + layout.TileHeight, layout.P2[1].Y, precision: 9);
+        }
+
+        /// <summary>
+        /// The grid starts at or before the level's left edge, so a level narrower than one tile keeps the
+        /// single overhanging tile it has always had.
+        /// </summary>
+        [Fact]
+        public void NarrowLevelStartsAtTheOverhangingTile()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 480, p1Aspect: P1Aspect16By9);
+
+            Assert.Equal(layout.Left, BackgroundPlacement.GridStart(layout.Left, layout.Width), precision: 9);
+            Assert.True(layout.Left < 0);
+        }
+
+        /// <summary>
+        /// A level wider than one tile is backed the whole way across: the grid steps back a tile so the
+        /// left edge is covered, and enough tiles follow to reach the right one.
+        /// </summary>
+        [Fact]
+        public void WideLevelIsTiledAcross()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 1600, levelHeight: 480, p1Aspect: P1Aspect16By9);
+
+            double start = BackgroundPlacement.GridStart(layout.Left, layout.Width);
+            Assert.Equal(layout.Left - layout.Width, start, precision: 9);
+            Assert.True(start <= 0);
+            Assert.True(start + layout.Width > 0);
+
+            int tiles = 0;
+            for (double tx = start; tx < 1600; tx += layout.Width)
+            {
+                tiles++;
+            }
+            Assert.Equal(3, tiles);
+            Assert.True(start + (tiles * layout.Width) >= 1600);
+        }
+
+        /// <summary>A grid already flush with the level's edge is left where it is.</summary>
+        [Fact]
+        public void FlushGridIsNotShiftedBack()
+        {
+            Assert.Equal(0, BackgroundPlacement.GridStart(0, 480), precision: 9);
+        }
+
+        /// <summary>
+        /// The section count carries the game's epsilon, so a map that is an exact multiple of one screen
+        /// is not credited with a further section: 960 spans two sections and one seam, not three and two.
+        /// </summary>
+        [Theory]
+        [InlineData(480, 0)]
+        [InlineData(700, 1)]
+        [InlineData(960, 1)]
+        [InlineData(1440, 2)]
+        [InlineData(1441, 3)]
+        public void SeamCountMatchesTheGamesSectionCount(double levelHeight, int expected)
+        {
+            Assert.Equal(expected, BackgroundPlacement.SeamCount(levelHeight));
         }
 
         /// <summary>No earth layer by default; the cosmic box supplies its position explicitly.</summary>
@@ -75,7 +201,7 @@ namespace CtrDxEditor.Core.Tests
             Assert.Empty(layout.EarthCenters);
         }
 
-        /// <summary>A single-screen cosmic box draws one earth at earthBgPosition ÷ MapScale, column-offset.</summary>
+        /// <summary>A single-screen cosmic box draws one earth at earthBgPosition ÷ MapScale, grid-offset.</summary>
         [Fact]
         public void EarthCenteredAtScaledPosition()
         {
@@ -88,7 +214,20 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(724.0 / 3.0, earth.Y, precision: 9);
         }
 
-        /// <summary>Maps wider than one screen (mapWidth &gt; 2560) get a second earth one column right.</summary>
+        /// <summary>The earth's authored position is in texture pixels too, so it takes the cover scale.</summary>
+        [Fact]
+        public void EarthPositionTakesTheCoverScale()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 320, levelHeight: 480, p1Aspect: Bgr11Aspect, p1TextureWidth: Bgr11Width,
+                earthPosition: new Vec2(1284, 724));
+
+            Vec2 earth = Assert.Single(layout.EarthCenters);
+            Assert.Equal(layout.Left + (1284.0 * 1.25 / 3.0), earth.X, precision: 9);
+            Assert.Equal(layout.Top + (724.0 * 1.25 / 3.0), earth.Y, precision: 9);
+        }
+
+        /// <summary>Maps wider than one screen (mapWidth &gt; 2560) get a second earth one tile right.</summary>
         [Fact]
         public void WideMapDuplicatesEarthHorizontally()
         {
@@ -131,6 +270,20 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(3, layout.EarthCenters.Count);
         }
 
+        /// <summary>
+        /// However far a map runs on, the earth still gets only one copy per axis: the p1 grid repeats
+        /// without limit, the earth does not (GameScene.LoadMetadata's map case).
+        /// </summary>
+        [Fact]
+        public void EarthNeverExceedsThreeCopies()
+        {
+            BackgroundLayout layout = BackgroundPlacement.Compute(
+                levelWidth: 4000, levelHeight: 4000, p1Aspect: P1Aspect16By9,
+                earthPosition: new Vec2(1284, 724));
+
+            Assert.Equal(3, layout.EarthCenters.Count);
+        }
+
         /// <summary>A missing p2 (no p2Y) yields no p2 even for tall maps.</summary>
         [Fact]
         public void NoP2WhenP2YIsZero()
@@ -139,7 +292,7 @@ namespace CtrDxEditor.Core.Tests
                 levelWidth: 320, levelHeight: 960, p1Aspect: P1Aspect16By9,
                 p2Aspect: 0, p2Y: 0);
 
-            Assert.Null(layout.P2);
+            Assert.Empty(layout.P2);
         }
     }
 }

--- a/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
+++ b/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
@@ -18,17 +18,19 @@ namespace CtrDxEditor.Core.Editing
     /// size the overlays the game draws inside the background's own scaled matrix.
     /// </param>
     /// <param name="P2">
-    /// The secondary background's bounds, one per seam between p1 sections, empty when the map is short
-    /// or the background has no p2.
+    /// The secondary background's bands, one per seam between p1 sections, empty when the map is short or
+    /// the background has no p2. Each band describes the grid's origin column; the game repeats it across
+    /// every column the p1 grid covers, so <see cref="BackgroundLayout.Left"/> is where it starts, not
+    /// where it ends.
     /// </param>
-    /// <param name="EarthCenters">
-    /// Level-space centers of the earth decoration (cosmic box only), empty when there is no earth. The
-    /// game draws a base earth plus a horizontal copy for maps wider than one screen and a vertical copy
-    /// for maps taller than one screen (up to three), so this holds 0..3 positions.
+    /// <param name="EarthOffset">
+    /// The earth decoration's center as an offset from a p1 tile's top-left (cosmic box only), or null
+    /// when the background has no earth. The earth belongs to the tile rather than to the map, so it is
+    /// drawn once per tile in the grid.
     /// </param>
     public readonly record struct BackgroundLayout(
         double Left, double Top, double Width, double TileHeight, double Scale,
-        IReadOnlyList<LevelBounds> P2, IReadOnlyList<Vec2> EarthCenters);
+        IReadOnlyList<LevelBounds> P2, Vec2? EarthOffset);
 
     /// <summary>
     /// Pure background placement math. The game (GameScene.Draw / GameScene.Init / GameScene.cs) draws the
@@ -38,9 +40,11 @@ namespace CtrDxEditor.Core.Editing
     /// centre (<c>UpdateBackgroundScale</c> sets <c>back.x = SCREEN_WIDTH / 2 / scale - texWidth / 2</c> and
     /// the same for y), and the map is itself centered in that screen (offsetX = (SCREEN_WIDTH - mapWidth) / 2),
     /// so the grid comes out centered on the map horizontally.
-    /// A p2 texture is drawn once per seam between p1 sections (<c>BackgroundTiling.GetP2Count</c> /
-    /// <c>ResolveP2Y</c>), and the earth decorations sit at <c>back.x/back.y</c> plus their authored offset -
-    /// all inside the background's scaled matrix, hence the <see cref="BackgroundLayout.Scale"/> factor.
+    /// Everything anchored to one p1 section repeats with it (<c>BackgroundTiling.GetSectionRange</c>): the
+    /// p2 band dresses the seam on every column, and the earth is drawn on every tile. p2's vertical
+    /// placement is the exception, still driven by the map's height alone through
+    /// <c>GetP2Count</c> / <c>ResolveP2Y</c>. All of it is drawn inside the background's own scaled matrix,
+    /// hence the <see cref="BackgroundLayout.Scale"/> factor.
     /// The world is <see cref="SpritePlacement.MapScale"/> times level space, so all screen-space
     /// constants below are divided by it.
     /// </summary>
@@ -105,8 +109,10 @@ namespace CtrDxEditor.Core.Editing
             double top = (LevelScreenHeight - tileHeight) / 2.0;
 
             List<LevelBounds> p2 = [];
-            // One p2 per seam between p1 sections (BackgroundTiling.GetP2Count / ResolveP2Y). p2 ships the
-            // same pixel width as p1, so it spans one tile and only its height follows its own aspect.
+            // One p2 per seam between p1 sections (BackgroundTiling.GetP2Count / ResolveP2Y). Only the
+            // vertical placement is the map's business: horizontally the band repeats with the columns,
+            // which is the renderer's to walk. p2 ships the same pixel width as p1, so it spans one tile
+            // and only its height follows its own aspect.
             int p2Count = SeamCount(levelHeight);
             if (p2Y > 0 && p2Aspect > 0.0)
             {
@@ -117,31 +123,15 @@ namespace CtrDxEditor.Core.Editing
                 }
             }
 
-            // The earth is center-anchored at earthBgPosition within the p1 texture's space (GameScene
+            // The earth is center-anchored at earthBgPosition within the p1 texture's own space (GameScene
             // CreateEarthImageWithOffsetXY + GravityState.RelayoutEarthAnimations), so it maps to level
-            // space by ×Scale ÷MapScale, offset by the grid origin. The game wraps it with the tiled
-            // background when the map exceeds one screen: an extra copy one tile to the right for wide
-            // maps (mapWidth > SCREEN_WIDTH) and one tile down for tall maps (mapHeight > SCREEN_HEIGHT).
-            // Only ever one copy per axis, however far the map runs on - the p1 grid repeats, the earth
-            // does not (GameScene.LoadMetadata's map case).
-            List<Vec2> earthCenters = [];
-            if (earthPosition is { } e)
-            {
-                Vec2 baseEarth = new(
-                    left + (e.X * scale / SpritePlacement.MapScale),
-                    top + (e.Y * scale / SpritePlacement.MapScale));
-                earthCenters.Add(baseEarth);
-                if (levelWidth > LevelScreenWidth)
-                {
-                    earthCenters.Add(new Vec2(baseEarth.X + width, baseEarth.Y));
-                }
-                if (levelHeight > LevelScreenHeight)
-                {
-                    earthCenters.Add(new Vec2(baseEarth.X, baseEarth.Y + tileHeight));
-                }
-            }
+            // space by ×Scale ÷MapScale and belongs to the tile rather than to the map: GameScene.Draw
+            // translates it by the p1 cadence over every section the view covers, so each tile carries one.
+            Vec2? earthOffset = earthPosition is { } e
+                ? new Vec2(e.X * scale / SpritePlacement.MapScale, e.Y * scale / SpritePlacement.MapScale)
+                : null;
 
-            return new BackgroundLayout(left, top, width, tileHeight, scale, p2, earthCenters);
+            return new BackgroundLayout(left, top, width, tileHeight, scale, p2, earthOffset);
         }
 
         /// <summary>

--- a/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
+++ b/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
@@ -20,7 +20,7 @@ namespace CtrDxEditor.Core.Editing
     /// <param name="P2">
     /// The secondary background's bands, one per seam between p1 sections, empty when the map is short or
     /// the background has no p2. Each band describes the grid's origin column; the game repeats it across
-    /// every column the p1 grid covers, so <see cref="BackgroundLayout.Left"/> is where it starts, not
+    /// every column the p1 grid covers, so <see cref="Left"/> is where it starts, not
     /// where it ends.
     /// </param>
     /// <param name="EarthOffset">

--- a/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
+++ b/src/CtrDxEditor.Core/Editing/BackgroundPlacement.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CtrDxEditor.Core.Geometry;
@@ -5,28 +6,41 @@ using CtrDxEditor.Core.Geometry;
 namespace CtrDxEditor.Core.Editing
 {
     /// <summary>
-    /// Placement of a level-decoration background in level space: a single vertically-repeating p1
-    /// column plus an optional secondary p2 layer.
+    /// Placement of a level-decoration background in level space: an infinite p1 tile grid plus the
+    /// secondary p2 layers and earth decorations drawn over it.
     /// </summary>
-    /// <param name="Left">Level-space X of the p1 column's left edge (also the p2 layer's left edge).</param>
-    /// <param name="Width">Level-space width of the p1 column (the internal screen width).</param>
-    /// <param name="TileHeight">Level-space height of one p1 tile; repeat this down from y=0.</param>
-    /// <param name="P2">The secondary background's bounds, or null when the map is short or has no p2.</param>
+    /// <param name="Left">Level-space X of the p1 grid's origin column; tiles repeat both ways from here.</param>
+    /// <param name="Top">Level-space Y of the p1 grid's origin row; tiles repeat both ways from here.</param>
+    /// <param name="Width">Level-space width of one p1 tile.</param>
+    /// <param name="TileHeight">Level-space height of one p1 tile.</param>
+    /// <param name="Scale">
+    /// The game's background cover scale (internal pixels drawn per texture pixel), needed to place and
+    /// size the overlays the game draws inside the background's own scaled matrix.
+    /// </param>
+    /// <param name="P2">
+    /// The secondary background's bounds, one per seam between p1 sections, empty when the map is short
+    /// or the background has no p2.
+    /// </param>
     /// <param name="EarthCenters">
     /// Level-space centers of the earth decoration (cosmic box only), empty when there is no earth. The
     /// game draws a base earth plus a horizontal copy for maps wider than one screen and a vertical copy
     /// for maps taller than one screen (up to three), so this holds 0..3 positions.
     /// </param>
     public readonly record struct BackgroundLayout(
-        double Left, double Width, double TileHeight, LevelBounds? P2, IReadOnlyList<Vec2> EarthCenters);
+        double Left, double Top, double Width, double TileHeight, double Scale,
+        IReadOnlyList<LevelBounds> P2, IReadOnlyList<Vec2> EarthCenters);
 
     /// <summary>
-    /// Pure background placement math. The game (GameScene.Draw / GameScene.Init) draws the box
-    /// background as a <c>TileMap</c> scaled so the p1 texture spans the internal screen width
-    /// (<c>GetBackgroundWidthScale</c> = SCREEN_WIDTH / textureWidth), repeated
-    /// vertically (<c>Repeat.ALL</c>) but never horizontally (<c>Repeat.NONE</c>). The map is centered
-    /// in that screen (offsetX = (SCREEN_WIDTH - mapWidth) / 2), so the column is centered on the map.
-    /// A secondary p2 texture is drawn once at (0, p2Y) only when the map is taller than one screen.
+    /// Pure background placement math. The game (GameScene.Draw / GameScene.Init / GameScene.cs) draws the
+    /// box background as a <c>TileMap</c> repeating on <em>both</em> axes (<c>Repeat.ALL</c> horizontally and
+    /// vertically), scaled by <c>GetBackgroundCoverScale</c> - a cover fit of the p1 texture against the
+    /// internal screen, so the axis with room to spare crops. The grid is anchored on the design screen's
+    /// centre (<c>UpdateBackgroundScale</c> sets <c>back.x = SCREEN_WIDTH / 2 / scale - texWidth / 2</c> and
+    /// the same for y), and the map is itself centered in that screen (offsetX = (SCREEN_WIDTH - mapWidth) / 2),
+    /// so the grid comes out centered on the map horizontally.
+    /// A p2 texture is drawn once per seam between p1 sections (<c>BackgroundTiling.GetP2Count</c> /
+    /// <c>ResolveP2Y</c>), and the earth decorations sit at <c>back.x/back.y</c> plus their authored offset -
+    /// all inside the background's scaled matrix, hence the <see cref="BackgroundLayout.Scale"/> factor.
     /// The world is <see cref="SpritePlacement.MapScale"/> times level space, so all screen-space
     /// constants below are divided by it.
     /// </summary>
@@ -38,8 +52,17 @@ namespace CtrDxEditor.Core.Editing
         /// <summary>Game internal screen height (Application sets PORTRAIT_SCREEN_HEIGHT to 1440).</summary>
         public const double ScreenHeight = 1440.0;
 
-        /// <summary>The p1 column's drawn width in level space (internal screen width ÷ MapScale).</summary>
+        /// <summary>The internal screen width in level space (the p1 tile width for 16:9 art).</summary>
         public static double LevelScreenWidth => ScreenWidth / SpritePlacement.MapScale;
+
+        /// <summary>The internal screen height in level space (one p1 section of the map).</summary>
+        public static double LevelScreenHeight => ScreenHeight / SpritePlacement.MapScale;
+
+        /// <summary>
+        /// The game's slack when counting p1 sections, so a map that is an exact multiple of one screen
+        /// is not credited with a further section (<c>BackgroundTiling.Epsilon</c>).
+        /// </summary>
+        private const double SectionEpsilon = 0.001;
 
         /// <summary>
         /// Computes background placement for a level of the given size.
@@ -47,50 +70,111 @@ namespace CtrDxEditor.Core.Editing
         /// <param name="levelWidth">Level width in level (XML) units.</param>
         /// <param name="levelHeight">Level height in level (XML) units.</param>
         /// <param name="p1Aspect">The decoded p1 bitmap's height ÷ width (aspect is preserved on decode).</param>
+        /// <param name="p1TextureWidth">
+        /// The p1 art's authored pixel width, which the cover scale is measured against. Defaults to the
+        /// design width, where the scale is the identity.
+        /// </param>
         /// <param name="p2Aspect">The decoded p2 bitmap's height ÷ width, or 0 when there is no p2.</param>
-        /// <param name="p2Y">The pack's <c>boxBackgroundP2Y</c> (internal px), or 0 when there is no p2.</param>
+        /// <param name="p2Y">The pack's <c>boxBackgroundP2Y</c> (p1 texture px), or 0 when there is no p2.</param>
         /// <param name="earthPosition">
-        /// The earth decoration's center in internal pixels (the game's <c>earthBgPosition</c>, measured
-        /// from the p1 column's top-left), or null when the background has no earth layer.
+        /// The earth decoration's center in p1 texture pixels (the game's <c>earthBgPosition</c>, measured
+        /// from the p1 texture's top-left), or null when the background has no earth layer.
         /// </param>
         public static BackgroundLayout Compute(
-            double levelWidth, double levelHeight, double p1Aspect,
+            double levelWidth, double levelHeight, double p1Aspect, double p1TextureWidth = ScreenWidth,
             double p2Aspect = 0.0, int p2Y = 0, Vec2? earthPosition = null)
         {
-            double width = LevelScreenWidth;
-            double left = (levelWidth - width) / 2.0;
+            // GetBackgroundCoverScale takes the larger of the two fits, so the drawn tile is at least a
+            // screen on both axes. Expressed against the texture's aspect alone, its drawn width is
+            // whichever of the screen width and the width its screen-tall form would have is larger.
+            double drawnWidth = p1Aspect > 0.0
+                ? Math.Max(ScreenWidth, ScreenHeight / p1Aspect)
+                : ScreenWidth;
+            double width = drawnWidth / SpritePlacement.MapScale;
             double tileHeight = width * p1Aspect;
 
-            LevelBounds? p2 = null;
-            // The game only draws p2 when mapHeight (world) exceeds SCREEN_HEIGHT (GameScene.Draw).
-            bool tall = levelHeight > ScreenHeight / SpritePlacement.MapScale;
-            if (tall && p2Y > 0 && p2Aspect > 0.0)
+            // The scale the game applies to everything drawn inside the background's matrix: the p2 offset,
+            // and the earth positions and art. Those are all authored in the p1 texture's own pixels, which
+            // the cover fit spreads across drawnWidth internal ones.
+            double scale = p1TextureWidth > 0.0 ? drawnWidth / p1TextureWidth : 1.0;
+
+            // The grid is anchored on the design screen's centre. Horizontally that lands on the map's
+            // centre once the map's own centring offset is taken back out; vertically it is a straight
+            // centring of one tile on one screen, which is exactly 0 for art the screen's own shape.
+            double left = (levelWidth - width) / 2.0;
+            double top = (LevelScreenHeight - tileHeight) / 2.0;
+
+            List<LevelBounds> p2 = [];
+            // One p2 per seam between p1 sections (BackgroundTiling.GetP2Count / ResolveP2Y). p2 ships the
+            // same pixel width as p1, so it spans one tile and only its height follows its own aspect.
+            int p2Count = SeamCount(levelHeight);
+            if (p2Y > 0 && p2Aspect > 0.0)
             {
-                // p2 ships the same pixel width as p1, so it spans the same screen-wide column.
-                p2 = new LevelBounds(left, p2Y / SpritePlacement.MapScale, width, width * p2Aspect);
+                double firstY = top + (p2Y * scale / SpritePlacement.MapScale);
+                for (int seam = 0; seam < p2Count; seam++)
+                {
+                    p2.Add(new LevelBounds(left, firstY + (seam * tileHeight), width, width * p2Aspect));
+                }
             }
 
-            // The earth is center-anchored at earthBgPosition within the p1 column's space (GameScene
-            // CreateEarthImageWithOffsetXY), so it maps to level space by ÷MapScale, offset by the column.
-            // The game wraps it with the tiled background when the map exceeds one screen: an extra copy
-            // one column to the right for wide maps (mapWidth > SCREEN_WIDTH) and one tile down for tall
-            // maps (mapHeight > SCREEN_HEIGHT). Both offsets scale to the p1 column width / tile height.
+            // The earth is center-anchored at earthBgPosition within the p1 texture's space (GameScene
+            // CreateEarthImageWithOffsetXY + GravityState.RelayoutEarthAnimations), so it maps to level
+            // space by ×Scale ÷MapScale, offset by the grid origin. The game wraps it with the tiled
+            // background when the map exceeds one screen: an extra copy one tile to the right for wide
+            // maps (mapWidth > SCREEN_WIDTH) and one tile down for tall maps (mapHeight > SCREEN_HEIGHT).
+            // Only ever one copy per axis, however far the map runs on - the p1 grid repeats, the earth
+            // does not (GameScene.LoadMetadata's map case).
             List<Vec2> earthCenters = [];
             if (earthPosition is { } e)
             {
-                Vec2 baseEarth = new(left + (e.X / SpritePlacement.MapScale), e.Y / SpritePlacement.MapScale);
+                Vec2 baseEarth = new(
+                    left + (e.X * scale / SpritePlacement.MapScale),
+                    top + (e.Y * scale / SpritePlacement.MapScale));
                 earthCenters.Add(baseEarth);
-                if (levelWidth > width)
+                if (levelWidth > LevelScreenWidth)
                 {
                     earthCenters.Add(new Vec2(baseEarth.X + width, baseEarth.Y));
                 }
-                if (tall)
+                if (levelHeight > LevelScreenHeight)
                 {
                     earthCenters.Add(new Vec2(baseEarth.X, baseEarth.Y + tileHeight));
                 }
             }
 
-            return new BackgroundLayout(left, width, tileHeight, p2, earthCenters);
+            return new BackgroundLayout(left, top, width, tileHeight, scale, p2, earthCenters);
+        }
+
+        /// <summary>
+        /// The first grid line at or before the level's own edge, from which tiles can be laid down to the
+        /// far edge to cover it.
+        /// </summary>
+        /// <remarks>
+        /// The p1 grid is anchored on the design screen rather than on the level, and repeats both ways
+        /// from there (<c>Repeat.ALL</c>), so the tile covering the level's top-left corner generally
+        /// starts outside the level. Walking forward from the anchor alone would leave that corner bare.
+        /// </remarks>
+        /// <param name="origin">The grid's anchor on this axis, in level units.</param>
+        /// <param name="tileSize">The tile's extent on this axis, in level units.</param>
+        /// <returns>The anchor shifted back by whole tiles until it is at or before zero.</returns>
+        public static double GridStart(double origin, double tileSize)
+        {
+            return tileSize > 0.0
+                ? origin - (Math.Ceiling(origin / tileSize) * tileSize)
+                : origin;
+        }
+
+        /// <summary>
+        /// The number of seams between the p1 sections a map of this height uses, which is the number of
+        /// p2 overlays the game draws (<c>BackgroundTiling.GetP2Count</c>).
+        /// </summary>
+        /// <param name="levelHeight">Level height in level (XML) units.</param>
+        /// <returns>One fewer than the map's p1 section count, and never negative.</returns>
+        public static int SeamCount(double levelHeight)
+        {
+            int sections = Math.Max(
+                1,
+                (int)Math.Ceiling((levelHeight / LevelScreenHeight) - SectionEpsilon));
+            return Math.Max(0, sections - 1);
         }
     }
 }

--- a/src/CtrDxEditor.Shared/Content/SpriteCache.cs
+++ b/src/CtrDxEditor.Shared/Content/SpriteCache.cs
@@ -88,10 +88,16 @@ namespace CtrDxEditor.Content
         }
 
         /// <summary>
-        /// Per-background secondary (p2) layer Y offset in internal pixels, from the game's pack config
-        /// (<c>boxBackgroundP2Y</c> in ctroriginal_packs.json). Index is the background id (1..17);
+        /// Per-background secondary (p2) layer Y offset in p1 <em>texture</em> pixels, from the game's pack
+        /// config (<c>boxBackgroundP2Y</c> in ctroriginal_packs.json). Index is the background id (1..17);
         /// only bgr_01..bgr_11 ship a p2 layer, so ids 12..17 are 0 (no p2).
         /// </summary>
+        /// <remarks>
+        /// The game draws p2 inside the background's own scaled matrix (<c>GameScene.Draw</c>), so this
+        /// offset is multiplied by the background's cover scale before it reaches the screen - see
+        /// <see cref="GetBackgroundTextureWidth"/>. On art authored below the design width (bgr_11) the two
+        /// differ by a quarter, which is the difference between p2 sitting on the seam and well above it.
+        /// </remarks>
         private static readonly int[] BackgroundP2Y =
         [
             0,     // (id 0 unused)
@@ -118,7 +124,51 @@ namespace CtrDxEditor.Content
         }
 
         /// <summary>
-        /// The earth decoration's center in internal pixels (the game's <c>earthBgPosition</c>) for the
+        /// The p1 art's authored pixel width per background id (1..17), which the game's
+        /// <c>GetBackgroundCoverScale</c> measures the internal screen against. Ids outside the table fall
+        /// back to the design width, the scale's own no-op.
+        /// </summary>
+        /// <remarks>
+        /// Held here rather than read off the decoded bitmap because the canvas decodes every background to
+        /// a fixed <see cref="BackgroundDecodeWidth"/>, which is what makes the art cheap to hold but also
+        /// throws its authored size away. Aspect survives that decode; absolute size does not, and the cover
+        /// scale needs the absolute size.
+        /// </remarks>
+        private static readonly int[] BackgroundTextureWidth =
+        [
+            0,     // (id 0 unused)
+            2559,  // bgr_01
+            2560,  // bgr_02
+            2560,  // bgr_03
+            2560,  // bgr_04
+            2560,  // bgr_05
+            2560,  // bgr_06
+            2560,  // bgr_07
+            2560,  // bgr_08
+            2560,  // bgr_09
+            2560,  // bgr_10
+            2048,  // bgr_11
+            2560,  // bgr_12
+            2560,  // bgr_13
+            2560,  // bgr_14
+            2560,  // bgr_15
+            2048,  // bgr_16
+            2048,  // bgr_17
+        ];
+
+        /// <summary>
+        /// The p1 art's authored pixel width for the given background id, or the game's design width for an
+        /// id the table does not cover.
+        /// </summary>
+        public static double GetBackgroundTextureWidth(int id)
+        {
+            return id >= 1 && id < BackgroundTextureWidth.Length
+                ? BackgroundTextureWidth[id]
+                : BackgroundPlacement.ScreenWidth;
+        }
+
+        /// <summary>
+        /// The earth decoration's center in p1 texture pixels (the game's <c>earthBgPosition</c>) for the
         /// given background id, or null when it has no earth layer. Only the cosmic box (bgr_08) does.
         /// </summary>
         public static Vec2? GetEarthBgPosition(int id)

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -611,7 +611,7 @@ namespace CtrDxEditor.Rendering
             Vec2 tl = v.LevelToScreen(new Vec2(0, 0));
             Vec2 br = v.LevelToScreen(new Vec2(doc.Width, doc.Height));
 
-            // Decoration is clipped to the level's vertical span but not its width: the background column and
+            // Decoration is clipped to the level's vertical span but not its width: the background grid and
             // the water band both legitimately overhang a narrow level's sides, while nothing may spill past
             // its top or bottom edge.
             Rect levelClip = new(0, tl.Y, renderSize.Width, br.Y - tl.Y);
@@ -626,30 +626,46 @@ namespace CtrDxEditor.Rendering
                     doc.Width, doc.Height, ActiveBackground, p1Aspect, p2Aspect,
                     () => BackgroundPlacement.Compute(
                         doc.Width, doc.Height, p1Aspect,
+                        SpriteCache.GetBackgroundTextureWidth(ActiveBackground),
                         p2Aspect, SpriteCache.GetBackgroundP2Y(ActiveBackground),
                         SpriteCache.GetEarthBgPosition(ActiveBackground)));
 
                 using (context.PushClip(levelClip))
                 {
-                    if (layout.TileHeight > 0.5)
+                    // The game's tile map repeats on both axes (Repeat.ALL), so this is a grid rather than a
+                    // column: a level wider than one screen is backed the whole way across, not down its
+                    // middle only. Both loops start at the last grid line at or before the level's own edge,
+                    // since the grid is anchored on the design screen and need not begin on it.
+                    if (layout.TileHeight > 0.5 && layout.Width > 0.5)
                     {
                         Rect bgSrc = new(bgSize);
-                        for (double ty = 0; ty < doc.Height; ty += layout.TileHeight)
+                        double firstX = BackgroundPlacement.GridStart(layout.Left, layout.Width);
+                        double firstY = BackgroundPlacement.GridStart(layout.Top, layout.TileHeight);
+                        for (double tx = firstX; tx < doc.Width; tx += layout.Width)
                         {
-                            context.DrawImage(bg, bgSrc, LevelSceneRenderer.LevelRectToScreen(v, layout.Left, ty, layout.Width, layout.TileHeight));
+                            for (double ty = firstY; ty < doc.Height; ty += layout.TileHeight)
+                            {
+                                context.DrawImage(bg, bgSrc, LevelSceneRenderer.LevelRectToScreen(v, tx, ty, layout.Width, layout.TileHeight));
+                            }
                         }
                     }
 
-                    if (layout.P2 is { } p2b && p2 is not null)
+                    if (p2 is not null)
                     {
-                        context.DrawImage(p2, new Rect(p2.Size), LevelSceneRenderer.LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
+                        Rect p2Src = new(p2.Size);
+                        foreach (LevelBounds p2b in layout.P2)
+                        {
+                            context.DrawImage(p2, p2Src, LevelSceneRenderer.LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
+                        }
                     }
 
                     if (layout.EarthCenters.Count > 0 && sprites.GetEarthArt() is { } earthArt)
                     {
+                        // The earth is drawn inside the background's own scaled matrix, so its art takes the
+                        // background's cover scale rather than being sized off the atlas alone.
                         IntRect ef = earthArt.Frame.Frame;
-                        double ew = ef.W / SpritePlacement.MapScale;
-                        double eh = ef.H / SpritePlacement.MapScale;
+                        double ew = ef.W * layout.Scale / SpritePlacement.MapScale;
+                        double eh = ef.H * layout.Scale / SpritePlacement.MapScale;
                         Rect earthSrc = new(ef.X, ef.Y, ef.W, ef.H);
                         foreach (Vec2 ec in layout.EarthCenters)
                         {

--- a/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
+++ b/src/CtrDxEditor.Shared/Rendering/LevelCanvas.Rendering.cs
@@ -638,9 +638,13 @@ namespace CtrDxEditor.Rendering
                     // since the grid is anchored on the design screen and need not begin on it.
                     if (layout.TileHeight > 0.5 && layout.Width > 0.5)
                     {
-                        Rect bgSrc = new(bgSize);
                         double firstX = BackgroundPlacement.GridStart(layout.Left, layout.Width);
                         double firstY = BackgroundPlacement.GridStart(layout.Top, layout.TileHeight);
+
+                        // One pass per layer rather than one per column, so the layers stack in the game's
+                        // order (GameScene.Draw: the whole tile map, then every p2, then every earth) and no
+                        // column's art can be painted over by the next column's tiles.
+                        Rect bgSrc = new(bgSize);
                         for (double tx = firstX; tx < doc.Width; tx += layout.Width)
                         {
                             for (double ty = firstY; ty < doc.Height; ty += layout.TileHeight)
@@ -648,31 +652,41 @@ namespace CtrDxEditor.Rendering
                                 context.DrawImage(bg, bgSrc, LevelSceneRenderer.LevelRectToScreen(v, tx, ty, layout.Width, layout.TileHeight));
                             }
                         }
-                    }
 
-                    if (p2 is not null)
-                    {
-                        Rect p2Src = new(p2.Size);
-                        foreach (LevelBounds p2b in layout.P2)
+                        // p2 dresses the seam on every column, but its rows stay the map's business rather
+                        // than the grid's - a level of a single section has no seam to dress at all.
+                        if (p2 is not null && layout.P2.Count > 0)
                         {
-                            context.DrawImage(p2, p2Src, LevelSceneRenderer.LevelRectToScreen(v, p2b.X, p2b.Y, p2b.W, p2b.H));
+                            Rect p2Src = new(p2.Size);
+                            for (double tx = firstX; tx < doc.Width; tx += layout.Width)
+                            {
+                                foreach (LevelBounds p2b in layout.P2)
+                                {
+                                    context.DrawImage(p2, p2Src, LevelSceneRenderer.LevelRectToScreen(v, tx, p2b.Y, p2b.W, p2b.H));
+                                }
+                            }
                         }
-                    }
 
-                    if (layout.EarthCenters.Count > 0 && sprites.GetEarthArt() is { } earthArt)
-                    {
-                        // The earth is drawn inside the background's own scaled matrix, so its art takes the
-                        // background's cover scale rather than being sized off the atlas alone.
-                        IntRect ef = earthArt.Frame.Frame;
-                        double ew = ef.W * layout.Scale / SpritePlacement.MapScale;
-                        double eh = ef.H * layout.Scale / SpritePlacement.MapScale;
-                        Rect earthSrc = new(ef.X, ef.Y, ef.W, ef.H);
-                        foreach (Vec2 ec in layout.EarthCenters)
+                        // The earth belongs to the p1 tile rather than to the map, so it rides the grid on
+                        // both axes. Its art is drawn inside the background's own scaled matrix, so it takes
+                        // the background's cover scale rather than being sized off the atlas alone.
+                        if (layout.EarthOffset is { } eo && sprites.GetEarthArt() is { } earthArt)
                         {
-                            context.DrawImage(
-                                earthArt.Bitmap,
-                                earthSrc,
-                                LevelSceneRenderer.LevelRectToScreen(v, ec.X - (ew / 2.0), ec.Y - (eh / 2.0), ew, eh));
+                            IntRect ef = earthArt.Frame.Frame;
+                            double ew = ef.W * layout.Scale / SpritePlacement.MapScale;
+                            double eh = ef.H * layout.Scale / SpritePlacement.MapScale;
+                            Rect earthSrc = new(ef.X, ef.Y, ef.W, ef.H);
+                            for (double tx = firstX; tx < doc.Width; tx += layout.Width)
+                            {
+                                for (double ty = firstY; ty < doc.Height; ty += layout.TileHeight)
+                                {
+                                    context.DrawImage(
+                                        earthArt.Bitmap,
+                                        earthSrc,
+                                        LevelSceneRenderer.LevelRectToScreen(
+                                            v, tx + eo.X - (ew / 2.0), ty + eo.Y - (eh / 2.0), ew, eh));
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Make the editor's background tiling like [Cut the Rope: DX's implementation](https://github.com/yell0wsuit/cuttherope-dx/pull/334).