### PR TITLE
fix: Match Time Travel's chain link shading

### DIFF
--- a/src/CtrDxEditor.Core.Tests/ChainRopeTests.cs
+++ b/src/CtrDxEditor.Core.Tests/ChainRopeTests.cs
@@ -208,20 +208,43 @@ namespace CtrDxEditor.Core.Tests
             Assert.Equal(Math.Atan2(0, -1) + (Math.PI / 2), plan[1].Rotation, 6);
         }
 
-        /// <summary>Every link is either left white or shaded a grey in the game's [0.5, 1] range.</summary>
+        /// <summary>Every link is either left white or given one of the game's three mask shades.</summary>
         [Fact]
-        public void LinkTintsAreWhiteOrGrey()
+        public void LinkTintsAreWhiteOrAMaskShade()
+        {
+            IReadOnlyList<ChainSprite> plan = ChainSpritePlanner.Build(new Vec2(0, 0), new Vec2(300, 120), 340, seed: 12345);
+
+            (double R, double G, double B)[] allowed =
+            [
+                (0.78, 0.71, 0.795),
+                (0.85, 0.83, 0.9),
+                (0.88, 0.85, 0.91),
+                (1, 1, 1)
+            ];
+
+            Assert.All(plan, s =>
+            {
+                Assert.Contains(allowed, c => c.R == s.Tint.R && c.G == s.Tint.G && c.B == s.Tint.B);
+                Assert.Equal(1, s.Tint.A);
+            });
+            Assert.Contains(plan, s => s.Tint.R == 1);
+        }
+
+        /// <summary>A link sprite keeps its fourth corner white so the tint shades across the quad;
+        /// a midpoint sprite is flat.</summary>
+        [Fact]
+        public void LinkSpritesShadeTheirFourthCornerAndMidpointsDoNot()
         {
             IReadOnlyList<ChainSprite> plan = ChainSpritePlanner.Build(new Vec2(0, 0), new Vec2(300, 120), 340, seed: 12345);
 
             Assert.All(plan, s =>
             {
-                Assert.Equal(s.Tint.R, s.Tint.G);
-                Assert.Equal(s.Tint.G, s.Tint.B);
-                Assert.InRange(s.Tint.R, 0.5, 1.0);
-                Assert.Equal(1, s.Tint.A);
+                RopeRgba expected = s.QuadIndex == ChainSpritePlanner.LinkQuad ? new RopeRgba(1, 1, 1, 1) : s.Tint;
+                Assert.Equal(expected, s.CornerTint);
             });
-            Assert.Contains(plan, s => s.Tint.R == 1);
+
+            // The rule only shows up where a link is actually tinted, so make sure that case is covered.
+            Assert.Contains(plan, s => s.QuadIndex == ChainSpritePlanner.LinkQuad && s.Tint.R != 1);
         }
 
         /// <summary>The same seed always produces the same tints, so links never flicker across redraws.</summary>

--- a/src/CtrDxEditor.Core/Editing/ChainSpritePlanner.cs
+++ b/src/CtrDxEditor.Core/Editing/ChainSpritePlanner.cs
@@ -13,8 +13,10 @@ namespace CtrDxEditor.Core.Editing
     /// <param name="QuadIndex">Atlas quad to draw: <see cref="ChainSpritePlanner.LinkQuad"/> or <see cref="ChainSpritePlanner.MidpointQuad"/>.</param>
     /// <param name="Center">Sprite center in level units.</param>
     /// <param name="Rotation">Sprite rotation in radians, clockwise in screen space.</param>
-    /// <param name="Tint">Per-link color; white for half the links and a grey shade for the rest.</param>
-    public readonly record struct ChainSprite(int QuadIndex, Vec2 Center, double Rotation, RopeRgba Tint);
+    /// <param name="Tint">Per-link color; white for half the links and one of three shades for the rest.</param>
+    /// <param name="CornerTint">Color of the sprite's fourth corner, which a link sprite keeps white so
+    /// the tint shades across the quad. Equal to <paramref name="Tint"/> on a midpoint sprite.</param>
+    public readonly record struct ChainSprite(int QuadIndex, Vec2 Center, double Rotation, RopeRgba Tint, RopeRgba CornerTint);
 
     /// <summary>
     /// Lays out the sprites that draw a chain rope, porting the game's <c>Bungee.DrawChain</c> /
@@ -39,6 +41,14 @@ namespace CtrDxEditor.Core.Editing
 
         // Bungee.ChainDrawSamplePoints: bezier samples per control-point segment.
         private const int SamplePoints = 2;
+
+        // Bungee.ChainMaskRed / ChainMaskGreen / ChainMaskBlue: the three shades a tinted link takes.
+        private static readonly double[] MaskRed = [0.78, 0.85, 0.88];
+        private static readonly double[] MaskGreen = [0.71, 0.83, 0.85];
+        private static readonly double[] MaskBlue = [0.795, 0.9, 0.91];
+
+        // The untinted half of the links, and every link sprite's fourth corner.
+        private static readonly RopeRgba White = new(1, 1, 1, 1);
 
         /// <summary>
         /// Builds the chain sprites for a rope from <paramref name="a"/> (the grab) to
@@ -85,14 +95,20 @@ namespace CtrDxEditor.Core.Editing
             for (int i = 0; i < sampleCount; i++)
             {
                 double angle = i == 0 ? 0 : Angle(samples[i - 1], samples[i]);
-                sprites.Add(new ChainSprite(LinkQuad, samples[i], angle, Tint(seed, sprites.Count)));
+
+                // The game's first drawChain pass leaves a link's fourth corner opaque white, so a
+                // tinted link shades across the quad rather than sitting flat.
+                sprites.Add(new ChainSprite(LinkQuad, samples[i], angle, Tint(seed, sprites.Count), White));
             }
             for (int i = 0; i < sampleCount - 1; i++)
             {
                 Vec2 center = new(
                     samples[i].X + ((samples[i + 1].X - samples[i].X) * 0.5),
                     samples[i].Y + ((samples[i + 1].Y - samples[i].Y) * 0.5));
-                sprites.Add(new ChainSprite(MidpointQuad, center, Angle(samples[i], samples[i + 1]), Tint(seed, sprites.Count)));
+
+                // The second pass tints all four corners, so a midpoint sprite is flat.
+                RopeRgba tint = Tint(seed, sprites.Count);
+                sprites.Add(new ChainSprite(MidpointQuad, center, Angle(samples[i], samples[i + 1]), tint, tint));
             }
 
             return sprites;
@@ -118,12 +134,12 @@ namespace CtrDxEditor.Core.Editing
             uint hash = Hash(seed, index);
             if ((hash & 1) != 0)
             {
-                return new RopeRgba(1, 1, 1, 1);
+                return White;
             }
 
-            // Bungee.GetChainMaskColor: a grey in [0.5, 1].
-            double grey = 0.5 + (((hash >> 8) & 0xFF) / 255.0 * 0.5);
-            return new RopeRgba(grey, grey, grey, 1);
+            // Bungee.GetChainMaskColor: one of three shades, indexed at random.
+            int shade = (int)((hash >> 1) % (uint)MaskRed.Length);
+            return new RopeRgba(MaskRed[shade], MaskGreen[shade], MaskBlue[shade], 1);
         }
 
         // Bungee.HashChainSprite. Deliberately unchecked: the game relies on the wrap-around.

--- a/src/CtrDxEditor.Shared/Rendering/ChainDrawOperation.cs
+++ b/src/CtrDxEditor.Shared/Rendering/ChainDrawOperation.cs
@@ -19,15 +19,16 @@ namespace CtrDxEditor.Rendering
     /// <summary>
     /// Renders a chain rope's links through SkiaSharp, reproducing the game's <c>Bungee.DrawChain</c>:
     /// the same link art at every planned point, rotated onto the curve and multiplied by that link's
-    /// tint (half the links stay white, the rest take a grey shade).
+    /// tint (half the links stay white, the rest take one of three shades).
     /// </summary>
     /// <remarks>
-    /// This needs its own draw operation for the same reason the glow does: the tint is a per-sprite
+    /// This needs its own draw operation for the same reason the glow does: the tint is a per-vertex
     /// colour multiply, which Avalonia's <see cref="DrawingContext"/> cannot express - pushing opacity
-    /// instead would fade a link toward the background rather than darken it. Skia's modulate colour
-    /// filter is exactly the game's vertex-colour multiply, and folding the caller's opacity into that
-    /// filter's alpha keeps the pale "invisible grab" rendering working. On a non-Skia backend the
-    /// chain is simply not drawn, like the cord strips above it.
+    /// instead would fade a link toward the background rather than darken it. The game's tint is not
+    /// even flat across a sprite: a link keeps its fourth corner white, so the shade falls off across
+    /// the quad. That is a colour mesh rather than a single multiply, so each sprite is drawn as two
+    /// textured triangles whose vertex colours modulate the atlas, exactly as the game's vertex arrays
+    /// do. On a non-Skia backend the chain is simply not drawn, like the cord strips above it.
     /// </remarks>
     /// <param name="bounds">Control bounds for the custom draw operation.</param>
     /// <param name="view">Level-to-screen transform, applied on the Skia canvas so links zoom with the art.</param>
@@ -50,6 +51,9 @@ namespace CtrDxEditor.Rendering
         // the bitmap - the same caching the glow operation uses, and for the same reason: the atlas is
         // already decoded, so decoding it again per frame would be pure waste.
         private static readonly ConditionalWeakTable<Bitmap, SKImage> ImageCache = [];
+
+        // Bungee.BuildQuadIndices: two triangles per sprite over the game's four-corner order.
+        private static readonly ushort[] QuadIndices = [0, 1, 2, 3, 2, 1];
 
         /// <inheritdoc />
         public Rect Bounds { get; } = bounds;
@@ -89,6 +93,15 @@ namespace CtrDxEditor.Rendering
             canvas.Translate((float)view.PanX, (float)view.PanY);
             canvas.Scale((float)view.Zoom);
 
+            // Vertex texture coordinates address the whole atlas, so one shader covers both quads.
+            using SKShader shader = SKShader.CreateImage(
+                image, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp, sampling);
+            using SKPaint paint = new() { IsAntialias = true, Shader = shader };
+
+            SKPoint[] positions = new SKPoint[4];
+            SKPoint[] texs = new SKPoint[4];
+            SKColor[] colors = new SKColor[4];
+
             foreach (ChainSprite sprite in links)
             {
                 IntRect frame = sprite.QuadIndex == ChainSpritePlanner.MidpointQuad ? midpointFrame : linkFrame;
@@ -97,28 +110,39 @@ namespace CtrDxEditor.Rendering
                 float halfW = (float)(frame.W / SpritePlacement.MapScale / 2);
                 float halfH = (float)(frame.H / SpritePlacement.MapScale / 2);
 
-                using SKPaint paint = new()
-                {
-                    IsAntialias = true,
-                    ColorFilter = SKColorFilter.CreateBlendMode(Tint(sprite.Tint, opacity), SKBlendMode.Modulate),
-                };
+                // The game's corner order, so its fourth (shaded) corner lands where it does there.
+                positions[0] = new SKPoint(-halfW, -halfH);
+                positions[1] = new SKPoint(halfW, -halfH);
+                positions[2] = new SKPoint(-halfW, halfH);
+                positions[3] = new SKPoint(halfW, halfH);
+
+                texs[0] = new SKPoint(frame.X, frame.Y);
+                texs[1] = new SKPoint(frame.X + frame.W, frame.Y);
+                texs[2] = new SKPoint(frame.X, frame.Y + frame.H);
+                texs[3] = new SKPoint(frame.X + frame.W, frame.Y + frame.H);
+
+                SKColor tint = Tint(sprite.Tint, opacity);
+                colors[0] = tint;
+                colors[1] = tint;
+                colors[2] = tint;
+                colors[3] = Tint(sprite.CornerTint, opacity);
 
                 int linkSave = canvas.Save();
                 canvas.Translate((float)sprite.Center.X, (float)sprite.Center.Y);
                 canvas.RotateRadians((float)sprite.Rotation);
-                canvas.DrawImage(
-                    image,
-                    new SKRect(frame.X, frame.Y, frame.X + frame.W, frame.Y + frame.H),
-                    new SKRect(-halfW, -halfH, halfW, halfH),
-                    sampling,
-                    paint);
+
+                // Positions are rotated by the canvas; texs stay in atlas space, which is what lets
+                // Skia derive the per-triangle mapping back onto the shader.
+                using SKVertices vertices = SKVertices.CreateCopy(
+                    SKVertexMode.Triangles, positions, texs, colors, QuadIndices);
+                canvas.DrawVertices(vertices, SKBlendMode.Modulate, paint);
                 canvas.RestoreToCount(linkSave);
             }
 
             canvas.RestoreToCount(save);
         }
 
-        // The game multiplies the sprite by a straight RGBA vertex colour; modulate against a
+        // The game multiplies the sprite by a straight RGBA vertex colour; modulating a
         // premultiplied-alpha image needs the colour premultiplied too, or a tinted link at reduced
         // opacity would keep more colour than alpha and fringe.
         private static SKColor Tint(RopeRgba tint, double opacity)


### PR DESCRIPTION
## Description

Port the chain link shading fix from the game, where the tint colors were invented and the per-quad gradient was missing.